### PR TITLE
Stop auto quoting when app is in background

### DIFF
--- a/packages/WalletCore/Sources/WalletCore/Modules/SendNew/SendView.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/SendNew/SendView.swift
@@ -60,6 +60,12 @@ struct SendView: View {
                 }
             }
         }
+        .onAppear {
+            viewModel.autoQuoteIfRequired()
+        }
+        .onDisappear {
+            viewModel.stopAutoQuoting()
+        }
         .onReceive(viewModel.errorPublisher) { error in
             Coordinator.shared.present(type: .bottomSheet) { isPresented in
                 BottomSheetView(

--- a/packages/WalletCore/Sources/WalletCore/Modules/SendNew/SendViewModel.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/SendNew/SendViewModel.swift
@@ -9,6 +9,7 @@ class SendViewModel: ObservableObject {
     private let currencyManager = Core.shared.currencyManager
     private let marketKit = Core.shared.marketKit
     private let recentAddressStorage = Core.shared.recentAddressStorage
+    private let appManager = Core.shared.appManager
 
     private var syncTask: AnyTask?
     private var ratesCancellable: AnyCancellable?
@@ -71,6 +72,16 @@ class SendViewModel: ObservableObject {
             .sink { [weak self] in
                 self?.sync()
             }
+            .store(in: &cancellables)
+
+        appManager.didEnterBackgroundPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in self?.stopAutoQuoting() }
+            .store(in: &cancellables)
+
+        appManager.willEnterForegroundPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in self?.autoQuoteIfRequired() }
             .store(in: &cancellables)
 
         sync()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Send flow auto-quote behavior is now lifecycle-aware: quote updates pause when the app goes to the background and automatically resume when it returns to the foreground, reducing unnecessary background activity and keeping displayed prices current.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->