### PR TITLE
Make AppEnvironment config public

### DIFF
--- a/packages/WalletCore/Sources/WalletCore/Core/AppConfig.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/AppConfig.swift
@@ -70,8 +70,8 @@ enum AppConfig {
         AppEnvironment.config.showBuildNumber
     }
 
-    static var showTestSwitchers: Bool {
-        AppEnvironment.config.showTestSwitchers
+    static var showDevTools: Bool {
+        AppEnvironment.config.showDevTools
     }
 
     static var marketApiUrl: String {

--- a/packages/WalletCore/Sources/WalletCore/Core/AppEnvironment.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/AppEnvironment.swift
@@ -16,20 +16,20 @@ public enum AppEnvironment: String {
     }
 }
 
-extension AppEnvironment {
+public extension AppEnvironment {
     struct Config {
-        let marketApiUrl: String
-        let swapApiUrl: String
-        let referralAppServerUrl: String
-        let showBuildNumber: Bool
-        let showTestSwitchers: Bool
+        public let marketApiUrl: String
+        public let swapApiUrl: String
+        public let referralAppServerUrl: String
+        public let showBuildNumber: Bool
+        public let showDevTools: Bool
 
         static let dev = Config(
             marketApiUrl: "https://api-dev.blocksdecoded.com",
             swapApiUrl: "https://swap-dev.unstoppable.money/api",
             referralAppServerUrl: "https://dev-be.unstoppable.money/api",
             showBuildNumber: true,
-            showTestSwitchers: true
+            showDevTools: true
         )
 
         static let prod = Config(
@@ -37,7 +37,7 @@ extension AppEnvironment {
             swapApiUrl: "https://swap-api.unstoppable.money",
             referralAppServerUrl: "https://be.unstoppable.money/api",
             showBuildNumber: false,
-            showTestSwitchers: false
+            showDevTools: false
         )
     }
 }

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/MultiSwapQuotesView.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/MultiSwapQuotesView.swift
@@ -9,7 +9,7 @@ struct MultiSwapQuotesView: View {
             ThemeView(style: .list) {
                 ThemeList {
                     Section {
-                        let isDebug = AppConfig.showTestSwitchers
+                        let isDebug = AppConfig.showDevTools
 
                         ForEach(viewModel.sortedQuotes, id: \.provider.id) { (quote: MultiSwapViewModel.Quote) in
                             VStack(spacing: 0) {

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/USwap/USwapMultiSwapProvider.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/USwap/USwapMultiSwapProvider.swift
@@ -1163,7 +1163,7 @@ extension USwapMultiSwapProvider {
 
     static func track(swap: Swap, parameters: Parameters, networkManager: NetworkManager, isEvm: Bool = false) async throws -> Swap {
         var parameters = parameters
-        if AppConfig.showTestSwitchers, Core.shared.localStorage.simulateFailSwap == .server {
+        if AppConfig.showDevTools, Core.shared.localStorage.simulateFailSwap == .server {
             parameters["testActionRequired"] = true
         }
 

--- a/packages/WalletCore/Sources/WalletCore/Modules/Settings/Main/MainSettingsView.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/Settings/Main/MainSettingsView.swift
@@ -90,7 +90,7 @@ struct MainSettingsView: View {
 
                     footer()
 
-                    if viewModel.showTestSwitchers {
+                    if viewModel.showDevTools {
                         Spacer().frame(height: .margin32)
                         testSwitchersSection()
                     }

--- a/packages/WalletCore/Sources/WalletCore/Modules/Settings/Main/MainSettingsViewModel.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/Settings/Main/MainSettingsViewModel.swift
@@ -33,7 +33,7 @@ class MainSettingsViewModel: ObservableObject {
 
     @Published var debu: String?
 
-    let showTestSwitchers: Bool
+    let showDevTools: Bool
 
     @Published var forceEnableSwap: Bool {
         didSet {
@@ -75,7 +75,7 @@ class MainSettingsViewModel: ObservableObject {
     }
 
     init() {
-        showTestSwitchers = AppConfig.showTestSwitchers
+        showDevTools = AppConfig.showDevTools
         forceEnableSwap = localStorage.forceEnableSwap
         simulateFailSwap = localStorage.simulateFailSwap
         emulatePurchase = localStorage.emulatePurchase

--- a/packages/WalletCore/Sources/WalletCore/Modules/SwapHistory/SwapHistoryViewModel.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/SwapHistory/SwapHistoryViewModel.swift
@@ -221,7 +221,7 @@ extension SwapHistoryViewModel {
     }
 
     func correctedSwap(_ swap: Swap) -> Swap {
-        guard AppConfig.showTestSwitchers, Core.shared.localStorage.simulateFailSwap == .local else {
+        guard AppConfig.showDevTools, Core.shared.localStorage.simulateFailSwap == .local else {
             return swap
         }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Renamed the app’s testing controls to **Developer Tools** across the UI and configuration.
  * Developer-tool visibility now follows the updated app environment setting.

* **Bug Fixes**
  * Updated swap-related debug and retry behavior to use the new Developer Tools flag consistently.
  * Settings screens now correctly show the developer/testing section based on the new toggle name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->