### PR TITLE
Rate update bugfix

### DIFF
--- a/BankWallet/BankWallet/Core/Managers/AdapterManager.swift
+++ b/BankWallet/BankWallet/Core/Managers/AdapterManager.swift
@@ -57,10 +57,6 @@ class AdapterManager {
 
 extension AdapterManager: IAdapterManager {
 
-    func preloadAdapters() {
-        initAdapters()
-    }
-
     func adapter(for wallet: Wallet) -> IAdapter? {
         return adaptersMap[wallet]
     }

--- a/BankWallet/BankWallet/Core/Managers/AppManager.swift
+++ b/BankWallet/BankWallet/Core/Managers/AppManager.swift
@@ -38,7 +38,6 @@ extension AppManager: IAppManager {
         passcodeLockManager.didFinishLaunching()
         accountManager.preloadAccounts()
         walletManager.preloadWallets()
-        adapterManager.preloadAdapters()
         biometryManager.refresh()
     }
 

--- a/BankWallet/BankWallet/Core/Managers/RateSyncer.swift
+++ b/BankWallet/BankWallet/Core/Managers/RateSyncer.swift
@@ -29,13 +29,20 @@ class RateSyncer {
     }
 
     private func syncLatestRates() {
-        if reachabilityManager.isReachable && walletManager.wallets.count > 0 {
-            var coinCodes = Set<CoinCode>()
-            for wallet in walletManager.wallets {
-                coinCodes.insert(wallet.coin.code)
-            }
-            rateManager.refreshLatestRates(coinCodes: Array(coinCodes), currencyCode: currencyManager.baseCurrency.code)
+        guard reachabilityManager.isReachable else {
+            return
         }
+
+        var coinCodes = Set<CoinCode>()
+        for wallet in walletManager.wallets {
+            coinCodes.insert(wallet.coin.code)
+        }
+
+        guard coinCodes.count > 0 else {
+            return
+        }
+
+        rateManager.refreshLatestRates(coinCodes: Array(coinCodes), currencyCode: currencyManager.baseCurrency.code)
     }
 
 }

--- a/BankWallet/BankWallet/Core/Managers/RateSyncer.swift
+++ b/BankWallet/BankWallet/Core/Managers/RateSyncer.swift
@@ -29,7 +29,7 @@ class RateSyncer {
     }
 
     private func syncLatestRates() {
-        if reachabilityManager.isReachable {
+        if reachabilityManager.isReachable && walletManager.wallets.count > 0 {
             var coinCodes = Set<CoinCode>()
             for wallet in walletManager.wallets {
                 coinCodes.insert(wallet.coin.code)

--- a/BankWallet/BankWallet/Core/Managers/WalletManager.swift
+++ b/BankWallet/BankWallet/Core/Managers/WalletManager.swift
@@ -33,6 +33,7 @@ extension WalletManager: IWalletManager {
 
     func preloadWallets() {
         cache.set(wallets: storage.wallets(accounts: accountManager.accounts))
+        walletsUpdatedSignal.notify()
     }
 
     func enable(wallets: [Wallet]) {

--- a/BankWallet/BankWallet/Core/Protocols.swift
+++ b/BankWallet/BankWallet/Core/Protocols.swift
@@ -66,7 +66,6 @@ protocol IAdapterManager: class {
     func balanceAdapter(for: Wallet) -> IBalanceAdapter?
     func transactionsAdapter(for: Wallet) -> ITransactionsAdapter?
     func depositAdapter(for wallet: Wallet) -> IDepositAdapter?
-    func preloadAdapters()
     func refresh()
 }
 

--- a/BankWallet/BankWallet/Modules/Send/SubModules/SendFee/SendFeePresenter.swift
+++ b/BankWallet/BankWallet/Modules/Send/SubModules/SendFee/SendFeePresenter.swift
@@ -108,7 +108,6 @@ extension SendFeePresenter: ISendFeeModule {
     func set(availableFeeBalance: Decimal) {
         self.availableFeeBalance = availableFeeBalance
         syncError()
-
     }
 
     func update(inputType: SendInputType) {


### PR DESCRIPTION
- AdapterManager#preloadAdapters is no more needed, because it's triggered when wallets are updated

#798 