### PR TITLE
Calculate height only by textInput field (PrimarySizedHStack).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,4 +52,3 @@ buildServer.json
 /.serena/
 /.venv-translate/
 /CLAUDE.md
-/docs/

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,9 @@ buildServer.json
 # Claude
 
 .claude
+/.codebase-memory/
+/.playwright-mcp/
+/.serena/
+/.venv-translate/
+/CLAUDE.md
+/docs/

--- a/Unstoppable/Unstoppable.xcodeproj/project.pbxproj
+++ b/Unstoppable/Unstoppable.xcodeproj/project.pbxproj
@@ -206,7 +206,6 @@
 				"Configuration/App/Widget-Dev.xcconfig",
 				"Configuration/App/Widget-Prod.xcconfig",
 				Configuration/Config.template.xcconfig,
-				Configuration/Config.xcconfig,
 				"Configuration/Stable/App-Stable-Dev.xcconfig",
 				"Configuration/Stable/App-Stable-Prod.xcconfig",
 				"Configuration/Stable/Intent-Stable-Dev.xcconfig",

--- a/Unstoppable/Unstoppable.xcodeproj/project.pbxproj
+++ b/Unstoppable/Unstoppable.xcodeproj/project.pbxproj
@@ -206,6 +206,7 @@
 				"Configuration/App/Widget-Dev.xcconfig",
 				"Configuration/App/Widget-Prod.xcconfig",
 				Configuration/Config.template.xcconfig,
+				Configuration/Config.xcconfig,
 				"Configuration/Stable/App-Stable-Dev.xcconfig",
 				"Configuration/Stable/App-Stable-Prod.xcconfig",
 				"Configuration/Stable/Intent-Stable-Dev.xcconfig",

--- a/Unstoppable/Unstoppable/Modules/AddToken/AddTokenView.swift
+++ b/Unstoppable/Unstoppable/Modules/AddToken/AddTokenView.swift
@@ -71,27 +71,28 @@ struct AddTokenView: View {
     private var inputSection: some View {
         VStack(spacing: 0) {
             InputTextRow {
-                ShortcutButtonsView(
-                    content: {
-                        TextField(
-                            viewModel.placeholder,
-                            text: $viewModel.reference,
-                            axis: .vertical
-                        )
-                        .lineLimit(1 ... 3)
-                        .font(.themeBody)
-                        .tint(.themeInputFieldTintColor)
-                        .autocorrectionDisabled()
-                        .autocapitalization(.none)
-                        .modifier(RightChecking(state: checkingStateBinding))
-                    },
-                    showDelete: .init(get: { !viewModel.reference.isEmpty }, set: { _ in }),
-                    items: [.icon("scan"), .text("button.paste".localized)],
-                    onTap: onTap,
-                    onTapDelete: {
-                        viewModel.reference = ""
-                    }
-                )
+                PrimarySizedHStack {
+                    TextField(
+                        viewModel.placeholder,
+                        text: $viewModel.reference,
+                        axis: .vertical
+                    )
+                    .lineLimit(1 ... 3)
+                    .font(.themeBody)
+                    .tint(.themeInputFieldTintColor)
+                    .autocorrectionDisabled()
+                    .autocapitalization(.none)
+                    .modifier(RightChecking(state: checkingStateBinding))
+                } trailing: {
+                    ShortcutButtonsView(
+                        showDelete: .init(get: { !viewModel.reference.isEmpty }, set: { _ in }),
+                        items: [.icon("scan"), .text("button.paste".localized)],
+                        onTap: onTap,
+                        onTapDelete: {
+                            viewModel.reference = ""
+                        }
+                    )
+                }
             }
             .modifier(CautionBorder(cautionState: cautionStateBinding))
             .modifier(CautionPrompt(cautionState: cautionStateBinding))

--- a/Unstoppable/Unstoppable/Modules/Backup/Name/BackupNameContentView.swift
+++ b/Unstoppable/Unstoppable/Modules/Backup/Name/BackupNameContentView.swift
@@ -8,27 +8,28 @@ struct BackupNameContentView: View {
             ListSectionHeader(text: "backup_app.backup.name.title".localized, uppercased: false, insets: .zero)
 
             InputTextRow {
-                ShortcutButtonsView(
-                    content: {
-                        InputTextView(
-                            placeholder: "backup.cloud.name.placeholder".localized,
-                            text: $viewModel.name,
-                            isValidText: { BackupFilenameValidator.isValidFilename($0) }
-                        )
-                        .autocapitalization(.words)
-                        .autocorrectionDisabled()
-                    },
-                    showDelete: .init(get: { !viewModel.name.isEmpty }, set: { _ in }),
-                    items: [.text("button.paste".localized)],
-                    onTap: { _ in
-                        if let text = UIPasteboard.general.string {
-                            viewModel.name = text
+                PrimarySizedHStack {
+                    InputTextView(
+                        placeholder: "backup.cloud.name.placeholder".localized,
+                        text: $viewModel.name,
+                        isValidText: { BackupFilenameValidator.isValidFilename($0) }
+                    )
+                    .autocapitalization(.words)
+                    .autocorrectionDisabled()
+                } trailing: {
+                    ShortcutButtonsView(
+                        showDelete: .init(get: { !viewModel.name.isEmpty }, set: { _ in }),
+                        items: [.text("button.paste".localized)],
+                        onTap: { _ in
+                            if let text = UIPasteboard.general.string {
+                                viewModel.name = text
+                            }
+                        },
+                        onTapDelete: {
+                            viewModel.name = ""
                         }
-                    },
-                    onTapDelete: {
-                        viewModel.name = ""
-                    }
-                )
+                    )
+                }
             }
             .modifier(CautionBorder(cautionState: $viewModel.cautionState))
             .modifier(CautionPrompt(cautionState: $viewModel.cautionState))

--- a/Unstoppable/Unstoppable/Modules/BirthdayInput/BirthdayInputView.swift
+++ b/Unstoppable/Unstoppable/Modules/BirthdayInput/BirthdayInputView.swift
@@ -26,40 +26,41 @@ struct BirthdayInputView: View {
 
                             VStack(spacing: 8) {
                                 InputTextRow {
-                                    ShortcutButtonsView(
-                                        content: {
-                                            InputTextView(
-                                                placeholder: viewModel.placeholder,
-                                                text: $viewModel.heightString
-                                            )
-                                            .keyboardType(.numberPad)
-                                            .autocorrectionDisabled()
-                                            .focused($inputFocused)
-                                        },
-                                        showDelete: .init(get: { !viewModel.heightString.isEmpty }, set: { _ in }),
-                                        items: [.icon("date"), .text("button.paste".localized)],
-                                        onTap: { index in
-                                            switch index {
-                                            case 0:
-                                                Coordinator.shared.present(type: .bottomSheet) { isPresented in
-                                                    BirthdayPickerView(
-                                                        date: viewModel.defaultDate,
-                                                        startDate: viewModel.startDate,
-                                                        isPresented: isPresented
-                                                    ) { date in
-                                                        viewModel.handle(date: date)
+                                    PrimarySizedHStack {
+                                        InputTextView(
+                                            placeholder: viewModel.placeholder,
+                                            text: $viewModel.heightString
+                                        )
+                                        .keyboardType(.numberPad)
+                                        .autocorrectionDisabled()
+                                        .focused($inputFocused)
+                                    } trailing: {
+                                        ShortcutButtonsView(
+                                            showDelete: .init(get: { !viewModel.heightString.isEmpty }, set: { _ in }),
+                                            items: [.icon("date"), .text("button.paste".localized)],
+                                            onTap: { index in
+                                                switch index {
+                                                case 0:
+                                                    Coordinator.shared.present(type: .bottomSheet) { isPresented in
+                                                        BirthdayPickerView(
+                                                            date: viewModel.defaultDate,
+                                                            startDate: viewModel.startDate,
+                                                            isPresented: isPresented
+                                                        ) { date in
+                                                            viewModel.handle(date: date)
+                                                        }
                                                     }
+                                                case 1:
+                                                    if let string = UIPasteboard.general.string {
+                                                        viewModel.heightString = string.replacingOccurrences(of: "\n", with: " ").trimmingCharacters(in: .whitespacesAndNewlines)
+                                                    }
+                                                default: ()
                                                 }
-                                            case 1:
-                                                if let string = UIPasteboard.general.string {
-                                                    viewModel.heightString = string.replacingOccurrences(of: "\n", with: " ").trimmingCharacters(in: .whitespacesAndNewlines)
-                                                }
-                                            default: ()
+                                            }, onTapDelete: {
+                                                viewModel.heightString = ""
                                             }
-                                        }, onTapDelete: {
-                                            viewModel.heightString = ""
-                                        }
-                                    )
+                                        )
+                                    }
                                 }
 
                                 HStack {

--- a/Unstoppable/Unstoppable/Modules/CreateAccount/CreateAccountView.swift
+++ b/Unstoppable/Unstoppable/Modules/CreateAccount/CreateAccountView.swift
@@ -28,21 +28,21 @@ struct CreateAccountView: View {
                             ListSectionHeader(text: "create_wallet.name".localized, uppercased: false)
 
                             InputTextRow {
-                                ShortcutButtonsView(
-                                    content: {
-                                        InputTextView(text: $viewModel.name)
-                                            .autocapitalization(.words)
-                                            .autocorrectionDisabled()
-                                            .focused($focusedField, equals: .name)
-                                    },
-                                    showDelete: .init(get: { false }, set: { _ in }),
-                                    items: [.icon("swap_e")],
-                                    onTap: { _ in
-                                        viewModel.refreshName()
-                                    },
-                                    onTapDelete: {}
-                                )
-                                .padding(.vertical, -5) // TODO: remove this
+                                PrimarySizedHStack {
+                                    InputTextView(text: $viewModel.name)
+                                        .autocapitalization(.words)
+                                        .autocorrectionDisabled()
+                                        .focused($focusedField, equals: .name)
+                                } trailing: {
+                                    ShortcutButtonsView(
+                                        showDelete: .constant(false),
+                                        items: [.icon("swap_e")],
+                                        onTap: { _ in
+                                            viewModel.refreshName()
+                                        },
+                                        onTapDelete: {}
+                                    )
+                                }
                             }
                         }
 

--- a/Unstoppable/Unstoppable/Modules/MultiSwap/AddressView/AddressViewNew.swift
+++ b/Unstoppable/Unstoppable/Modules/MultiSwap/AddressView/AddressViewNew.swift
@@ -23,43 +23,44 @@ struct AddressViewNew: View {
 
     var body: some View {
         InputTextRow(vertical: .margin8, borderColor: $borderColor) {
-            ShortcutButtonsView(
-                content: {
-                    textField(
-                        placeholder: placeholder,
-                        text: $viewModel.text
-                    )
-                    .onAppear {
-                        viewModel.text = text
-                    }
-                    .onChange(of: text) { newText in
-                        if newText != viewModel.text {
-                            viewModel.text = newText
-                        }
-                    }
-                    .onChange(of: viewModel.text) { newText in
-                        if newText != text {
-                            text = newText
-                        }
-                    }
-                    .onChange(of: viewModel.result) { newResult in
-                        if newResult != result {
-                            result = newResult
-                        }
-                    }
-                    .font(.themeBody)
-                    .foregroundStyle(foregroundColor)
-                    .autocorrectionDisabled()
-                    .autocapitalization(.none)
-                },
-                showDelete: .init(get: { !viewModel.text.isEmpty }, set: { _ in }),
-                items: viewModel.shortcuts,
-                onTap: {
-                    viewModel.onTap(index: $0)
-                }, onTapDelete: {
-                    viewModel.onTapDelete()
+            PrimarySizedHStack {
+                textField(
+                    placeholder: placeholder,
+                    text: $viewModel.text
+                )
+                .onAppear {
+                    viewModel.text = text
                 }
-            )
+                .onChange(of: text) { newText in
+                    if newText != viewModel.text {
+                        viewModel.text = newText
+                    }
+                }
+                .onChange(of: viewModel.text) { newText in
+                    if newText != text {
+                        text = newText
+                    }
+                }
+                .onChange(of: viewModel.result) { newResult in
+                    if newResult != result {
+                        result = newResult
+                    }
+                }
+                .font(.themeBody)
+                .foregroundStyle(foregroundColor)
+                .autocorrectionDisabled()
+                .autocapitalization(.none)
+            } trailing: {
+                ShortcutButtonsView(
+                    showDelete: .init(get: { !viewModel.text.isEmpty }, set: { _ in }),
+                    items: viewModel.shortcuts,
+                    onTap: {
+                        viewModel.onTap(index: $0)
+                    }, onTapDelete: {
+                        viewModel.onTapDelete()
+                    }
+                )
+            }
         }
     }
 

--- a/Unstoppable/Unstoppable/Modules/RestoreAccount/RestoreMnemonic/MnemonicInputCellWrapper.swift
+++ b/Unstoppable/Unstoppable/Modules/RestoreAccount/RestoreMnemonic/MnemonicInputCellWrapper.swift
@@ -23,7 +23,11 @@ struct MnemonicInputCellWrapper: UIViewRepresentable {
         cell.contentView.backgroundColor = .clear
         cell.set(placeholderText: placeholder)
 
-        cell.onChangeMnemonicText = onChangeMnemonicText
+        cell.onChangeMnemonicText = { text, cursorOffset in
+            DispatchQueue.main.async {
+                onChangeMnemonicText(text, cursorOffset)
+            }
+        }
         cell.onChangeEntering = { [weak cell] in
             guard let cell else { return }
             onChangeEntering(cell.entering)

--- a/Unstoppable/Unstoppable/Modules/RestoreAccount/RestoreMnemonic/RestoreMnemonicView.swift
+++ b/Unstoppable/Unstoppable/Modules/RestoreAccount/RestoreMnemonic/RestoreMnemonicView.swift
@@ -74,21 +74,21 @@ struct RestoreMnemonicView: View {
             ListSectionHeader(text: "create_wallet.name".localized, uppercased: false)
 
             InputTextRow {
-                ShortcutButtonsView(
-                    content: {
-                        InputTextView(text: $viewModel.name)
-                            .autocapitalization(.words)
-                            .autocorrectionDisabled()
-                            .focused($focusedField, equals: .name)
-                    },
-                    showDelete: .init(get: { false }, set: { _ in }),
-                    items: [.icon("swap_e")],
-                    onTap: { _ in
-                        viewModel.refreshName()
-                    },
-                    onTapDelete: {}
-                )
-                .padding(.vertical, -5) // TODO: remove this
+                PrimarySizedHStack {
+                    InputTextView(text: $viewModel.name)
+                        .autocapitalization(.words)
+                        .autocorrectionDisabled()
+                        .focused($focusedField, equals: .name)
+                } trailing: {
+                    ShortcutButtonsView(
+                        showDelete: .constant(false),
+                        items: [.icon("swap_e")],
+                        onTap: { _ in
+                            viewModel.refreshName()
+                        },
+                        onTapDelete: {}
+                    )
+                }
             }
         }
     }

--- a/Unstoppable/Unstoppable/Modules/RestoreAccount/RestorePrivateKey/RestorePrivateKeyView.swift
+++ b/Unstoppable/Unstoppable/Modules/RestoreAccount/RestorePrivateKey/RestorePrivateKeyView.swift
@@ -71,21 +71,21 @@ struct RestorePrivateKeyView: View {
             ListSectionHeader(text: "create_wallet.name".localized, uppercased: false)
 
             InputTextRow {
-                ShortcutButtonsView(
-                    content: {
-                        InputTextView(text: $viewModel.name)
-                            .autocapitalization(.words)
-                            .autocorrectionDisabled()
-                            .focused($focusedField, equals: .name)
-                    },
-                    showDelete: .init(get: { false }, set: { _ in }),
-                    items: [.icon("swap_e")],
-                    onTap: { _ in
-                        viewModel.refreshName()
-                    },
-                    onTapDelete: {}
-                )
-                .padding(.vertical, -5) // TODO: remove this
+                PrimarySizedHStack {
+                    InputTextView(text: $viewModel.name)
+                        .autocapitalization(.words)
+                        .autocorrectionDisabled()
+                        .focused($focusedField, equals: .name)
+                } trailing: {
+                    ShortcutButtonsView(
+                        showDelete: .constant(false),
+                        items: [.icon("swap_e")],
+                        onTap: { _ in
+                            viewModel.refreshName()
+                        },
+                        onTapDelete: {}
+                    )
+                }
             }
         }
     }

--- a/Unstoppable/Unstoppable/Modules/Watch/WatchView.swift
+++ b/Unstoppable/Unstoppable/Modules/Watch/WatchView.swift
@@ -20,21 +20,21 @@ struct WatchView: View {
                             ListSectionHeader(text: "watch_address.name".localized, uppercased: false)
 
                             InputTextRow {
-                                ShortcutButtonsView(
-                                    content: {
-                                        InputTextView(text: $viewModel.name)
-                                            .autocapitalization(.words)
-                                            .autocorrectionDisabled()
-                                            .focused($focusedField, equals: .name)
-                                    },
-                                    showDelete: .init(get: { false }, set: { _ in }),
-                                    items: [.icon("swap_e")],
-                                    onTap: { _ in
-                                        viewModel.refreshName()
-                                    },
-                                    onTapDelete: {}
-                                )
-                                .padding(.vertical, -5) // TODO: remove this
+                                PrimarySizedHStack {
+                                    InputTextView(text: $viewModel.name)
+                                        .autocapitalization(.words)
+                                        .autocorrectionDisabled()
+                                        .focused($focusedField, equals: .name)
+                                } trailing: {
+                                    ShortcutButtonsView(
+                                        showDelete: .constant(false),
+                                        items: [.icon("swap_e")],
+                                        onTap: { _ in
+                                            viewModel.refreshName()
+                                        },
+                                        onTapDelete: {}
+                                    )
+                                }
                             }
                         }
 

--- a/Unstoppable/Unstoppable/UserInterface/SwiftUI/InputTextRow.swift
+++ b/Unstoppable/Unstoppable/UserInterface/SwiftUI/InputTextRow.swift
@@ -18,6 +18,6 @@ struct InputTextRow<Content: View>: View {
         .padding(EdgeInsets(top: vertical, leading: .margin16, bottom: vertical, trailing: .margin16))
         .background(RoundedRectangle(cornerRadius: .cornerRadius12, style: .continuous).fill(Color.themeLawrence))
         .overlay(RoundedRectangle(cornerRadius: .cornerRadius12, style: .continuous).stroke(borderColor, lineWidth: .heightOneDp))
-        .frame(minHeight: .heightSingleLineCell)
+        .frame(minHeight: .heightInputCell)
     }
 }

--- a/Unstoppable/Unstoppable/UserInterface/SwiftUI/PrimarySizedHStack.swift
+++ b/Unstoppable/Unstoppable/UserInterface/SwiftUI/PrimarySizedHStack.swift
@@ -15,12 +15,8 @@ struct PrimarySizedHStack<Primary: View, Trailing: View>: View {
         PrimarySizedHStackLayout(spacing: spacing) {
             primary
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .background(Color.yellow.opacity(0.35))
-                .overlay(Rectangle().stroke(Color.yellow, lineWidth: 1))
 
             trailing
-                .background(Color.blue.opacity(0.35))
-                .overlay(Rectangle().stroke(Color.blue, lineWidth: 1))
         }
     }
 }

--- a/Unstoppable/Unstoppable/UserInterface/SwiftUI/PrimarySizedHStack.swift
+++ b/Unstoppable/Unstoppable/UserInterface/SwiftUI/PrimarySizedHStack.swift
@@ -1,0 +1,89 @@
+import SwiftUI
+
+struct PrimarySizedHStack<Primary: View, Trailing: View>: View {
+    let spacing: CGFloat
+    @ViewBuilder let primary: Primary
+    @ViewBuilder let trailing: Trailing
+
+    init(spacing: CGFloat = .margin16, @ViewBuilder primary: () -> Primary, @ViewBuilder trailing: () -> Trailing) {
+        self.spacing = spacing
+        self.primary = primary()
+        self.trailing = trailing()
+    }
+
+    var body: some View {
+        PrimarySizedHStackLayout(spacing: spacing) {
+            primary
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Color.yellow.opacity(0.35))
+                .overlay(Rectangle().stroke(Color.yellow, lineWidth: 1))
+
+            trailing
+                .background(Color.blue.opacity(0.35))
+                .overlay(Rectangle().stroke(Color.blue, lineWidth: 1))
+        }
+    }
+}
+
+extension PrimarySizedHStack where Trailing == EmptyView {
+    init(spacing: CGFloat = .margin16, @ViewBuilder primary: () -> Primary) {
+        self.spacing = spacing
+        self.primary = primary()
+        trailing = EmptyView()
+    }
+}
+
+private struct PrimarySizedHStackLayout: Layout {
+    let spacing: CGFloat
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache _: inout ()) -> CGSize {
+        let trailingWidth = trailingSize(subviews: subviews).width
+        let primarySize = subviews.first?.sizeThatFits(primaryProposal(proposal, trailingWidth: trailingWidth)) ?? .zero
+
+        return CGSize(
+            width: proposal.width ?? primarySize.width + reserve(for: trailingWidth),
+            height: primarySize.height
+        )
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal _: ProposedViewSize, subviews: Subviews, cache _: inout ()) {
+        let trailingSize = trailingSize(subviews: subviews)
+
+        subviews.first?.place(
+            at: CGPoint(x: bounds.minX, y: bounds.minY),
+            anchor: .topLeading,
+            proposal: ProposedViewSize(
+                width: max(0, bounds.width - reserve(for: trailingSize.width)),
+                height: bounds.height
+            )
+        )
+
+        guard trailingSize.width > 0, subviews.indices.contains(1) else {
+            return
+        }
+
+        subviews[1].place(
+            at: CGPoint(x: bounds.maxX, y: bounds.midY),
+            anchor: .trailing,
+            proposal: ProposedViewSize(trailingSize)
+        )
+    }
+
+    private func trailingSize(subviews: Subviews) -> CGSize {
+        guard subviews.indices.contains(1) else {
+            return .zero
+        }
+        return subviews[1].sizeThatFits(.unspecified)
+    }
+
+    private func primaryProposal(_ proposal: ProposedViewSize, trailingWidth: CGFloat) -> ProposedViewSize {
+        ProposedViewSize(
+            width: proposal.width.map { max(0, $0 - reserve(for: trailingWidth)) },
+            height: proposal.height
+        )
+    }
+
+    private func reserve(for trailingWidth: CGFloat) -> CGFloat {
+        trailingWidth > 0 ? trailingWidth + spacing : 0
+    }
+}

--- a/Unstoppable/Unstoppable/UserInterface/SwiftUI/ShortcutButtonsView.swift
+++ b/Unstoppable/Unstoppable/UserInterface/SwiftUI/ShortcutButtonsView.swift
@@ -1,8 +1,6 @@
 import SwiftUI
 
-struct ShortcutButtonsView<Content: View>: View {
-    @ViewBuilder let content: Content
-
+struct ShortcutButtonsView: View {
     @Binding var showDelete: Bool
     let items: [ShortCutButtonType]
     let onTap: (Int) -> Void
@@ -10,8 +8,6 @@ struct ShortcutButtonsView<Content: View>: View {
 
     var body: some View {
         HStack(spacing: .margin8) {
-            content
-
             if showDelete {
                 IconButton(icon: "trash", style: .secondary, size: .small) {
                     onTapDelete()

--- a/Unstoppable/Unstoppable/UserInterface/ThemeKit/Margins.swift
+++ b/Unstoppable/Unstoppable/UserInterface/ThemeKit/Margins.swift
@@ -41,6 +41,7 @@ public extension CGFloat {
     static let heightOnePixel: CGFloat = 1 / UIScreen.main.scale
     static let heightOneDp: CGFloat = 1
     static let heightSingleLineCell: CGFloat = 44
+    static let heightInputCell: CGFloat = 54
     static let heightGrid38: CGFloat = 38
     static let heightCell48: CGFloat = 48
     static let heightCell56: CGFloat = 56


### PR DESCRIPTION
* Update all text input cells with new layout.
* Set minimum height to 54.
* add .gitignore for serena & claude

ref #6946 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Redesigned input rows and shortcut controls across account creation, restore, backup, multiswap, watch, and other screens for more consistent spacing, sizing, and alignment.
  * Standardized input row height for improved visual harmony.

* **Chores**
  * Updated local tooling ignore rules for developer environment artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->