### PR TITLE
Fix displaying sign for outgoing transactions in transaction list for…

### DIFF
--- a/UnstoppableWallet/UnstoppableWallet/Models/TransactionRecords/BinanceChain/BinanceChainOutgoingTransactionRecord.swift
+++ b/UnstoppableWallet/UnstoppableWallet/Models/TransactionRecords/BinanceChain/BinanceChainOutgoingTransactionRecord.swift
@@ -1,3 +1,4 @@
+import Foundation
 import BinanceChainKit
 import MarketKit
 
@@ -7,7 +8,7 @@ class BinanceChainOutgoingTransactionRecord: BinanceChainTransactionRecord {
     let sentToSelf: Bool
 
     init(source: TransactionSource, transaction: TransactionInfo, feeCoin: PlatformCoin, coin: PlatformCoin, sentToSelf: Bool) {
-        value = .coinValue(platformCoin: coin, value: transaction.amount)
+        value = .coinValue(platformCoin: coin, value: Decimal(sign: .minus, exponent: transaction.amount.exponent, significand: transaction.amount.significand))
         to = transaction.to
         self.sentToSelf = sentToSelf
 

--- a/UnstoppableWallet/UnstoppableWallet/Models/TransactionRecords/Bitcoin/BitcoinOutgoingTransactionRecord.swift
+++ b/UnstoppableWallet/UnstoppableWallet/Models/TransactionRecords/Bitcoin/BitcoinOutgoingTransactionRecord.swift
@@ -9,7 +9,8 @@ class BitcoinOutgoingTransactionRecord: BitcoinTransactionRecord {
     init(coin: PlatformCoin, source: TransactionSource, uid: String, transactionHash: String, transactionIndex: Int, blockHeight: Int?, confirmationsThreshold: Int?, date: Date, fee: Decimal?, failed: Bool,
          lockInfo: TransactionLockInfo?, conflictingHash: String?, showRawTransaction: Bool,
          amount: Decimal, to: String?, sentToSelf: Bool, memo: String? = nil) {
-        value = .coinValue(platformCoin: coin, value: amount)
+
+        value = .coinValue(platformCoin: coin, value: Decimal(sign: .minus, exponent: amount.exponent, significand: amount.significand))
         self.to = to
         self.sentToSelf = sentToSelf
 

--- a/UnstoppableWallet/UnstoppableWallet/Modules/Transactions/TransactionsViewItemFactory.swift
+++ b/UnstoppableWallet/UnstoppableWallet/Modules/Transactions/TransactionsViewItemFactory.swift
@@ -20,7 +20,7 @@ class TransactionsViewItemFactory {
     }
 
     private func coinString(from transactionValue: TransactionValue, showSign: Bool = true) -> String {
-        guard var value = transactionValue.formattedShort(showSign: showSign) else {
+        guard let value = transactionValue.formattedShort(showSign: showSign) else {
             return "n/a".localized
         }
 


### PR DESCRIPTION
… `Bitcoin` alike and `BNB-bep2` items

#4174