### PR TITLE
Use down rounding for percent balance in pre send view

### DIFF
--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/USwap/USwapMultiSwapProvider.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/USwap/USwapMultiSwapProvider.swift
@@ -736,7 +736,7 @@ class USwapMultiSwapProvider: IMultiSwapProvider {
             }
         }
 
-        return EvmSwapFinalQuote(
+        return try EvmSwapFinalQuote(
             expectedBuyAmount: quote.expectedBuyAmount,
             transactionData: transactionData,
             transactionError: transactionError,
@@ -746,7 +746,7 @@ class USwapMultiSwapProvider: IMultiSwapProvider {
             gasPrice: gasPriceData?.userDefined,
             evmFeeData: evmFeeData,
             nonce: transactionSettings?.nonce,
-            toAddress: try deliveryAddress(quote: quote, recipient: recipient),
+            toAddress: deliveryAddress(quote: quote, recipient: recipient),
             depositAddress: quote.execution?.depositAddress,
             providerSwapId: quote.uuid
         )
@@ -793,7 +793,7 @@ class USwapMultiSwapProvider: IMultiSwapProvider {
             }
         }
 
-        return UtxoSwapFinalQuote(
+        return try UtxoSwapFinalQuote(
             expectedBuyAmount: quote.expectedBuyAmount,
             sendParameters: params,
             slippage: slippage,
@@ -801,7 +801,7 @@ class USwapMultiSwapProvider: IMultiSwapProvider {
             estimatedTime: quote.esimatedTime,
             transactionError: transactionError,
             fee: sendInfo?.fee,
-            toAddress: try deliveryAddress(quote: quote, recipient: recipient),
+            toAddress: deliveryAddress(quote: quote, recipient: recipient),
             depositAddress: deposit.address,
             providerSwapId: quote.uuid
         )
@@ -844,7 +844,7 @@ class USwapMultiSwapProvider: IMultiSwapProvider {
             transactionError = error
         }
 
-        return ZcashSwapFinalQuote(
+        return try ZcashSwapFinalQuote(
             expectedBuyAmount: amountOut,
             proposal: proposal,
             slippage: slippage,
@@ -852,7 +852,7 @@ class USwapMultiSwapProvider: IMultiSwapProvider {
             estimatedTime: quote.esimatedTime,
             transactionError: transactionError,
             fee: totalFeeRequired?.decimalValue.decimalValue,
-            toAddress: try deliveryAddress(quote: quote, recipient: recipient),
+            toAddress: deliveryAddress(quote: quote, recipient: recipient),
             depositAddress: quote.execution?.depositAddress,
             providerSwapId: quote.uuid
         )
@@ -911,7 +911,7 @@ class USwapMultiSwapProvider: IMultiSwapProvider {
             transactionError = error
         }
 
-        return TonSwapFinalQuote(
+        return try TonSwapFinalQuote(
             amountIn: amountIn,
             expectedAmountOut: amountOut,
             recipient: recipient,
@@ -920,7 +920,7 @@ class USwapMultiSwapProvider: IMultiSwapProvider {
             transactionParam: transactionParam,
             fee: fee,
             transactionError: transactionError,
-            toAddress: try deliveryAddress(quote: quote, recipient: recipient),
+            toAddress: deliveryAddress(quote: quote, recipient: recipient),
             depositAddress: quote.execution?.depositAddress,
             providerSwapId: quote.uuid
         )
@@ -969,7 +969,7 @@ class USwapMultiSwapProvider: IMultiSwapProvider {
             transactionError = error
         }
 
-        return StellarSwapFinalQuote(
+        return try StellarSwapFinalQuote(
             amountIn: amountIn,
             expectedAmountOut: amountOut,
             recipient: recipient,
@@ -979,7 +979,7 @@ class USwapMultiSwapProvider: IMultiSwapProvider {
             token: tokenIn,
             fee: fee,
             transactionError: transactionError,
-            toAddress: try deliveryAddress(quote: quote, recipient: recipient),
+            toAddress: deliveryAddress(quote: quote, recipient: recipient),
             depositAddress: quote.execution?.depositAddress,
             providerSwapId: quote.uuid
         )
@@ -1022,7 +1022,7 @@ class USwapMultiSwapProvider: IMultiSwapProvider {
             }
         }
 
-        return TronSwapFinalQuote(
+        return try TronSwapFinalQuote(
             amountIn: amountIn,
             expectedAmountOut: amountOut,
             recipient: recipient,
@@ -1031,7 +1031,7 @@ class USwapMultiSwapProvider: IMultiSwapProvider {
             createdTransaction: transaction,
             fees: fees,
             transactionError: transactionError,
-            toAddress: try deliveryAddress(quote: quote, recipient: recipient),
+            toAddress: deliveryAddress(quote: quote, recipient: recipient),
             depositAddress: quote.execution?.depositAddress,
             providerSwapId: quote.uuid
         )
@@ -1074,7 +1074,7 @@ class USwapMultiSwapProvider: IMultiSwapProvider {
             transactionError = error
         }
 
-        return MoneroSwapFinalQuote(
+        return try MoneroSwapFinalQuote(
             amountIn: amountIn,
             expectedAmountOut: amountOut,
             recipient: recipient,
@@ -1087,7 +1087,7 @@ class USwapMultiSwapProvider: IMultiSwapProvider {
             priority: priority,
             fee: fee,
             transactionError: transactionError,
-            toAddress: try deliveryAddress(quote: quote, recipient: recipient),
+            toAddress: deliveryAddress(quote: quote, recipient: recipient),
             depositAddress: quote.execution?.depositAddress,
             providerSwapId: quote.uuid
         )
@@ -1136,7 +1136,7 @@ class USwapMultiSwapProvider: IMultiSwapProvider {
             transactionError = error
         }
 
-        return ZanoSwapFinalQuote(
+        return try ZanoSwapFinalQuote(
             expectedAmountOut: amountOut,
             recipient: recipient,
             slippage: slippage,
@@ -1146,7 +1146,7 @@ class USwapMultiSwapProvider: IMultiSwapProvider {
             memo: deposit.memo,
             fee: fee,
             transactionError: transactionError,
-            toAddress: try deliveryAddress(quote: quote, recipient: recipient),
+            toAddress: deliveryAddress(quote: quote, recipient: recipient),
             depositAddress: quote.execution?.depositAddress,
             providerSwapId: quote.uuid
         )
@@ -1188,7 +1188,7 @@ class USwapMultiSwapProvider: IMultiSwapProvider {
             transactionError = error
         }
 
-        return SolanaSwapFinalQuote(
+        return try SolanaSwapFinalQuote(
             rawTransaction: rawTransaction,
             expectedAmountOut: amountOut,
             recipient: recipient,
@@ -1196,7 +1196,7 @@ class USwapMultiSwapProvider: IMultiSwapProvider {
             estimatedTime: quote.esimatedTime,
             fee: fee,
             transactionError: transactionError,
-            toAddress: try deliveryAddress(quote: quote, recipient: recipient),
+            toAddress: deliveryAddress(quote: quote, recipient: recipient),
             depositAddress: quote.execution?.depositAddress,
             providerSwapId: quote.uuid
         )

--- a/packages/WalletCore/Sources/WalletCore/Modules/SendNew/PreSendViewModel.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/SendNew/PreSendViewModel.swift
@@ -234,7 +234,7 @@ public extension PreSendViewModel {
 
         enteringFiat = false
 
-        amount = (availableBalance * Decimal(percent) / 100).rounded(decimal: customDecimals ?? token.decimals)
+        amount = (availableBalance * Decimal(percent) / 100).roundedDown(decimal: customDecimals ?? token.decimals)
     }
 
     func clearAmountIn() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved swap quote confirmation handling across multiple networks to make final quote creation more reliable.
  * Fixed percentage-based send amount calculation to round down consistently, avoiding amounts that could exceed the available balance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->