### PR TITLE
Fix loss of bip setting, when new wallet was created

### DIFF
--- a/UnstoppableWallet/UnstoppableWallet/Core/Factories/AdapterFactory.swift
+++ b/UnstoppableWallet/UnstoppableWallet/Core/Factories/AdapterFactory.swift
@@ -18,12 +18,7 @@ class AdapterFactory: IAdapterFactory {
 
     func adapter(wallet: Wallet) -> IAdapter? {
         let derivation = derivationSettingsManager?.setting(coinType: wallet.coin.type)?.derivation
-        let syncMode: SyncMode?
-        if wallet.account.origin == .created {
-            syncMode = .new
-        } else {
-            syncMode = initialSyncSettingsManager?.setting(coinType: wallet.coin.type)?.syncMode
-        }
+        let syncMode = initialSyncSettingsManager?.setting(coinType: wallet.coin.type, accountOrigin: wallet.account.origin)?.syncMode
 
         switch wallet.coin.type {
         case .bitcoin:

--- a/UnstoppableWallet/UnstoppableWallet/Core/Managers/DerivationSettingsManager.swift
+++ b/UnstoppableWallet/UnstoppableWallet/Core/Managers/DerivationSettingsManager.swift
@@ -26,13 +26,11 @@ class DerivationSettingsManager {
 
 extension DerivationSettingsManager: IDerivationSettingsManager {
 
-    var allActiveSettings: [(setting: DerivationSetting, wallets: [Wallet])] {
+    var allActiveSettings: [(setting: DerivationSetting, coin: Coin)] {
         let wallets = walletManager.wallets
 
         return supportedCoinTypes.compactMap { (coinType, _) in
-            let coinTypeWallets = wallets.filter { $0.coin.type == coinType }
-
-            guard !coinTypeWallets.isEmpty else {
+            guard let coinTypeWallet = (wallets.first { $0.coin.type == coinType }) else {
                 return nil
             }
 
@@ -40,7 +38,7 @@ extension DerivationSettingsManager: IDerivationSettingsManager {
                 return nil
             }
 
-            return (setting: setting, wallets: coinTypeWallets)
+            return (setting: setting, coin: coinTypeWallet.coin)
         }
     }
 

--- a/UnstoppableWallet/UnstoppableWallet/Core/Managers/DerivationSettingsManager.swift
+++ b/UnstoppableWallet/UnstoppableWallet/Core/Managers/DerivationSettingsManager.swift
@@ -50,7 +50,7 @@ extension DerivationSettingsManager: IDerivationSettingsManager {
     }
 
     func save(setting: DerivationSetting) {
-        storage.save(derivationSettings: [setting])
+        storage.save(derivationSetting: setting)
 
         let walletsForUpdate = walletManager.wallets.filter { $0.coin.type == setting.coinType }
 
@@ -59,7 +59,7 @@ extension DerivationSettingsManager: IDerivationSettingsManager {
         }
     }
 
-    func reset() {
+    func resetStandardSettings() {
         storage.deleteDerivationSettings()
     }
 

--- a/UnstoppableWallet/UnstoppableWallet/Core/Protocols.swift
+++ b/UnstoppableWallet/UnstoppableWallet/Core/Protocols.swift
@@ -543,7 +543,7 @@ protocol IRemoteAlertManager {
 }
 
 protocol IDerivationSettingsManager: AnyObject {
-    var allActiveSettings: [(setting: DerivationSetting, wallets: [Wallet])] { get }
+    var allActiveSettings: [(setting: DerivationSetting, coin: Coin)] { get }
     func setting(coinType: CoinType) -> DerivationSetting?
     func save(setting: DerivationSetting)
     func resetStandardSettings()

--- a/UnstoppableWallet/UnstoppableWallet/Core/Protocols.swift
+++ b/UnstoppableWallet/UnstoppableWallet/Core/Protocols.swift
@@ -346,17 +346,17 @@ protocol IPriceAlertRequestRecordStorage {
 
 protocol IBlockchainSettingsRecordStorage {
     func blockchainSettings(coinTypeKey: String, settingKey: String) -> BlockchainSettingRecord?
-    func save(blockchainSettings: [BlockchainSettingRecord])
+    func save(blockchainSetting: BlockchainSettingRecord)
     func deleteAll(settingKey: String)
 }
 
 protocol IBlockchainSettingsStorage {
     func derivationSetting(coinType: CoinType) -> DerivationSetting?
-    func save(derivationSettings: [DerivationSetting])
+    func save(derivationSetting: DerivationSetting)
     func deleteDerivationSettings()
 
     func initialSyncSetting(coinType: CoinType) -> InitialSyncSetting?
-    func save(initialSyncSettings: [InitialSyncSetting])
+    func save(initialSyncSetting: InitialSyncSetting)
 }
 
 protocol IKitCleaner {
@@ -546,12 +546,12 @@ protocol IDerivationSettingsManager: AnyObject {
     var allActiveSettings: [(setting: DerivationSetting, wallets: [Wallet])] { get }
     func setting(coinType: CoinType) -> DerivationSetting?
     func save(setting: DerivationSetting)
-    func reset()
+    func resetStandardSettings()
 }
 
 protocol IInitialSyncSettingsManager: AnyObject {
-    var allSettings: [(setting: InitialSyncSetting, coins: [Coin], changeable: Bool)] { get }
-    func setting(coinType: CoinType) -> InitialSyncSetting?
+    var allSettings: [(setting: InitialSyncSetting, coin: Coin, changeable: Bool)] { get }
+    func setting(coinType: CoinType, accountOrigin: AccountOrigin) -> InitialSyncSetting?
     func save(setting: InitialSyncSetting)
 }
 

--- a/UnstoppableWallet/UnstoppableWallet/Core/Storage/BlockchainSettingsStorage.swift
+++ b/UnstoppableWallet/UnstoppableWallet/Core/Storage/BlockchainSettingsStorage.swift
@@ -1,8 +1,8 @@
 class BlockchainSettingsStorage {
     let storage: IBlockchainSettingsRecordStorage
 
-    let derivationKey = "derivation"
-    let initialSyncKey = "initial_sync"
+    let derivationKey = "derivation"     //
+    let initialSyncKey = "initial_sync"  //use these two only for standard wallet
 
     init(storage: IBlockchainSettingsRecordStorage) {
         self.storage = storage
@@ -26,15 +26,12 @@ extension BlockchainSettingsStorage: IBlockchainSettingsStorage {
                 }
     }
 
-    func save(derivationSettings: [DerivationSetting]) {
-        let settingRecords: [BlockchainSettingRecord] = derivationSettings.compactMap { setting in
-            guard let coinTypeKey = BlockchainSettingRecord.key(for: setting.coinType) else {
-                return nil
-            }
-            return BlockchainSettingRecord(coinType: coinTypeKey, key: derivationKey, value: setting.derivation.rawValue)
+    func save(derivationSetting: DerivationSetting) {
+        guard let coinTypeKey = BlockchainSettingRecord.key(for: derivationSetting.coinType) else {
+            return
         }
 
-        storage.save(blockchainSettings: settingRecords)
+        storage.save(blockchainSetting: BlockchainSettingRecord(coinType: coinTypeKey, key: derivationKey, value: derivationSetting.derivation.rawValue))
     }
 
     func deleteDerivationSettings() {
@@ -55,16 +52,13 @@ extension BlockchainSettingsStorage: IBlockchainSettingsStorage {
                 }
     }
 
-    func save(initialSyncSettings: [InitialSyncSetting]) {
-        let settingRecords: [BlockchainSettingRecord] = initialSyncSettings.compactMap { setting in
-            let coinType = setting.coinType
-            guard let coinTypeKey = BlockchainSettingRecord.key(for: coinType) else {
-                return nil
-            }
-            return BlockchainSettingRecord(coinType: coinTypeKey, key: initialSyncKey, value: setting.syncMode.rawValue)
+    func save(initialSyncSetting: InitialSyncSetting) {
+        let coinType = initialSyncSetting.coinType
+        guard let coinTypeKey = BlockchainSettingRecord.key(for: coinType) else {
+            return
         }
 
-        storage.save(blockchainSettings: settingRecords)
+        storage.save(blockchainSetting: BlockchainSettingRecord(coinType: coinTypeKey, key: initialSyncKey, value: initialSyncSetting.syncMode.rawValue))
     }
 
 }

--- a/UnstoppableWallet/UnstoppableWallet/Core/Storage/GrdbStorage.swift
+++ b/UnstoppableWallet/UnstoppableWallet/Core/Storage/GrdbStorage.swift
@@ -439,11 +439,9 @@ extension GrdbStorage: IBlockchainSettingsRecordStorage {
         }
     }
 
-    func save(blockchainSettings: [BlockchainSettingRecord]) {
+    func save(blockchainSetting: BlockchainSettingRecord) {
         _ = try! dbPool.write { db in
-            for setting in blockchainSettings {
-                try setting.insert(db)
-            }
+            try blockchainSetting.insert(db)
         }
     }
 

--- a/UnstoppableWallet/UnstoppableWallet/Modules/CreateWallet/CreateWalletModule.swift
+++ b/UnstoppableWallet/UnstoppableWallet/Modules/CreateWallet/CreateWalletModule.swift
@@ -9,6 +9,7 @@ struct CreateWalletModule {
                 coinManager: App.shared.coinManager,
                 accountCreator: App.shared.accountCreator,
                 accountManager: App.shared.accountManager,
+                predefinedAccountTypeManager: App.shared.predefinedAccountTypeManager,
                 walletManager: App.shared.walletManager,
                 derivationSettingsManager: App.shared.derivationSettingsManager
         )

--- a/UnstoppableWallet/UnstoppableWallet/Modules/CreateWallet/CreateWalletService.swift
+++ b/UnstoppableWallet/UnstoppableWallet/Modules/CreateWallet/CreateWalletService.swift
@@ -6,6 +6,7 @@ class CreateWalletService {
     private let coinManager: ICoinManager
     private let accountCreator: IAccountCreator
     private let accountManager: IAccountManager
+    private let predefinedAccountTypeManager: IPredefinedAccountTypeManager
     private let walletManager: IWalletManager
     private let derivationSettingsManager: IDerivationSettingsManager
 
@@ -21,11 +22,12 @@ class CreateWalletService {
         }
     }
 
-    init(predefinedAccountType: PredefinedAccountType?, coinManager: ICoinManager, accountCreator: IAccountCreator, accountManager: IAccountManager, walletManager: IWalletManager, derivationSettingsManager: IDerivationSettingsManager) {
+    init(predefinedAccountType: PredefinedAccountType?, coinManager: ICoinManager, accountCreator: IAccountCreator, accountManager: IAccountManager, predefinedAccountTypeManager: IPredefinedAccountTypeManager, walletManager: IWalletManager, derivationSettingsManager: IDerivationSettingsManager) {
         self.predefinedAccountType = predefinedAccountType
         self.coinManager = coinManager
         self.accountCreator = accountCreator
         self.accountManager = accountManager
+        self.predefinedAccountTypeManager = predefinedAccountTypeManager
         self.walletManager = walletManager
         self.derivationSettingsManager = derivationSettingsManager
 
@@ -110,7 +112,14 @@ extension CreateWalletService {
             accountManager.save(account: account)
         }
 
-        derivationSettingsManager.reset()
+
+        let creatingStandardAccount = accounts.contains { account in
+            predefinedAccountTypeManager.predefinedAccountType(accountType: account.type) == .standard
+        }
+
+        if creatingStandardAccount {
+            derivationSettingsManager.resetStandardSettings()
+        }
 
         walletManager.save(wallets: Array(wallets.values))
     }

--- a/UnstoppableWallet/UnstoppableWallet/Modules/DerivationSettings/DerivationSettingsInteractor.swift
+++ b/UnstoppableWallet/UnstoppableWallet/Modules/DerivationSettings/DerivationSettingsInteractor.swift
@@ -11,7 +11,7 @@ class DerivationSettingsInteractor {
 
 extension DerivationSettingsInteractor: IDerivationSettingsInteractor {
 
-    var allActiveSettings: [(setting: DerivationSetting, wallets: [Wallet])] {
+    var allActiveSettings: [(setting: DerivationSetting, coin: Coin)] {
         derivationSettingsManager.allActiveSettings
     }
 

--- a/UnstoppableWallet/UnstoppableWallet/Modules/DerivationSettings/DerivationSettingsModule.swift
+++ b/UnstoppableWallet/UnstoppableWallet/Modules/DerivationSettings/DerivationSettingsModule.swift
@@ -3,7 +3,7 @@ protocol IDerivationSettingsView: class {
 }
 
 protocol IDerivationSettingsInteractor: class {
-    var allActiveSettings: [(setting: DerivationSetting, wallets: [Wallet])] { get }
+    var allActiveSettings: [(setting: DerivationSetting, coin: Coin)] { get }
     var wallets: [Wallet] { get }
 
     func save(setting: DerivationSetting)

--- a/UnstoppableWallet/UnstoppableWallet/Modules/DerivationSettings/DerivationSettingsPresenter.swift
+++ b/UnstoppableWallet/UnstoppableWallet/Modules/DerivationSettings/DerivationSettingsPresenter.swift
@@ -13,8 +13,8 @@ class DerivationSettingsPresenter {
     }
 
     private func updateUI() {
-        items = interactor.allActiveSettings.map { setting, wallets in
-            DerivationSettingsItem(firstCoin: wallets[0].coin, setting: setting)
+        items = interactor.allActiveSettings.map { setting, coin in
+            DerivationSettingsItem(firstCoin: coin, setting: setting)
         }
 
         let viewItems = items.map { factory.sectionViewItem(item: $0) }

--- a/UnstoppableWallet/UnstoppableWallet/Modules/ManageAccounts/ManageAccountsInteractor.swift
+++ b/UnstoppableWallet/UnstoppableWallet/Modules/ManageAccounts/ManageAccountsInteractor.swift
@@ -37,7 +37,7 @@ extension ManageAccountsInteractor: IManageAccountsInteractor {
         predefinedAccountTypeManager.allTypes
     }
 
-    var allActiveDerivationSettings: [(setting: DerivationSetting, wallets: [Wallet])] {
+    var allActiveDerivationSettings: [(setting: DerivationSetting, coin: Coin)] {
         derivationSettingsManager.allActiveSettings
     }
 

--- a/UnstoppableWallet/UnstoppableWallet/Modules/ManageAccounts/ManageAccountsModule.swift
+++ b/UnstoppableWallet/UnstoppableWallet/Modules/ManageAccounts/ManageAccountsModule.swift
@@ -16,7 +16,7 @@ protocol IManageAccountsViewDelegate {
 
 protocol IManageAccountsInteractor {
     var predefinedAccountTypes: [PredefinedAccountType] { get }
-    var allActiveDerivationSettings: [(setting: DerivationSetting, wallets: [Wallet])] { get }
+    var allActiveDerivationSettings: [(setting: DerivationSetting, coin: Coin)] { get }
     func account(predefinedAccountType: PredefinedAccountType) -> Account?
 }
 

--- a/UnstoppableWallet/UnstoppableWallet/Modules/NoAccount/NoAccountInteractor.swift
+++ b/UnstoppableWallet/UnstoppableWallet/Modules/NoAccount/NoAccountInteractor.swift
@@ -26,7 +26,7 @@ extension NoAccountInteractor: INoAccountInteractor {
     }
 
     func resetDerivationSettings() {
-        derivationSettingsManager.reset()
+        derivationSettingsManager.resetStandardSettings()
     }
 
 }

--- a/UnstoppableWallet/UnstoppableWallet/Modules/NoAccount/NoAccountPresenter.swift
+++ b/UnstoppableWallet/UnstoppableWallet/Modules/NoAccount/NoAccountPresenter.swift
@@ -34,7 +34,7 @@ extension NoAccountPresenter: INoAccountViewDelegate {
 
     func onTapCreate() {
         do {
-            if interactor.derivationSettings(coin: coin) != nil {
+            if predefinedAccountType == .standard {
                 interactor.resetDerivationSettings()
             }
 

--- a/UnstoppableWallet/UnstoppableWallet/Modules/Privacy/PrivacyInteractor.swift
+++ b/UnstoppableWallet/UnstoppableWallet/Modules/Privacy/PrivacyInteractor.swift
@@ -19,7 +19,7 @@ extension PrivacyInteractor: IPrivacyInteractor {
         walletManager.wallets
     }
 
-    var syncSettings: [(setting: InitialSyncSetting, coins: [Coin], changeable: Bool)] {
+    var syncSettings: [(setting: InitialSyncSetting, coin: Coin, changeable: Bool)] {
         initialSyncSettingsManager.allSettings
     }
 

--- a/UnstoppableWallet/UnstoppableWallet/Modules/Privacy/PrivacyModule.swift
+++ b/UnstoppableWallet/UnstoppableWallet/Modules/Privacy/PrivacyModule.swift
@@ -7,7 +7,7 @@ protocol IPrivacyRouter {
 
 protocol IPrivacyInteractor {
     var wallets: [Wallet] { get }
-    var syncSettings: [(setting: InitialSyncSetting, coins: [Coin], changeable: Bool)] { get }
+    var syncSettings: [(setting: InitialSyncSetting, coin: Coin, changeable: Bool)] { get }
     var sortMode: TransactionDataSortMode { get }
     var ethereumConnection: EthereumRpcMode { get }
     func save(syncSetting: InitialSyncSetting)

--- a/UnstoppableWallet/UnstoppableWallet/Modules/Privacy/PrivacyPresenter.swift
+++ b/UnstoppableWallet/UnstoppableWallet/Modules/Privacy/PrivacyPresenter.swift
@@ -44,12 +44,8 @@ extension PrivacyPresenter: IPrivacyViewDelegate {
         updateConnection()
 
         if !standardCreatedWalletExists {
-            syncItems = interactor.syncSettings.compactMap {(setting, coins, changeable) in
-                guard let coin = coins.first else {
-                    return nil
-                }
-
-                return PrivacySyncItem(coin: coin, setting: setting, changeable: changeable)
+            syncItems = interactor.syncSettings.compactMap {(setting, coin, changeable) in
+                PrivacySyncItem(coin: coin, setting: setting, changeable: changeable)
             }
 
             updateSync()


### PR DESCRIPTION
- remove derivation settings only when standard wallet created
- refactor initial sync
- extract `new` sync mode from adapter factory to InitialSyncSettingsManager
- remove arrays where they are not needed

#2413