### PR TITLE
Always show receive for new wallets.

### DIFF
--- a/UnstoppableWallet/UnstoppableWallet/Modules/Backup/BackupRequiredView.swift
+++ b/UnstoppableWallet/UnstoppableWallet/Modules/Backup/BackupRequiredView.swift
@@ -15,7 +15,7 @@ struct BackupRequiredView: View {
                 .title(icon: ThemeImage.warning, title: title),
                 .text(text: description),
                 .buttonGroup(.init(buttons: [
-                    .init(style: .gray, title: "backup_prompt.backup_manual".localized, icon: "edit_24") {
+                    .init(style: .yellow, title: "backup_prompt.backup_manual".localized, icon: "edit_24") {
                         isPresented = false
 
                         Coordinator.shared.present { _ in
@@ -23,10 +23,13 @@ struct BackupRequiredView: View {
                         }
                         stat(page: statPage, event: .open(page: .manualBackup))
                     },
-                    .init(style: .transparent, title: "backup_prompt.backup_cloud".localized, icon: "icloud_24") {
+                    .init(style: .gray, title: "backup_prompt.backup_cloud".localized, icon: "icloud_24") {
                         isPresented = false
 
                         Coordinator.shared.presentWalletBackup(account: account, statPage: statPage)
+                    },
+                    .init(style: .transparent, title: cancelText) {
+                        isPresented = false
                     },
                 ])),
             ],
@@ -40,17 +43,6 @@ struct BackupRequiredView: View {
             description: "backup_prompt.warning".localized,
             cancelText: "backup_prompt.later".localized,
             statPage: .backupPromptAfterCreate,
-            isPresented: isPresented
-        )
-    }
-
-    static func prompt(account: Account, description: String, isPresented: Binding<Bool>) -> BackupRequiredView {
-        BackupRequiredView(
-            account: account,
-            title: "backup_prompt.backup_required".localized,
-            description: description,
-            cancelText: "button.cancel".localized,
-            statPage: .backupRequired,
             isPresented: isPresented
         )
     }

--- a/UnstoppableWallet/UnstoppableWallet/Modules/Wallet/Token/WalletTokenViewModel.swift
+++ b/UnstoppableWallet/UnstoppableWallet/Modules/Wallet/Token/WalletTokenViewModel.swift
@@ -149,27 +149,13 @@ extension WalletTokenViewModel {
     }
 
     func onTapReceive() {
-        if wallet.account.backedUp || cloudBackupManager.backedUp(uniqueId: wallet.account.type.uniqueId()) {
-            Coordinator.shared.present { [wallet] _ in
-                EmptyThemeNavigationStack { path in
-                    ReceiveAddressModule.instance(wallet: wallet, path: path)
-                }
+        Coordinator.shared.present { [wallet] _ in
+            EmptyThemeNavigationStack { path in
+                ReceiveAddressModule.instance(wallet: wallet, path: path)
             }
-
-            stat(page: .tokenPage, event: .openReceive(token: wallet.token))
-        } else {
-            let wallet = wallet
-
-            Coordinator.shared.present(type: .bottomSheet) { isPresented in
-                BackupRequiredView.prompt(
-                    account: wallet.account,
-                    description: "receive_alert.not_backed_up_description".localized(wallet.account.name, wallet.coin.name),
-                    isPresented: isPresented
-                )
-            }
-
-            stat(page: .tokenPage, event: .open(page: .backupRequired))
         }
+
+        stat(page: .tokenPage, event: .openReceive(token: wallet.token))
     }
 
     func onTapAmount() {

--- a/UnstoppableWallet/UnstoppableWallet/Modules/Wallet/WalletView.swift
+++ b/UnstoppableWallet/UnstoppableWallet/Modules/Wallet/WalletView.swift
@@ -202,10 +202,6 @@ struct WalletView: View {
     }
 
     private func copyAddressIfBackedUp(address: String) {
-        guard viewModel.verifyBackedUp() else {
-            return
-        }
-
         CopyHelper.copyAndNotify(value: address)
     }
 

--- a/UnstoppableWallet/UnstoppableWallet/Modules/Wallet/WalletViewModel.swift
+++ b/UnstoppableWallet/UnstoppableWallet/Modules/Wallet/WalletViewModel.swift
@@ -111,19 +111,6 @@ extension WalletViewModel {
         appStateManager.swapEnabled
     }
 
-    func verifyBackedUp() -> Bool {
-        guard let account else {
-            return false
-        }
-
-        let backedUp = account.backedUp || cloudBackupManager.backedUp(uniqueId: account.type.uniqueId())
-        if !backedUp {
-            showBackupBottomSheet()
-        }
-
-        return backedUp
-    }
-
     func onAppear() {
         rateAppManager.onBalancePageAppear()
     }
@@ -140,28 +127,8 @@ extension WalletViewModel {
         balanceConversionManager.toggleConversionToken()
     }
 
-    func showBackupBottomSheet() {
-        guard let account else {
-            return
-        }
-
-        Coordinator.shared.present(type: .bottomSheet) { isPresented in
-            BackupRequiredView.prompt(
-                account: account,
-                description: "receive_alert.any_coins.not_backed_up_description".localized(account.name),
-                isPresented: isPresented
-            )
-        }
-
-        stat(page: .balance, event: .open(page: .backupRequired))
-    }
-
     func onTapReceive() {
         guard let account else {
-            return
-        }
-
-        guard verifyBackedUp() else {
             return
         }
 

--- a/UnstoppableWallet/UnstoppableWallet/Modules/WalletConnect/WalletConnectVerificationModel.swift
+++ b/UnstoppableWallet/UnstoppableWallet/Modules/WalletConnect/WalletConnectVerificationModel.swift
@@ -23,19 +23,6 @@ class WalletConnectVerificationModel: ObservableObject {
             return
         }
 
-        if !activeAccount.backedUp, !cloudBackupManager.backedUp(uniqueId: activeAccount.type.uniqueId()) {
-            Coordinator.shared.present(type: .bottomSheet) { isPresented in
-                BackupRequiredView.prompt(
-                    account: activeAccount,
-                    description: "wallet_connect.unbackuped_account.description".localized(activeAccount.name),
-                    isPresented: isPresented
-                )
-            }
-
-            stat(page: .walletConnect, event: .open(page: .backupRequired))
-            return
-        }
-
         onSuccess()
     }
 

--- a/UnstoppableWallet/UnstoppableWallet/de.lproj/Localizable.strings
+++ b/UnstoppableWallet/UnstoppableWallet/de.lproj/Localizable.strings
@@ -1938,7 +1938,6 @@
 "wallet_connect_list.new_connection" = "Neue Verbindung";
 
 "wallet_connect.no_account.description" = "Sie müssen eine Wallet erstellen oder importieren bevor Sie WalletConnect verwenden können.";
-"wallet_connect.unbackuped_account.description" = "Sie müssen %@ sichern bevor Sie WalletConnect verwenden können";
 
 "wallet_connect.non_supported_account.description" = "Ihr aktueller Wallet-Typ %@ unterstützt WalletConnect nicht";
 "wallet_connect.non_supported_account.switch" = "Wechseln";

--- a/UnstoppableWallet/UnstoppableWallet/en.lproj/Localizable.strings
+++ b/UnstoppableWallet/UnstoppableWallet/en.lproj/Localizable.strings
@@ -1938,7 +1938,6 @@
 "wallet_connect_list.new_connection" = "New Connection";
 
 "wallet_connect.no_account.description" = "You need to create or import a wallet before you can use WalletConnect.";
-"wallet_connect.unbackuped_account.description" = "You need to backup %@ before you can use WalletConnect";
 
 "wallet_connect.non_supported_account.description" = "Your current wallet type %@ does not support WalletConnect";
 "wallet_connect.non_supported_account.switch" = "Switch";

--- a/UnstoppableWallet/UnstoppableWallet/es.lproj/Localizable.strings
+++ b/UnstoppableWallet/UnstoppableWallet/es.lproj/Localizable.strings
@@ -1938,7 +1938,6 @@
 "wallet_connect_list.new_connection" = "Nueva Conexión";
 
 "wallet_connect.no_account.description" = "Necesita crear o importar una cartera antes de poder usar WalletConnect.";
-"wallet_connect.unbackuped_account.description" = "Necesitas hacer una copia de seguridad de %@ antes de poder usar WalletConnect";
 
 "wallet_connect.non_supported_account.description" = "El tipo de cartera actual %@ no es compatible con WalletConnect";
 "wallet_connect.non_supported_account.switch" = "Cambiar";

--- a/UnstoppableWallet/UnstoppableWallet/fr.lproj/Localizable.strings
+++ b/UnstoppableWallet/UnstoppableWallet/fr.lproj/Localizable.strings
@@ -1938,7 +1938,6 @@
 "wallet_connect_list.new_connection" = "Nouvelle connexion";
 
 "wallet_connect.no_account.description" = "Vous devez créer ou importer un portefeuille avant de pouvoir utiliser WalletConnect.";
-"wallet_connect.unbackuped_account.description" = "Vous devez sauvegarder %@ avant de pouvoir utiliser WalletConnect";
 
 "wallet_connect.non_supported_account.description" = "Votre type de portefeuille actuel %@ ne prend pas en charge WalletConnect";
 "wallet_connect.non_supported_account.switch" = "Basculer";

--- a/UnstoppableWallet/UnstoppableWallet/ko.lproj/Localizable.strings
+++ b/UnstoppableWallet/UnstoppableWallet/ko.lproj/Localizable.strings
@@ -1938,7 +1938,6 @@
 "wallet_connect_list.new_connection" = "새로운 연결";
 
 "wallet_connect.no_account.description" = "WalletConnect를 사용하려면 먼저 지갑을 생성하거나 가져와야 합니다.";
-"wallet_connect.unbackuped_account.description" = "WalletConnect를 사용하려면 %@을(를) 백업해야 합니다.";
 
 "wallet_connect.non_supported_account.description" = "현재 지갑 유형 %@은(는) WalletConnect를 지원하지 않습니다.";
 "wallet_connect.non_supported_account.switch" = "전환";

--- a/UnstoppableWallet/UnstoppableWallet/pt-BR.lproj/Localizable.strings
+++ b/UnstoppableWallet/UnstoppableWallet/pt-BR.lproj/Localizable.strings
@@ -1938,7 +1938,6 @@
 "wallet_connect_list.new_connection" = "Nova Conexão";
 
 "wallet_connect.no_account.description" = "Você precisa criar ou importar uma carteira antes de usar o WalletConnect.";
-"wallet_connect.unbackuped_account.description" = "Você precisa fazer o backup de %@ antes de poder usar o WalletConnect";
 
 "wallet_connect.non_supported_account.description" = "Seu tipo de carteira atual %@ não suporta WalletConnect";
 "wallet_connect.non_supported_account.switch" = "Alternar";

--- a/UnstoppableWallet/UnstoppableWallet/ru.lproj/Localizable.strings
+++ b/UnstoppableWallet/UnstoppableWallet/ru.lproj/Localizable.strings
@@ -1938,7 +1938,6 @@
 "wallet_connect_list.new_connection" = "Новое соединение";
 
 "wallet_connect.no_account.description" = "Вам нужно создать или импортировать кошелек перед использованием WalletConnect.";
-"wallet_connect.unbackuped_account.description" = "Вам нужно сделать резервную копию %@ перед использованием WalletConnect";
 
 "wallet_connect.non_supported_account.description" = "Ваш текущий тип кошелька %@ не поддерживает WalletConnect";
 "wallet_connect.non_supported_account.switch" = "Перекл.";

--- a/UnstoppableWallet/UnstoppableWallet/tr.lproj/Localizable.strings
+++ b/UnstoppableWallet/UnstoppableWallet/tr.lproj/Localizable.strings
@@ -1938,7 +1938,6 @@
 "wallet_connect_list.new_connection" = "Yeni bağlantı";
 
 "wallet_connect.no_account.description" = "WalletConnect'i kullanmadan önce bir cüzdan oluşturmanız veya içe aktarmanız gerekir.";
-"wallet_connect.unbackuped_account.description" = "WalletConnect'i kullanmadan önce %@ yedeklemeniz gerekir";
 
 "wallet_connect.non_supported_account.description" = "Mevcut cüzdan türünüz %@ WalletConnect'i desteklemiyor";
 "wallet_connect.non_supported_account.switch" = "Değiştir";

--- a/UnstoppableWallet/UnstoppableWallet/translation_snapshot.json
+++ b/UnstoppableWallet/UnstoppableWallet/translation_snapshot.json
@@ -1506,7 +1506,6 @@
   "wallet_connect.list.empty_view_text": "No active sessions",
   "wallet_connect_list.new_connection": "New Connection",
   "wallet_connect.no_account.description": "You need to create or import a wallet before you can use WalletConnect.",
-  "wallet_connect.unbackuped_account.description": "You need to backup %@ before you can use WalletConnect",
   "wallet_connect.non_supported_account.description": "Your current wallet type %@ does not support WalletConnect",
   "wallet_connect.non_supported_account.switch": "Switch",
   "ton_connect.list.new_connection": "New Connection",

--- a/UnstoppableWallet/UnstoppableWallet/zh.lproj/Localizable.strings
+++ b/UnstoppableWallet/UnstoppableWallet/zh.lproj/Localizable.strings
@@ -1938,7 +1938,6 @@
 "wallet_connect_list.new_connection" = "新连接";
 
 "wallet_connect.no_account.description" = "您需要先创建或导入钱包才能使用 WaletConnect。";
-"wallet_connect.unbackuped_account.description" = "您需要先备份 %@ 才能使用钱包连接";
 
 "wallet_connect.non_supported_account.description" = "您当前的钱包类型 %@ 不支持 WalletConnect";
 "wallet_connect.non_supported_account.switch" = "切换";


### PR DESCRIPTION
ref #7010 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now receive wallet assets without requiring wallet backup.
  * Wallet address copying no longer requires backup verification.
  * Simplified WalletConnect messaging to focus on account creation/import requirement.

* **Style**
  * Updated button styling in backup-related prompts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/horizontalsystems/unstoppable-wallet-ios/pull/7012?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->