### PR TITLE
Rate api requests behaviour

### DIFF
--- a/BankWallet/BankWallet/Core/ApiProviders/RateApiProvider.swift
+++ b/BankWallet/BankWallet/Core/ApiProviders/RateApiProvider.swift
@@ -1,7 +1,7 @@
 import RxSwift
 
 class RateApiProvider {
-    private let timeoutInterval: TimeInterval = 5
+    private let timeoutInterval: TimeInterval = 10
     private let lastTimeoutInterval: TimeInterval = 60
 
     private let networkManager: NetworkManager

--- a/BankWallet/BankWallet/Core/Managers/AppConfigProvider.swift
+++ b/BankWallet/BankWallet/Core/Managers/AppConfigProvider.swift
@@ -3,8 +3,8 @@ import Foundation
 class AppConfigProvider: IAppConfigProvider {
     let ipfsId = "QmXTJZBMMRmBbPun6HFt3tmb3tfYF2usLPxFoacL7G5uMX"
     let ipfsGateways = [
-        "https://ipfs.io",
-        "https://ipfs-ext.horizontalsystems.xyz"
+        "https://ipfs-ext.horizontalsystems.xyz",
+        "https://ipfs.io"
     ]
 
     let fiatDecimal: Int = 2


### PR DESCRIPTION
- use 10 seconds timeout for non-last requests
- change order of API urls: make hs api first

Closes #642