### PR TITLE
Remove derivation from account check to support restore via bip49

### DIFF
--- a/BankWallet/BankWallet/Models/CoinType.swift
+++ b/BankWallet/BankWallet/Models/CoinType.swift
@@ -12,13 +12,13 @@ enum CoinType {
     func canSupport(accountType: AccountType) -> Bool {
         switch self {
         case .bitcoin, .bitcoinCash, .dash, .ethereum, .erc20:
-            if case let .mnemonic(words, derivation, salt) = accountType, words.count == 12, derivation == .bip44, salt == nil { return true }
+            if case let .mnemonic(words, _, salt) = accountType, words.count == 12, salt == nil { return true }
             return false
         case .eos:
             if case .eos = accountType { return true }
             return false
         case .binance:
-            if case let .mnemonic(words, derivation, salt) = accountType, words.count == 24, derivation == .bip44, salt == nil { return true }
+            if case let .mnemonic(words, _, salt) = accountType, words.count == 24, salt == nil { return true }
             return false
         }
     }

--- a/BankWallet/BankWallet/Modules/Balance/BalancePresenter.swift
+++ b/BankWallet/BankWallet/Modules/Balance/BalancePresenter.swift
@@ -92,7 +92,9 @@ extension BalancePresenter: IBalanceInteractorDelegate {
             return
         }
 
-        interactor.syncStats(coinCode: rate.coinCode, currencyCode: dataSource.currency.code)
+        if dataSource.statsButtonState == .selected {
+            interactor.syncStats(coinCode: rate.coinCode, currencyCode: dataSource.currency.code)
+        }
 
         let oldItems = dataSource.items
         for index in indexes {


### PR DESCRIPTION
- check if sync is on before triggering chart stats synchronization on rate update

ref #993 #994 #1062