### PR TITLE
Show estimated time when tokenIn is non-EVM token

### DIFF
--- a/Unstoppable/Unstoppable/Modules/MultiSwap/Providers/USwap/USwapMultiSwapProvider.swift
+++ b/Unstoppable/Unstoppable/Modules/MultiSwap/Providers/USwap/USwapMultiSwapProvider.swift
@@ -366,7 +366,8 @@ class USwapMultiSwapProvider: IMultiSwapProvider {
             return EvmMultiSwapQuote(expectedBuyAmount: quote.expectedBuyAmount, allowanceState: allowanceState, estimatedTime: esimatedTime)
 
         case .bitcoin, .bitcoinCash, .ecash, .litecoin, .dash, .zcash, .monero, .ton, .stellar, .zano, .solana:
-            return MultiSwapQuote(expectedBuyAmount: quote.expectedBuyAmount)
+            let estimatedTime = quote.esimatedTime ?? MultiSwapHelpers.estimate(tokenIn: tokenIn, tokenOut: tokenOut)
+            return MultiSwapQuote(expectedBuyAmount: quote.expectedBuyAmount, estimatedTime: estimatedTime)
 
         default:
             throw SwapError.unsupportedTokenIn


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed missing estimated swap times for Bitcoin, Litecoin, Zcash, Monero, TON, Solana, Stellar, and Zano blockchains in the multi-swap feature.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/horizontalsystems/unstoppable-wallet-ios/pull/6993?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->