### PR TITLE
Fix duplicate BEP-2 coins in coins list

### DIFF
--- a/UnstoppableWallet/UnstoppableWallet/Core/Managers/AppStatusManager.swift
+++ b/UnstoppableWallet/UnstoppableWallet/Core/Managers/AppStatusManager.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 class AppStatusManager {
-    static let statusBitcoinCoreIds = ["BTC", "LTC", "BCH", "DASH"]
+    static let statusBitcoinCoreTypes: [CoinType] = [.bitcoin, .litecoin, .bitcoinCash, .dash]
 
     private let systemInfoManager: ISystemInfoManager
     private let localStorage: ILocalStorage
@@ -49,8 +49,8 @@ class AppStatusManager {
     private var blockchainStatus: [(String, Any)] {
         var status = [(String, Any)]()
 
-        let bitcoinBaseWallets = AppStatusManager.statusBitcoinCoreIds.compactMap { coinId in
-            walletManager.wallets.first { $0.coin.id == coinId }
+        let bitcoinBaseWallets = AppStatusManager.statusBitcoinCoreTypes.compactMap { coinType in
+            walletManager.wallets.first { $0.coin.type == coinType }
         }
         status.append(contentsOf: bitcoinBaseWallets.compactMap {
             guard let adapter = adapterManager.adapter(for: $0) as? BitcoinBaseAdapter else {

--- a/UnstoppableWallet/UnstoppableWallet/Core/Managers/CoinManager.swift
+++ b/UnstoppableWallet/UnstoppableWallet/Core/Managers/CoinManager.swift
@@ -22,7 +22,7 @@ extension CoinManager: ICoinManager {
     var coins: [Coin] {
         let defaultCoins = appConfigProvider.defaultCoins
         let storedCoins = storage.coins.filter { coin in
-            !defaultCoins.contains { $0.id == coin.id }
+            !defaultCoins.contains { $0.type == coin.type }
         }
 
         return storedCoins + defaultCoins

--- a/UnstoppableWallet/UnstoppableWallet/Models/Coin.swift
+++ b/UnstoppableWallet/UnstoppableWallet/Models/Coin.swift
@@ -9,7 +9,7 @@ struct Coin {
 extension Coin: Hashable {
 
     public func hash(into hasher: inout Hasher) {
-        hasher.combine(id)
+        hasher.combine(type)
     }
 
 }


### PR DESCRIPTION
- use coinType instead of id when filtering stored coins from default coins