### PR TITLE
Remove smart-account from restore view.

### DIFF
--- a/packages/WalletCore/Sources/WalletCore/Modules/RestoreAccount/RestoreType/RestoreTypeView.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/RestoreAccount/RestoreType/RestoreTypeView.swift
@@ -98,23 +98,6 @@ struct RestoreTypeView: View {
                     }
                 }
             }
-        case .passkeySmartAccount:
-            Task {
-                do {
-                    _ = try await viewModel.restoreSmartAccount()
-
-                    DispatchQueue.main.async {
-                        (parentPresented ?? $isPresented).wrappedValue = false
-                    }
-                } catch {
-                    if case PasskeyManager.PasskeyError.userCanceled = error {
-                        return
-                    }
-                    DispatchQueue.main.async {
-                        HudHelper.instance.show(banner: .error(string: error.smartDescription))
-                    }
-                }
-            }
         case .backup:
             backupPresented = true
         }
@@ -126,7 +109,6 @@ extension RestoreTypeView {
         case recoveryPhrase
         case privateKey
         case passkey
-        case passkeySmartAccount
         case backup
 
         var id: String {
@@ -138,7 +120,6 @@ extension RestoreTypeView {
             case .recoveryPhrase: return "restore_type.recovery.title".localized
             case .privateKey: return "restore_type.private_key.title".localized
             case .passkey: return "restore_type.passkey.title".localized
-            case .passkeySmartAccount: return "restore_type.passkey_smart.title".localized
             case .backup: return "restore_type.backup.title".localized
             }
         }
@@ -148,7 +129,6 @@ extension RestoreTypeView {
             case .recoveryPhrase: return "restore_type.recovery.description".localized
             case .privateKey: return "restore_type.private_key.description".localized
             case .passkey: return "restore_type.passkey.description".localized
-            case .passkeySmartAccount: return "restore_type.passkey_smart.description".localized
             case .backup: return "restore_type.backup.description".localized
             }
         }
@@ -158,7 +138,6 @@ extension RestoreTypeView {
             case .recoveryPhrase: return "pen"
             case .privateKey: return "key_24"
             case .passkey: return "face_id"
-            case .passkeySmartAccount: return "face_id"
             case .backup: return "cloud"
             }
         }


### PR DESCRIPTION
ref #7064

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the smart account restore option from the account restoration process. Users can now restore accounts using recovery phrase, private key, passkey, or backup methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->