### PR TITLE
Hide filters(swap/approval) in transaction history.

### DIFF
--- a/packages/WalletCore/Sources/WalletCore/Core/Adapters/Evm/EvmTransactionsAdapter.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Adapters/Evm/EvmTransactionsAdapter.swift
@@ -58,8 +58,6 @@ class EvmTransactionsAdapter: BaseEvmAdapter {
         case .all: ()
         case .incoming: type = .incoming
         case .outgoing: type = .outgoing
-        case .swap: type = .swap
-        case .approve: type = .approve
         }
 
         return TransactionTagQuery(type: type, protocol: `protocol`, contractAddress: contractAddress, address: address)

--- a/packages/WalletCore/Sources/WalletCore/Core/Adapters/SolanaTransactionsAdapter.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Adapters/SolanaTransactionsAdapter.swift
@@ -93,14 +93,6 @@ extension SolanaTransactionsAdapter: ITransactionsAdapter {
 
         let incoming = incomingFilter(filter: filter)
 
-        // For unsupported filter types (.swap, .approve), return empty
-        if case .swap = filter {
-            return Observable.just([])
-        }
-        if case .approve = filter {
-            return Observable.just([])
-        }
-
         let publisher: AnyPublisher<[FullTransaction], Never>
 
         if let token {

--- a/packages/WalletCore/Sources/WalletCore/Core/Adapters/StellarTransactionAdapter.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Adapters/StellarTransactionAdapter.swift
@@ -63,8 +63,6 @@ class StellarTransactionAdapter {
         case .all: ()
         case .incoming: type = .incoming
         case .outgoing: type = .outgoing
-        case .swap: type = .swap
-        case .approve: type = .unsupported
         }
 
         if let address {

--- a/packages/WalletCore/Sources/WalletCore/Core/Adapters/TonTransactionAdapter.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Adapters/TonTransactionAdapter.swift
@@ -51,8 +51,6 @@ class TonTransactionAdapter {
         case .all: ()
         case .incoming: type = .incoming
         case .outgoing: type = .outgoing
-        case .swap: type = .swap
-        case .approve: type = .unsupported
         }
 
         let address = address.flatMap { try? TonSwift.Address.parse($0) }

--- a/packages/WalletCore/Sources/WalletCore/Core/Adapters/Tron/TronTransactionAdapter.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Adapters/Tron/TronTransactionAdapter.swift
@@ -55,8 +55,6 @@ class TronTransactionsAdapter: BaseTronAdapter {
         case .all: ()
         case .incoming: type = .incoming
         case .outgoing: type = .outgoing
-        case .swap: type = .swap
-        case .approve: type = .approve
         }
 
         return TransactionTagQuery(type: type, protocol: `protocol`, contractAddress: contractAddress, address: address)

--- a/packages/WalletCore/Sources/WalletCore/Extensions/StatExtensions.swift
+++ b/packages/WalletCore/Sources/WalletCore/Extensions/StatExtensions.swift
@@ -53,8 +53,6 @@ extension TransactionTypeFilter {
         case .all: return .all
         case .incoming: return .incoming
         case .outgoing: return .outgoing
-        case .swap: return .swap
-        case .approve: return .approve
         }
     }
 }

--- a/packages/WalletCore/Sources/WalletCore/Modules/Transactions/TransactionTypeFilter.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/Transactions/TransactionTypeFilter.swift
@@ -1,8 +1,8 @@
 enum TransactionTypeFilter: String {
-    case all, incoming, outgoing, swap, approve
+    case all, incoming, outgoing
 
     static var allCases: [TransactionTypeFilter] {
-        [all, incoming, outgoing] + (AppStateManager.instance.swapEnabled ? [swap] : []) + [approve]
+        [all, incoming, outgoing]
     }
 
     var title: String {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed swap and approve transaction filter options from the transaction view. Users can now filter transactions by all transactions, incoming transactions, or outgoing transactions only. This change has been applied consistently across all supported blockchain networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->