### PR TITLE
Fix incorrect top margin when there is only one coin

### DIFF
--- a/BankWallet/BankWallet/Modules/Transactions/TransactionsViewController.swift
+++ b/BankWallet/BankWallet/Modules/Transactions/TransactionsViewController.swift
@@ -99,7 +99,7 @@ extension TransactionsViewController: ITransactionsView {
     }
 
     func reload(with diff: [Change<TransactionViewItem>], items: [TransactionViewItem], animated: Bool) {
-        if self.items == nil {
+        if (self.items == nil) || !(isViewLoaded && view.window != nil) {
             self.items = items
             tableView.reloadData()
             return


### PR DESCRIPTION
closes #902

- When transactions view not visible reload tableView by default reloadData