### PR TITLE
Show send selector after scan qr-address.

### DIFF
--- a/UnstoppableWallet/UnstoppableWallet/Modules/Main/Workers/SendAppShowWorker/AddressAppShowModule.swift
+++ b/UnstoppableWallet/UnstoppableWallet/Modules/Main/Workers/SendAppShowWorker/AddressAppShowModule.swift
@@ -103,7 +103,7 @@ extension AddressAppShowModule: IEventHandler {
                 }
                 var uri = AddressUri(scheme: "")
                 uri.address = text
-                return
+                showSendTokenList(source: source, eventType: eventType, uri: uri, allowedBlockchainTypes: types)
             }
         }
     }

--- a/UnstoppableWallet/UnstoppableWallet/Modules/MultiSwap/MultiSwapViewModel.swift
+++ b/UnstoppableWallet/UnstoppableWallet/Modules/MultiSwap/MultiSwapViewModel.swift
@@ -21,6 +21,7 @@ class MultiSwapViewModel: ObservableObject {
     private let marketKit = App.shared.marketKit
     private let walletManager = App.shared.walletManager
     private let adapterManager = App.shared.adapterManager
+    private let decimalParser = AmountDecimalParser()
 
     @Published var currency: Currency
 
@@ -170,7 +171,7 @@ class MultiSwapViewModel: ObservableObject {
             syncQuotes()
             syncFiatAmountIn()
 
-            let amount = Decimal(string: amountString)
+            let amount = decimalParser.parseAnyDecimal(from: amountString)
 
             if amount != amountIn {
                 amountString = amountIn?.description ?? ""
@@ -180,7 +181,7 @@ class MultiSwapViewModel: ObservableObject {
 
     @Published var amountString: String = "" {
         didSet {
-            let amount = Decimal(string: amountString)
+            let amount = decimalParser.parseAnyDecimal(from: amountString)
 
             guard amount != amountIn else {
                 return
@@ -196,7 +197,7 @@ class MultiSwapViewModel: ObservableObject {
         didSet {
             syncAmountIn()
 
-            let amount = Decimal(string: fiatAmountString)?.rounded(decimal: 2)
+            let amount = decimalParser.parseAnyDecimal(from: fiatAmountString)?.rounded(decimal: 2)
 
             if amount != fiatAmountIn {
                 fiatAmountString = fiatAmountIn?.description ?? ""
@@ -206,7 +207,7 @@ class MultiSwapViewModel: ObservableObject {
 
     @Published var fiatAmountString: String = "" {
         didSet {
-            let amount = Decimal(string: fiatAmountString)?.rounded(decimal: 2)
+            let amount = decimalParser.parseAnyDecimal(from: fiatAmountString)?.rounded(decimal: 2)
 
             guard amount != fiatAmountIn else {
                 return

--- a/UnstoppableWallet/UnstoppableWallet/Modules/SendNew/PreSendViewModel.swift
+++ b/UnstoppableWallet/UnstoppableWallet/Modules/SendNew/PreSendViewModel.swift
@@ -9,6 +9,7 @@ class PreSendViewModel: ObservableObject {
     private let marketKit = App.shared.marketKit
     private let walletManager = App.shared.walletManager
     private let adapterManager = App.shared.adapterManager
+    private let decimalParser = AmountDecimalParser()
 
     private var cancellables = Set<AnyCancellable>()
 
@@ -19,7 +20,7 @@ class PreSendViewModel: ObservableObject {
             syncFiatAmount()
             syncSendData()
 
-            let amount = Decimal(string: amountString)
+            let amount = decimalParser.parseAnyDecimal(from: amountString)
 
             if amount != self.amount {
                 amountString = self.amount?.description ?? ""
@@ -29,7 +30,7 @@ class PreSendViewModel: ObservableObject {
 
     @Published var amountString: String = "" {
         didSet {
-            var amount = Decimal(string: amountString)
+            var amount = decimalParser.parseAnyDecimal(from: amountString)
 
             if amount == 0 {
                 amount = nil
@@ -49,7 +50,7 @@ class PreSendViewModel: ObservableObject {
         didSet {
             syncAmount()
 
-            let amount = Decimal(string: fiatAmountString)?.rounded(decimal: 2)
+            let amount = decimalParser.parseAnyDecimal(from: fiatAmountString)?.rounded(decimal: 2)
 
             if amount != fiatAmount {
                 fiatAmountString = fiatAmount?.description ?? ""
@@ -59,7 +60,7 @@ class PreSendViewModel: ObservableObject {
 
     @Published var fiatAmountString: String = "" {
         didSet {
-            let amount = Decimal(string: fiatAmountString)?.rounded(decimal: 2)
+            let amount = decimalParser.parseAnyDecimal(from: fiatAmountString)?.rounded(decimal: 2)
 
             guard amount != fiatAmount else {
                 return


### PR DESCRIPTION
Fix parsing amounts with ',' as separator.

ref #6029 