### PR TITLE
Show MEV Protection only for applicable providers

### DIFF
--- a/Unstoppable/Unstoppable/Core/Adapters/Evm/Merkle/MerkleTransactionAdapter.swift
+++ b/Unstoppable/Unstoppable/Core/Adapters/Evm/Merkle/MerkleTransactionAdapter.swift
@@ -99,8 +99,8 @@ extension MerkleTransactionAdapter {
         (transaction.extra[protectedKey] as? Bool) ?? false
     }
 
-    static func allowProtection(blockchainType: BlockchainType) -> Bool {
-        guard let chain = try? Core.shared.evmBlockchainManager.chain(blockchainType: blockchainType) else {
+    static func allowProtection(blockchainTypeIn: BlockchainType, blockchainTypeOut: BlockchainType) -> Bool {
+        guard blockchainTypeIn == blockchainTypeOut, let chain = try? Core.shared.evmBlockchainManager.chain(blockchainType: blockchainTypeIn) else {
             return false
         }
 

--- a/Unstoppable/Unstoppable/Modules/MultiSwap/IMultiSwapProvider.swift
+++ b/Unstoppable/Unstoppable/Modules/MultiSwap/IMultiSwapProvider.swift
@@ -12,6 +12,7 @@ protocol IMultiSwapProvider {
     var syncPublisher: AnyPublisher<Void, Never>? { get }
     func slippageSupported(tokenIn: Token, tokenOut: Token) -> Bool
     func supports(tokenIn: Token, tokenOut: Token) -> Bool
+    func mevProtectionAllowed(tokenIn: Token, tokenOut: Token) -> Bool
     func quote(tokenIn: Token, tokenOut: Token, amountIn: Decimal) async throws -> MultiSwapQuote
     func confirmationQuote(tokenIn: Token, tokenOut: Token, amountIn: Decimal, slippage: Decimal, recipient: String?, transactionSettings: TransactionSettings?) async throws -> SwapFinalQuote
     func validateTrustedProvider(tokenIn: Token, amountIn: Decimal) async throws -> Bool?
@@ -37,6 +38,10 @@ extension IMultiSwapProvider {
             return result == .dirty ? false : nil
         }
         return true
+    }
+
+    func mevProtectionAllowed(tokenIn _: Token, tokenOut _: Token) -> Bool {
+        false
     }
 }
 

--- a/Unstoppable/Unstoppable/Modules/MultiSwap/MultiSwapSendHandler.swift
+++ b/Unstoppable/Unstoppable/Modules/MultiSwap/MultiSwapSendHandler.swift
@@ -99,7 +99,7 @@ extension MultiSwapSendHandler: ISendHandler {
             transactionSettings: transactionSettings
         )
 
-        let otherSections: [SendDataSection] = [mevProtectionHelper.section(tokenIn: tokenIn)].compactMap { $0 }
+        let otherSections = provider.mevProtectionAllowed(tokenIn: tokenIn, tokenOut: tokenOut) ? [mevProtectionHelper.section()] : []
 
         return SendData(tokenIn: tokenIn, tokenOut: tokenOut, amountIn: amountIn, quote: quote, otherSections: otherSections)
     }
@@ -132,7 +132,7 @@ extension MultiSwapSendHandler: ISendHandler {
                 transactionData: transactionData,
                 gasPrice: gasPrice,
                 gasLimit: gasLimit,
-                privateSend: mevProtectionHelper.isActive,
+                privateSend: provider.mevProtectionAllowed(tokenIn: tokenIn, tokenOut: tokenOut) && mevProtectionHelper.isActive,
                 nonce: quote.nonce
             )
 

--- a/Unstoppable/Unstoppable/Modules/MultiSwap/Providers/AllBridgeProvider/AllBridgeMultiSwapProvider.swift
+++ b/Unstoppable/Unstoppable/Modules/MultiSwap/Providers/AllBridgeProvider/AllBridgeMultiSwapProvider.swift
@@ -91,6 +91,10 @@ class AllBridgeMultiSwapProvider: IMultiSwapProvider {
         tokenIn.blockchainType == tokenOut.blockchainType
     }
 
+    func mevProtectionAllowed(tokenIn: Token, tokenOut: Token) -> Bool {
+        MerkleTransactionAdapter.allowProtection(blockchainTypeIn: tokenIn.blockchainType, blockchainTypeOut: tokenOut.blockchainType)
+    }
+
     private func syncAssets() {
         let lastSyncTimetamp = try? swapAssetStorage.lastSyncTimetamp(provider: id)
 

--- a/Unstoppable/Unstoppable/Modules/MultiSwap/Providers/BaseEvmMultiSwapProvider.swift
+++ b/Unstoppable/Unstoppable/Modules/MultiSwap/Providers/BaseEvmMultiSwapProvider.swift
@@ -19,6 +19,10 @@ class BaseEvmMultiSwapProvider: IMultiSwapProvider {
         fatalError("Must be implemented in subclass")
     }
 
+    func mevProtectionAllowed(tokenIn: Token, tokenOut: Token) -> Bool {
+        MerkleTransactionAdapter.allowProtection(blockchainTypeIn: tokenIn.blockchainType, blockchainTypeOut: tokenOut.blockchainType)
+    }
+
     func quote(tokenIn _: Token, tokenOut _: Token, amountIn _: Decimal) async throws -> MultiSwapQuote {
         fatalError("Must be implemented in subclass")
     }

--- a/Unstoppable/Unstoppable/Modules/MultiSwap/Providers/MevProtectionHelper.swift
+++ b/Unstoppable/Unstoppable/Modules/MultiSwap/Providers/MevProtectionHelper.swift
@@ -6,12 +6,7 @@ class MevProtectionHelper {
     var isActive: Bool = false
     private let securityManager = Core.shared.securityManager
 
-    func section(tokenIn: Token) -> SendDataSection? {
-        guard MerkleTransactionAdapter.allowProtection(blockchainType: tokenIn.blockchainType) else {
-            isActive = false
-            return nil
-        }
-
+    func section() -> SendDataSection {
         isActive = securityManager.swapProtectionEnabled
 
         let binding = Binding<Bool>(
@@ -34,7 +29,7 @@ class MevProtectionHelper {
             }
         )
 
-        return .init([
+        return SendDataSection([
             .mevProtection(isOn: binding),
         ], isList: false)
     }


### PR DESCRIPTION
* Show mev only for providers with tokens in same blockchains.
* 1Inch/Uniswap/Pancake/AllBridge

ref #6968 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * MEV protection is now more intelligently applied during swaps by validating both input and output tokens. Protection is only enabled when both tokens are compatible, ensuring consistent availability across different swap scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/horizontalsystems/unstoppable-wallet-ios/pull/6977)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->