### PR TITLE
Update zcash using new libzcashlc.framework patch.

### DIFF
--- a/UnstoppableWallet/UnstoppableWallet.xcodeproj/project.pbxproj
+++ b/UnstoppableWallet/UnstoppableWallet.xcodeproj/project.pbxproj
@@ -14332,7 +14332,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.48.2;
+				MARKETING_VERSION = 0.48.3;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -14403,7 +14403,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.48.2;
+				MARKETING_VERSION = 0.48.3;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -14895,7 +14895,7 @@
 			repositoryURL = "https://github.com/horizontalsystems/ZcashLightClientKit";
 			requirement = {
 				kind = revision;
-				revision = 8881b297ac91ffafc5083267955e32872dfe0e00;
+				revision = e6c757a555ccbc8b05dc25a77d393d45a6094832;
 			};
 		};
 		6BDA29A929D6EA9B003847ED /* XCRemoteSwiftPackageReference "ECashKit.Swift" */ = {

--- a/UnstoppableWallet/UnstoppableWallet/Core/Adapters/Zcash/ZcashAdapter.swift
+++ b/UnstoppableWallet/UnstoppableWallet/Core/Adapters/Zcash/ZcashAdapter.swift
@@ -13,7 +13,7 @@ import ZcashLightClientKit
 class ZcashAdapter {
     static let minimalThreshold: Decimal = 0.0004 // minimal transparent balance to shielding
 
-    private static let endPoint = "zec.rocks" // "lightwalletd.electriccoin.co"
+    private static let endPoint = "us.zec.stardust.rest" // ZODL NU6.2 endpoint; was "zec.rocks" (Zebra zr3 degraded GetSubtreeRoots during NU6.2 rollout)
     private let queue = DispatchQueue(label: "\(AppConfig.label).zcash-adapter", qos: .userInitiated)
 
     private var cancellables: [AnyCancellable] = []


### PR DESCRIPTION
* NU 6.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Zcash network services configuration and protocol libraries.

* **Chores**
  * Application version bumped to 0.48.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->