### PR TITLE
AA passkey: per-app domain + 1-Face-ID create (PRF at registration)

### DIFF
--- a/packages/WalletCore/Sources/WalletCore/Core/AppConfig.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/AppConfig.swift
@@ -10,6 +10,10 @@ enum AppConfig {
     static let reportEmail = "support.unstoppable@protonmail.com"
     static let companyWebPageLink = "https://horizontalsystems.io"
     static let appWebPageLink = "https://unstoppable.money"
+
+    // Relying-party domain (WebAuthn RP ID) for passkey wallets in this app. Passed explicitly to every
+    // PasskeyManager — see Stable's AppConfig.passkeyDomain for the stable app's value.
+    static let passkeyDomain = "unstoppable.money"
     static let analyticsLink = "https://unstoppable.money/analytics"
     static let privacyPolicyLink = "https://unstoppable.money/privacy-policy"
     static let appleTermsOfServiceLink = "https://www.apple.com/legal/internet-services/itunes/dev/stdeula"

--- a/packages/WalletCore/Sources/WalletCore/Core/Managers/PasskeyManager.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Managers/PasskeyManager.swift
@@ -3,7 +3,20 @@ import Foundation
 import HdWalletKit
 
 public class PasskeyManager: NSObject {
-    private let relyingParty = "unstoppable.money"
+    // PRF salt — the credential-bound input that derives the wallet seed. MUST be identical for the
+    // registration-PRF and assertion-PRF paths, else the create-time seed wouldn't match the sign-time
+    // seed and funds derived from it would be unrecoverable.
+    private static let prfSalt = Data("wallet".utf8)
+
+    // Relying-party domain (WebAuthn RP ID) the passkey is bound to. No default — every caller passes it
+    // explicitly (from its app's AppConfig), so a forgotten domain is a compile error rather than a silent
+    // wrong-domain credential that can't assert.
+    private let domain: String
+
+    public init(domain: String) {
+        self.domain = domain
+        super.init()
+    }
 
     private var assertionContinuation: CheckedContinuation<PrfOutput, Error>?
     private var registrationContinuation: CheckedContinuation<Registration, Error>?
@@ -21,9 +34,9 @@ public class PasskeyManager: NSObject {
         try await register(name: name).credentialID
     }
 
-    func register(name: String) async throws -> Registration {
+    func register(name: String, requestPRF: Bool = false) async throws -> Registration {
         let provider = ASAuthorizationPlatformPublicKeyCredentialProvider(
-            relyingPartyIdentifier: relyingParty
+            relyingPartyIdentifier: domain
         )
 
         let request = provider.createCredentialRegistrationRequest(
@@ -32,6 +45,13 @@ public class PasskeyManager: NSObject {
             userID: Data("\(name)::\(UUID().uuidString)".utf8)
         )
 
+        // Request PRF evaluation during registration (iOS 18) with the SAME salt as assertion, so the
+        // wallet seed can come from the single create ceremony (1 Face ID). The authenticator may still
+        // return no PRF here — `registerWithPRF` then falls back to a PRF assertion on the same credential.
+        if requestPRF, #available(iOS 18.0, *) {
+            request.prf = .inputValues(.init(saltInput1: Self.prfSalt))
+        }
+
         return try await withCheckedThrowingContinuation { (c: CheckedContinuation<Registration, Error>) in
             registrationContinuation = c
             let controller = ASAuthorizationController(authorizationRequests: [request])
@@ -39,6 +59,36 @@ public class PasskeyManager: NSObject {
             controller.presentationContextProvider = self
             controller.performRequests()
         }
+    }
+
+    // One-call create ceremony for a passkey-owned wallet: returns the attestation (it embeds the
+    // credential public key for on-chain validators) AND the wallet mnemonic (from PRF), so the
+    // orchestrator gets both from a single entry point.
+    //
+    // 1 Face ID: PRF is requested during the registration ceremony, so one prompt yields both the
+    // attestation and the seed. If the authenticator declines to evaluate PRF at registration, it falls
+    // back to a PRF assertion on the SAME credential (a second Face ID) — never a second registration,
+    // so it can't strand a credential.
+    func registerWithPRF(name: String) async throws -> RegistrationWithSeed {
+        guard #available(iOS 18.0, *) else { throw PasskeyError.prfNotSupported }
+
+        let registration = try await register(name: name, requestPRF: true)
+
+        let mnemonic: [String]
+        if let prf = registration.prfOutput, !prf.isEmpty {
+            // 1 Face ID: the authenticator evaluated PRF during registration.
+            mnemonic = Mnemonic.generate(entropy: prf)
+        } else {
+            // The authenticator deferred PRF to assertion → derive the seed via a PRF assertion on the
+            // SAME credential (a second Face ID, but never a second registration → no stranded credential).
+            mnemonic = try await loginWith(credentialID: registration.credentialID).mnemonic
+        }
+
+        return RegistrationWithSeed(
+            credentialID: registration.credentialID,
+            attestationObject: registration.attestationObject,
+            mnemonic: mnemonic
+        )
     }
 
     public func loginWith(credentialID: Data) async throws -> Passkey {
@@ -55,13 +105,13 @@ public class PasskeyManager: NSObject {
         }
 
         let provider = ASAuthorizationPlatformPublicKeyCredentialProvider(
-            relyingPartyIdentifier: relyingParty
+            relyingPartyIdentifier: domain
         )
         let request = provider.createCredentialAssertionRequest(
             challenge: generateChallenge()
         )
 
-        request.prf = .inputValues(.init(saltInput1: Data("wallet".utf8)))
+        request.prf = .inputValues(.init(saltInput1: Self.prfSalt))
 
         if let credentialID {
             request.allowedCredentials = [
@@ -93,9 +143,14 @@ extension PasskeyManager: ASAuthorizationControllerDelegate {
         if let reg = authorization.credential
             as? ASAuthorizationPlatformPublicKeyCredentialRegistration
         {
-            // Keep the raw attestation (it carries the credential's public key) alongside credentialID,
-            // so a provisioner that needs the public key can read it. The attestation is opaque here.
-            registrationContinuation?.resume(returning: Registration(credentialID: reg.credentialID, attestationObject: reg.rawAttestationObject))
+            // Keep the raw attestation (it carries the credential's public key) alongside credentialID.
+            // On iOS 18, also read the PRF output if it was evaluated at registration (enables 1-Face-ID
+            // create); nil otherwise and the caller falls back to a PRF assertion.
+            var prfOutput: Data?
+            if #available(iOS 18.0, *), let prf = reg.prf, let first = prf.first {
+                prfOutput = first.withUnsafeBytes { Data($0) }
+            }
+            registrationContinuation?.resume(returning: Registration(credentialID: reg.credentialID, attestationObject: reg.rawAttestationObject, prfOutput: prfOutput))
             registrationContinuation = nil
             return
         }
@@ -176,6 +231,17 @@ extension PasskeyManager {
     struct Registration {
         let credentialID: Data
         let attestationObject: Data?
+        // PRF output evaluated AT registration (iOS 18), when requested and returned by the authenticator;
+        // nil if PRF wasn't requested or the authenticator deferred it to an assertion.
+        let prfOutput: Data?
+    }
+
+    // Result of the combined create ceremony (`registerWithPRF`): the attestation (public key) plus the
+    // wallet mnemonic derived from the credential's PRF output.
+    struct RegistrationWithSeed {
+        let credentialID: Data
+        let attestationObject: Data?
+        let mnemonic: [String]
     }
 
     private struct PrfOutput {

--- a/packages/WalletCore/Sources/WalletCore/Modules/CreateAccount/CreateAccountViewModel.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/CreateAccount/CreateAccountViewModel.swift
@@ -10,7 +10,7 @@ class CreateAccountViewModel: ObservableObject {
     private let walletManager = Core.shared.walletManager
     private let marketKit = Core.shared.marketKit
     private let predefinedBlockchainService = Core.shared.predefinedBlockchainService
-    private let passkeyManager = PasskeyManager()
+    private let passkeyManager = PasskeyManager(domain: AppConfig.passkeyDomain)
 
     let walletType: WalletType
 

--- a/packages/WalletCore/Sources/WalletCore/Modules/CreatePasskeyAccount/CreatePasskeyAccountService.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/CreatePasskeyAccount/CreatePasskeyAccountService.swift
@@ -11,8 +11,13 @@ public enum ProvisioningCredentials {
 }
 
 public protocol IAccountProvisioner {
-    // Self-selects: returns the account type for `abstract` if this provisioner handles it, else nil
-    // (chain passes to the next). Throws if it handles `abstract` but type construction fails.
+    // The relying-party domain this provisioner's passkeys are bound to. The orchestrator builds the
+    // WebAuthn ceremony with it, so each app's domain reaches the ceremony without WalletCore having to
+    // read app-specific config.
+    var domain: String { get }
+    // Self-selection by abstract type, evaluated BEFORE the ceremony (no credential exists yet).
+    func handles(abstract: AccountType.Abstract) -> Bool
+    // Builds the account type from the credential the ceremony produced. nil only if construction fails.
     func accountType(abstract: AccountType.Abstract, credentialID: Data, mnemonic: [String]) -> AccountType?
     func provision(account: Account, seed: Data, credentials: ProvisioningCredentials) throws -> [Token]
 }
@@ -27,13 +32,13 @@ public class CreatePasskeyAccountService {
     private let accountFactory: AccountFactory
     private let accountManager: AccountManager
     private let walletManager: WalletManager
-    private let passkeyManager: PasskeyManager
 
-    init(accountFactory: AccountFactory, accountManager: AccountManager, walletManager: WalletManager, passkeyManager: PasskeyManager = PasskeyManager()) {
+    // No PasskeyManager held here: the ceremony is built per request with the selected provisioner's
+    // domain (the provisioner is the only thing that knows which relying-party domain to use).
+    init(accountFactory: AccountFactory, accountManager: AccountManager, walletManager: WalletManager) {
         self.accountFactory = accountFactory
         self.accountManager = accountManager
         self.walletManager = walletManager
-        self.passkeyManager = passkeyManager
     }
 }
 
@@ -42,23 +47,30 @@ public extension CreatePasskeyAccountService {
         let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { throw CreateError.emptyName }
 
-        let registration = try await passkeyManager.register(name: trimmed)
-        // The attestation carries the credential's public key and is the provisioning payload — without
-        // it the account can't be provisioned. Fail here, before the next biometric prompt.
+        // Select the provisioner first — it carries the relying-party domain the ceremony must use.
+        let provisioner = try Self.provisioner(for: abstract)
+        let ceremony = PasskeyManager(domain: provisioner.domain)
+
+        // One ceremony yields both the attestation (credential public key) and the wallet mnemonic.
+        let registration = try await ceremony.registerWithPRF(name: trimmed)
+        // The attestation carries the public key and is the provisioning payload — without it the account
+        // can't be provisioned.
         guard let attestationObject = registration.attestationObject else {
             throw CreateError.missingAttestation
         }
-        // The PRF assertion derives the wallet seed (PRF → mnemonic → seed).
-        let passkey = try await passkeyManager.loginWith(credentialID: registration.credentialID)
-        return try provision(
-            abstract: abstract, credentialID: registration.credentialID, mnemonic: passkey.mnemonic,
+        return try finalize(
+            provisioner: provisioner, abstract: abstract,
+            credentialID: registration.credentialID, mnemonic: registration.mnemonic,
             credentials: .create(attestation: attestationObject), origin: .created,
             name: trimmed, statPage: .newWalletPasskey
         ) { .createWallet(walletType: $0) }
     }
 
     func restore(abstract: AccountType.Abstract) async throws -> Account {
-        let passkey = try await passkeyManager.login()
+        let provisioner = try Self.provisioner(for: abstract)
+        let ceremony = PasskeyManager(domain: provisioner.domain)
+
+        let passkey = try await ceremony.login()
         // Restore must not fail on a missing/odd display name — the credential's userID is outside our
         // control. Fall back to a default; wallet identity comes from the credential, not the name.
         let trimmed = passkey.name.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -66,46 +78,51 @@ public extension CreatePasskeyAccountService {
 
         // Restore reuses the provisioning path with `.restore`: the provisioner recovers the credential's
         // public key out-of-band (synchronizable keychain). `origin: .restored` keeps provenance correct.
-        return try provision(
-            abstract: abstract, credentialID: passkey.credentialID, mnemonic: passkey.mnemonic,
+        return try finalize(
+            provisioner: provisioner, abstract: abstract,
+            credentialID: passkey.credentialID, mnemonic: passkey.mnemonic,
             credentials: .restore, origin: .restored,
             name: name, statPage: .importWalletPasskey
         ) { .importWallet(walletType: $0) }
     }
 
-    private func provision(abstract: AccountType.Abstract, credentialID: Data, mnemonic: [String], credentials: ProvisioningCredentials, origin: AccountOrigin, name: String, statPage: StatPage, statEvent: (String) -> StatEvent) throws -> Account {
-        for provisioner in Self.provisioners {
-            guard let type = provisioner.accountType(abstract: abstract, credentialID: credentialID, mnemonic: mnemonic) else {
-                continue
-            }
-            guard let seed = Mnemonic.seed(mnemonic: mnemonic, passphrase: "") else {
-                throw CreateError.seedDerivationFailed
-            }
-
-            let account = accountFactory.account(type: type, origin: origin, backedUp: true, fileBackedUp: false, name: name)
-
-            // Provisioner persists its records first; if it or the save below throws the account is never
-            // saved, so the provisioner's records are orphaned (its own repair handles them).
-            let tokens = try provisioner.provision(account: account, seed: seed, credentials: credentials)
-
-            accountManager.save(account: account)
-            walletManager.save(wallets: tokens.map { Wallet(token: $0, account: account) })
-            // `lastCreatedAccount` is a create-only signal (popped once on Main) — a restored account must
-            // not be marked as the "last created" one.
-            if origin == .created {
-                accountManager.set(lastCreatedAccount: account)
-            }
-
-            stat(page: statPage, event: statEvent(account.type.statDescription))
-
-            return account
+    private func finalize(provisioner: IAccountProvisioner, abstract: AccountType.Abstract, credentialID: Data, mnemonic: [String], credentials: ProvisioningCredentials, origin: AccountOrigin, name: String, statPage: StatPage, statEvent: (String) -> StatEvent) throws -> Account {
+        guard let type = provisioner.accountType(abstract: abstract, credentialID: credentialID, mnemonic: mnemonic) else {
+            throw CreateError.noProvisioner
+        }
+        guard let seed = Mnemonic.seed(mnemonic: mnemonic, passphrase: "") else {
+            throw CreateError.seedDerivationFailed
         }
 
-        throw CreateError.noProvisioner
+        let account = accountFactory.account(type: type, origin: origin, backedUp: true, fileBackedUp: false, name: name)
+
+        // Provisioner persists its records first; if it or the save below throws the account is never
+        // saved, so the provisioner's records are orphaned (its own repair handles them).
+        let tokens = try provisioner.provision(account: account, seed: seed, credentials: credentials)
+
+        accountManager.save(account: account)
+        walletManager.save(wallets: tokens.map { Wallet(token: $0, account: account) })
+        // `lastCreatedAccount` is a create-only signal (popped once on Main) — a restored account must
+        // not be marked as the "last created" one.
+        if origin == .created {
+            accountManager.set(lastCreatedAccount: account)
+        }
+
+        stat(page: statPage, event: statEvent(account.type.statDescription))
+
+        return account
     }
 }
 
 extension CreatePasskeyAccountService {
+    // First registered provisioner that handles `abstract` (selection before any ceremony).
+    static func provisioner(for abstract: AccountType.Abstract) throws -> IAccountProvisioner {
+        guard let provisioner = provisioners.first(where: { $0.handles(abstract: abstract) }) else {
+            throw CreateError.noProvisioner
+        }
+        return provisioner
+    }
+
     enum CreateError: Error {
         case emptyName
         case noProvisioner

--- a/packages/WalletCore/Sources/WalletCore/Modules/RestoreAccount/RestoreType/RestoreTypeViewModel.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/RestoreAccount/RestoreType/RestoreTypeViewModel.swift
@@ -2,7 +2,7 @@ import Combine
 
 class RestoreTypeViewModel: ObservableObject {
     private let cloudAccountBackupManager = Core.shared.cloudBackupManager
-    private let passkeyManager = PasskeyManager()
+    private let passkeyManager = PasskeyManager(domain: AppConfig.passkeyDomain)
 
     var isCloudAvailable: Bool {
         cloudAccountBackupManager.isAvailable


### PR DESCRIPTION
- PasskeyManager(domain:) — relying-party domain injected per app, no default (every caller passes it explicitly, so a forgotten domain is a compile error). AppConfig.passkeyDomain added (unstoppable.money) for uw's own call sites.
- registerWithPRF: request PRF during the registration ceremony so create is a single Face ID; falls back to a PRF assertion on the same credential if the authenticator defers PRF (never re-registers -> no stranded credential).
- CreatePasskeyAccountService selects the provisioner by handles(abstract:) before the ceremony and builds PasskeyManager(domain: provisioner.domain); it no longer holds a default PasskeyManager.
- IAccountProvisioner: +domain +handles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Passkey setup and sign-in now use a configurable relying-party domain for improved flexibility.
  * Account creation can now complete passkey registration and wallet provisioning in a single flow.

* **Bug Fixes**
  * Improved passkey credential handling so registration and login use consistent security parameters.
  * Restoring an account now uses the same domain-aware passkey flow as creation.

* **Refactor**
  * Streamlined account provisioning by selecting the correct provider earlier and simplifying the final setup steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->