### PR TITLE
Update EthereumKit pods

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -473,13 +473,13 @@ CHECKOUT OPTIONS:
     :commit: 7f4d99f20d415488e9b67af5c2f58b22f448feab
     :git: https://github.com/horizontalsystems/bitcoin-kit-ios.git
   Erc20Kit.swift:
-    :commit: 46969852095d63c37ced3902cdb86fe3dc997c0e
+    :commit: a5e4ca85035ac1cebf6b38c38090db5cc9626c74
     :git: https://github.com/horizontalsystems/ethereum-kit-ios
   EthereumABI:
     :commit: f77b49868885e9f909bd7dcf4c50c42e84f43ef7
     :git: https://github.com/horizontalsystems/EthereumABI
   EthereumKit.swift:
-    :commit: 46969852095d63c37ced3902cdb86fe3dc997c0e
+    :commit: a5e4ca85035ac1cebf6b38c38090db5cc9626c74
     :git: https://github.com/horizontalsystems/ethereum-kit-ios
   FeeRateKit.swift:
     :commit: 44a9da96067fea69f4c21088f3d00773265d1c22
@@ -524,7 +524,7 @@ CHECKOUT OPTIONS:
     :commit: 392186c18e8df97d40ca0f4587d857259d878dd4
     :git: https://github.com/horizontalsystems/gui-kit/
   UniswapKit.swift:
-    :commit: 46969852095d63c37ced3902cdb86fe3dc997c0e
+    :commit: a5e4ca85035ac1cebf6b38c38090db5cc9626c74
     :git: https://github.com/horizontalsystems/ethereum-kit-ios
   WalletConnect:
     :commit: 467915ce2ba7b4bb831150be911bd0b8b1d94c36

--- a/UnstoppableWallet/UnstoppableWallet/Core/Adapters/EthereumAdapter.swift
+++ b/UnstoppableWallet/UnstoppableWallet/Core/Adapters/EthereumAdapter.swift
@@ -55,7 +55,7 @@ class EthereumAdapter: EthereumBaseAdapter {
                 blockHeight: receipt?.blockNumber,
                 confirmationsThreshold: EthereumBaseAdapter.confirmationsThreshold,
                 amount: abs(amount),
-                fee: receipt.map { Decimal(sign: .plus, exponent: -decimal, significand: Decimal($0.cumulativeGasUsed * transaction.gasPrice)) },
+                fee: receipt.map { Decimal(sign: .plus, exponent: -decimal, significand: Decimal($0.gasUsed * transaction.gasPrice)) },
                 date: Date(timeIntervalSince1970: Double(transaction.timestamp)),
                 failed: fullTransaction.failed,
                 from: from.hex,


### PR DESCRIPTION
- Use gasUsed instead of cumulativeGasUsed in EthereumAdapter

#2557 