### PR TITLE
Update UI for wallets/token screens.

### DIFF
--- a/packages/WalletCore/Sources/WalletCore/Modules/Main/MainView.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/Main/MainView.swift
@@ -68,18 +68,23 @@ struct MainView: View {
             }
         case .wallet:
             if walletViewModel.account != nil {
-                ToolbarItem(placement: .primaryAction) {
-                    Button(action: {
-                        Coordinator.shared.present { isPresented in
-                            MainTransactionsView(transactionsViewModel: transactionsViewModel, isPresented: isPresented)
+                if walletViewModel.buttonHidden {
+                    ToolbarItemGroup(placement: .primaryAction) {
+                        Button(action: onTapScan) {
+                            Image("scan")
                         }
-                        stat(page: .transactions, event: .open(page: .transactions))
-                    }) {
-                        Image("clock")
+                    }
+
+                    if #available(iOS 26, *) {
+                        ToolbarSpacer(.fixed, placement: .primaryAction)
                     }
                 }
 
-                ToolbarItem(placement: .primaryAction) {
+                ToolbarItemGroup(placement: .primaryAction) {
+                    Button(action: onTapHistory) {
+                        Image("clock")
+                    }
+
                     Button(action: {
                         Coordinator.shared.present { isPresented in
                             ManageAccountsView(parentPresented: isPresented)
@@ -90,30 +95,6 @@ struct MainView: View {
                     }
                 }
 
-                if walletViewModel.totalItem.state == .syncing {
-                    ToolbarItem(placement: .navigationBarLeading) {
-                        ProgressView(value: 0.55)
-                            .progressViewStyle(DeterminiteSpinnerStyle())
-                            .frame(size: 24)
-                            .spinning()
-                    }
-                }
-
-                if walletViewModel.buttonHidden {
-                    ToolbarItem(placement: .navigationBarLeading) {
-                        Button(action: {
-                            Coordinator.shared.present { isPresented in
-                                ScanQrViewNew(reportAfterDismiss: true, isPresented: isPresented) { text in
-                                    walletViewModel.process(scanned: text)
-                                }
-                                .ignoresSafeArea()
-                            }
-                            stat(page: .balance, event: .open(page: .scanQrCode))
-                        }) {
-                            Image("scan")
-                        }
-                    }
-                }
             }
         case .swap:
             ToolbarItem(placement: .primaryAction) {
@@ -149,6 +130,23 @@ struct MainView: View {
         case .settings:
             ToolbarItem {}
         }
+    }
+
+    private func onTapScan() {
+        Coordinator.shared.present { isPresented in
+            ScanQrViewNew(reportAfterDismiss: true, isPresented: isPresented) { text in
+                walletViewModel.process(scanned: text)
+            }
+            .ignoresSafeArea()
+        }
+        stat(page: .balance, event: .open(page: .scanQrCode))
+    }
+
+    private func onTapHistory() {
+        Coordinator.shared.present { isPresented in
+            MainTransactionsView(transactionsViewModel: transactionsViewModel, isPresented: isPresented)
+        }
+        stat(page: .transactions, event: .open(page: .transactions))
     }
 
     var title: String {

--- a/packages/WalletCore/Sources/WalletCore/Modules/Wallet/Token/ToolbarWalletTokenView.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/Wallet/Token/ToolbarWalletTokenView.swift
@@ -13,7 +13,7 @@ struct ToolbarWalletTokenView<Content: View>: View {
         BaseWalletTokenView(wallet: wallet) { viewModel, transactionsViewModel in
             content(viewModel, transactionsViewModel)
                 .toolbar {
-                    if WalletTokenToolbarItems.hasToolbarStatus(viewModel: viewModel) {
+                    if WalletTokenToolbarItems.hasToolbarItems(viewModel: viewModel) {
                         ToolbarItem(placement: .topBarTrailing) {
                             HStack(spacing: 8) {
                                 WalletTokenToolbarItems(viewModel: viewModel)
@@ -28,33 +28,11 @@ struct ToolbarWalletTokenView<Content: View>: View {
 struct WalletTokenToolbarItems: View {
     @ObservedObject var viewModel: WalletTokenViewModel
 
-    // must be changed with items logic
-    static func hasToolbarStatus(viewModel: WalletTokenViewModel) -> Bool {
-        switch viewModel.state {
-        case .notSynced: return viewModel.isReachable
-        case .syncing, .customSyncing: return true
-        default: return viewModel.wallet.account.watchAccount
-        }
+    static func hasToolbarItems(viewModel: WalletTokenViewModel) -> Bool {
+        viewModel.wallet.account.watchAccount
     }
 
     var body: some View {
-        switch viewModel.state {
-        case .notSynced:
-            if viewModel.isReachable {
-                Button(action: {
-                    Coordinator.shared.presentBalanceError(wallet: viewModel.wallet, state: viewModel.state)
-                }) {
-                    Image("warning_filled").icon(colorStyle: .red)
-                }
-            }
-        case let .syncing(progress, _, _), let .customSyncing(_, _, progress):
-            ProgressView(value: max(0.1, Float(progress ?? 10) / 100))
-                .progressViewStyle(DeterminiteSpinnerStyle())
-                .frame(width: 20, height: 20)
-                .spinning()
-        default: EmptyView()
-        }
-
         if viewModel.wallet.account.watchAccount {
             Button(action: {
                 Coordinator.shared.presentCoinPage(coin: viewModel.wallet.coin, page: .tokenPage)

--- a/packages/WalletCore/Sources/WalletCore/Modules/Wallet/Token/TronToolbarWalletTokenView.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/Wallet/Token/TronToolbarWalletTokenView.swift
@@ -2,12 +2,10 @@ import SwiftUI
 
 struct TronToolbarWalletTokenView<Content: View>: View {
     let wallet: Wallet
-    @ObservedObject var tronWalletViewModel: TronWalletTokenViewModel
     private let content: (WalletTokenViewModel, TransactionsViewModel) -> Content
 
-    init(wallet: Wallet, tronWalletViewModel: TronWalletTokenViewModel, @ViewBuilder content: @escaping (WalletTokenViewModel, TransactionsViewModel) -> Content) {
+    init(wallet: Wallet, @ViewBuilder content: @escaping (WalletTokenViewModel, TransactionsViewModel) -> Content) {
         self.wallet = wallet
-        self.tronWalletViewModel = tronWalletViewModel
         self.content = content
     }
 
@@ -15,17 +13,9 @@ struct TronToolbarWalletTokenView<Content: View>: View {
         BaseWalletTokenView(wallet: wallet) { viewModel, transactionsViewModel in
             content(viewModel, transactionsViewModel)
                 .toolbar {
-                    ToolbarItem(placement: .topBarTrailing) {
-                        // show default toolbars if it's present
-                        if WalletTokenToolbarItems.hasToolbarStatus(viewModel: viewModel) {
+                    if WalletTokenToolbarItems.hasToolbarItems(viewModel: viewModel) {
+                        ToolbarItem(placement: .topBarTrailing) {
                             WalletTokenToolbarItems(viewModel: viewModel)
-
-                        } else if !tronWalletViewModel.accountActive {
-                            Button(action: {
-                                tronWalletViewModel.showPopup()
-                            }) {
-                                Image("warning_filled").icon(colorStyle: .yellow)
-                            }
                         }
                     }
                 }

--- a/packages/WalletCore/Sources/WalletCore/Modules/Wallet/Token/TronWalletTokenView.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/Wallet/Token/TronWalletTokenView.swift
@@ -11,13 +11,22 @@ struct TronWalletTokenView: View {
     }
 
     var body: some View {
-        TronToolbarWalletTokenView(wallet: wallet, tronWalletViewModel: viewModel) { walletTokenViewModel, transactionsViewModel in
+        TronToolbarWalletTokenView(wallet: wallet) { walletTokenViewModel, transactionsViewModel in
             let transactionListStatus = viewModel.accountActive ? transactionsViewModel.transactionListStatus : .inactiveWallet
 
             ViewWithTransactionList(
                 transactionListStatus: transactionListStatus,
                 content: {
-                    WalletTokenTopView(viewModel: walletTokenViewModel).themeListTopView()
+                    WalletTokenTopView(
+                        viewModel: walletTokenViewModel,
+                        status: {
+                            TronWalletTokenHeaderStatusView(viewModel: walletTokenViewModel, tronViewModel: viewModel)
+                        },
+                        content: {
+                            EmptyView()
+                        }
+                    )
+                    .themeListTopView()
                 },
                 transactionList: {
                     TransactionsView(viewModel: transactionsViewModel, statPage: .tokenPage)

--- a/packages/WalletCore/Sources/WalletCore/Modules/Wallet/Token/WalletTokenTopView.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/Wallet/Token/WalletTokenTopView.swift
@@ -1,14 +1,17 @@
 import SwiftUI
 
-struct WalletTokenTopView<Content: View>: View {
+struct WalletTokenTopView<Content: View, Status: View>: View {
     @ObservedObject var viewModel: WalletTokenViewModel
+    let status: () -> Status
     let content: () -> Content
 
     init(
         viewModel: WalletTokenViewModel,
-        @ViewBuilder content: @escaping () -> Content = { EmptyView() }
+        @ViewBuilder status: @escaping () -> Status,
+        @ViewBuilder content: @escaping () -> Content
     ) {
         self.viewModel = viewModel
+        self.status = status
         self.content = content
     }
 
@@ -23,7 +26,11 @@ struct WalletTokenTopView<Content: View>: View {
                         HapticGenerator.instance.notification(.feedback(.soft))
                     }
 
-                ThemeText(secondaryValue, style: .body, colorStyle: .secondary)
+                PrimarySizedHStack(spacing: .margin8) {
+                    ThemeText(secondaryValue, style: .body, colorStyle: .secondary)
+                } trailing: {
+                    status()
+                }
             }
             .padding(.horizontal, 16)
 
@@ -162,5 +169,25 @@ struct WalletTokenTopView<Content: View>: View {
 
             return "----"
         }
+    }
+}
+
+extension WalletTokenTopView where Content == EmptyView, Status == WalletTokenHeaderStatusView {
+    init(viewModel: WalletTokenViewModel) {
+        self.init(
+            viewModel: viewModel,
+            status: { WalletTokenHeaderStatusView(viewModel: viewModel) },
+            content: { EmptyView() }
+        )
+    }
+}
+
+extension WalletTokenTopView where Status == WalletTokenHeaderStatusView {
+    init(viewModel: WalletTokenViewModel, @ViewBuilder content: @escaping () -> Content) {
+        self.init(
+            viewModel: viewModel,
+            status: { WalletTokenHeaderStatusView(viewModel: viewModel) },
+            content: content
+        )
     }
 }

--- a/packages/WalletCore/Sources/WalletCore/Modules/Wallet/WalletView.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/Wallet/WalletView.swift
@@ -238,6 +238,11 @@ struct WalletView: View {
 
             if !viewModel.isReachable {
                 ThemeText("alert.no_internet".localized, style: .subheadSB, colorStyle: .red)
+            } else if viewModel.totalItem.state == .syncing {
+                ProgressView(value: 0.6)
+                    .progressViewStyle(DeterminiteSpinnerStyle())
+                    .frame(size: 20)
+                    .spinning()
             }
         }
     }


### PR DESCRIPTION
* Move loading state in headers
* Move Qr scan as separate button in ios26 on right side
* Move warning/incative/error status in header (tokenBalance screen)

ref #6937 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual progress indicator to wallet header when syncing account totals

* **Refactor**
  * Reorganized wallet and token toolbar logic for improved consistency
  * Simplified toolbar visibility conditions and view composition
  * Refined wallet header state management to better reflect sync status
  * Streamlined view initialization and dependency handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->