### PR TITLE
Feature/swap broadcaster

### DIFF
--- a/Unstoppable/Tests/Modules/MultiSwap/AllowancePolicyTests.swift
+++ b/Unstoppable/Tests/Modules/MultiSwap/AllowancePolicyTests.swift
@@ -1,0 +1,53 @@
+import Foundation
+import MarketKit
+import Testing
+@testable import Unstoppable
+@testable import WalletCore
+
+@Suite(.serialized)
+struct AllowancePolicyTests {
+    private static let token = Token(
+        coin: Coin(uid: "test-coin", name: "Test", code: "TST"),
+        blockchain: Blockchain(type: .ethereum, name: "Test", explorerUrl: nil),
+        type: .native,
+        decimals: 8
+    )
+
+    init() {
+        AllowancePolicy.reset()
+    }
+
+    @Test func emptyRegistryReturnsNil() async {
+        let state = await AllowancePolicy.state(spenderAddress: Address(raw: "spender"), token: Self.token, amount: 1)
+
+        #expect(state == nil)
+    }
+
+    @Test func prependedPolicyWins() async {
+        AllowancePolicy.prepend(NotRequiredPolicy.self)
+
+        let state = await AllowancePolicy.state(spenderAddress: Address(raw: "spender"), token: Self.token, amount: 1)
+
+        #expect(state == .notRequired)
+    }
+
+    @Test func decliningPolicyFallsThrough() async {
+        AllowancePolicy.prepend(DecliningPolicy.self)
+
+        let state = await AllowancePolicy.state(spenderAddress: Address(raw: "spender"), token: Self.token, amount: 1)
+
+        #expect(state == nil)
+    }
+}
+
+private enum NotRequiredPolicy: IAllowancePolicy {
+    static func allowanceState(spenderAddress _: Address, token _: Token, amount _: Decimal) async -> AllowancePolicyState? {
+        .notRequired
+    }
+}
+
+private enum DecliningPolicy: IAllowancePolicy {
+    static func allowanceState(spenderAddress _: Address, token _: Token, amount _: Decimal) async -> AllowancePolicyState? {
+        nil
+    }
+}

--- a/Unstoppable/Tests/Modules/MultiSwap/ApprovalResetTests.swift
+++ b/Unstoppable/Tests/Modules/MultiSwap/ApprovalResetTests.swift
@@ -1,0 +1,48 @@
+import Foundation
+import MarketKit
+import Testing
+@testable import Unstoppable
+@testable import WalletCore
+
+// requiresApprovalReset: canonical USDT (ETH/Tron) reverts on non-zero -> non-zero approve;
+// other eip20 tokens and native coins don't. Shared by EOA pre-swap and the AA swap broadcaster.
+struct ApprovalResetTests {
+    private static func eip20(_ address: String, blockchainType: BlockchainType) -> Token {
+        Token(
+            coin: Coin(uid: "c", name: "C", code: "C"),
+            blockchain: Blockchain(type: blockchainType, name: "B", explorerUrl: nil),
+            type: .eip20(address: address),
+            decimals: 6
+        )
+    }
+
+    @Test func ethereumUsdtRequiresReset() {
+        let usdt = Self.eip20("0xdac17f958d2ee523a2206206994597c13d831ec7", blockchainType: .ethereum)
+        #expect(ApprovalReset.required(token: usdt))
+    }
+
+    @Test func ethereumUsdtMatchIsCaseInsensitive() {
+        let usdt = Self.eip20("0xDAC17F958D2EE523A2206206994597C13D831EC7", blockchainType: .ethereum)
+        #expect(ApprovalReset.required(token: usdt))
+    }
+
+    @Test func bscStablecoinDoesNotRequireReset() {
+        let bscUsd = Self.eip20("0x55d398326f99059ff775485246999027b3197955", blockchainType: .binanceSmartChain)
+        #expect(!ApprovalReset.required(token: bscUsd))
+    }
+
+    @Test func otherEthereumTokenDoesNotRequireReset() {
+        let usdc = Self.eip20("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", blockchainType: .ethereum)
+        #expect(!ApprovalReset.required(token: usdc))
+    }
+
+    @Test func nativeCoinDoesNotRequireReset() {
+        let native = Token(
+            coin: Coin(uid: "eth", name: "Ethereum", code: "ETH"),
+            blockchain: Blockchain(type: .ethereum, name: "Ethereum", explorerUrl: nil),
+            type: .native,
+            decimals: 18
+        )
+        #expect(!ApprovalReset.required(token: native))
+    }
+}

--- a/Unstoppable/Tests/Modules/MultiSwap/ApprovalResetTests.swift
+++ b/Unstoppable/Tests/Modules/MultiSwap/ApprovalResetTests.swift
@@ -5,7 +5,7 @@ import Testing
 @testable import WalletCore
 
 // requiresApprovalReset: canonical USDT (ETH/Tron) reverts on non-zero -> non-zero approve;
-// other eip20 tokens and native coins don't. Shared by EOA pre-swap and the AA swap broadcaster.
+// other eip20 tokens and native coins don't. Shared by swap flows that build approvals.
 struct ApprovalResetTests {
     private static func eip20(_ address: String, blockchainType: BlockchainType) -> Token {
         Token(

--- a/Unstoppable/Tests/Modules/MultiSwap/SwapBroadcasterFactoryTests.swift
+++ b/Unstoppable/Tests/Modules/MultiSwap/SwapBroadcasterFactoryTests.swift
@@ -1,0 +1,101 @@
+import Foundation
+import MarketKit
+import Testing
+@testable import Unstoppable
+@testable import WalletCore
+
+@Suite(.serialized)
+struct SwapBroadcasterFactoryTests {
+    private static let account = Account(
+        id: "test", level: 0, name: "Test",
+        type: .mnemonic(words: [], salt: "", bip39Compliant: true),
+        origin: .created, backedUp: true, fileBackedUp: false
+    )
+
+    init() {
+        SwapBroadcasterFactory.reset()
+    }
+
+    @Test func resolvesRegisteredType() throws {
+        SwapBroadcasterFactory.register([MatchingType.self])
+
+        let broadcaster = try SwapBroadcasterFactory.broadcaster(blockchainType: .ethereum, account: Self.account)
+
+        let stub = try #require(broadcaster as? StubBroadcaster)
+        #expect(stub.id == "matching")
+    }
+
+    @Test func prependWinsOverRegistered() throws {
+        SwapBroadcasterFactory.register([MatchingType.self])
+        SwapBroadcasterFactory.prepend(PrependedType.self)
+
+        let broadcaster = try SwapBroadcasterFactory.broadcaster(blockchainType: .ethereum, account: Self.account)
+
+        let stub = try #require(broadcaster as? StubBroadcaster)
+        #expect(stub.id == "prepended")
+    }
+
+    @Test func emptyRegistryThrowsNoBroadcaster() {
+        #expect(throws: SwapBroadcasterError.noBroadcaster) {
+            _ = try SwapBroadcasterFactory.broadcaster(blockchainType: .ethereum, account: Self.account)
+        }
+    }
+
+    // fail-closed: a type that declines must never fall through to raw sending
+    @Test func nothingResolvesThrowsNoBroadcaster() {
+        SwapBroadcasterFactory.register([DecliningType.self])
+
+        #expect(throws: SwapBroadcasterError.noBroadcaster) {
+            _ = try SwapBroadcasterFactory.broadcaster(blockchainType: .ethereum, account: Self.account)
+        }
+    }
+
+    @Test func decliningTypeIsSkipped() throws {
+        SwapBroadcasterFactory.register([DecliningType.self, MatchingType.self])
+
+        let broadcaster = try SwapBroadcasterFactory.broadcaster(blockchainType: .ethereum, account: Self.account)
+
+        let stub = try #require(broadcaster as? StubBroadcaster)
+        #expect(stub.id == "matching")
+    }
+
+    // downstream apps extend SwapBroadcasterError without touching WalletCore
+    @Test func errorIsExtensible() {
+        #expect(SwapBroadcasterError.stubExternal == SwapBroadcasterError(rawValue: "stubExternal"))
+        #expect(SwapBroadcasterError.stubExternal != .noBroadcaster)
+    }
+}
+
+private extension SwapBroadcasterError {
+    static var stubExternal: Self { .init(rawValue: "stubExternal") }
+}
+
+private struct StubBroadcaster: ISwapBroadcaster {
+    let id: String
+
+    func prepare(_ executable: ISwapExecutable) async throws -> IPrepared {
+        EoaPrepared(executable: executable)
+    }
+
+    func submit(_: IPrepared) async throws -> BroadcastResult {
+        BroadcastResult(onChainTxHash: nil, trackingHandle: nil)
+    }
+}
+
+private enum MatchingType: ISwapBroadcasterType {
+    static func make(blockchainType _: BlockchainType, account _: Account) -> ISwapBroadcaster? {
+        StubBroadcaster(id: "matching")
+    }
+}
+
+private enum PrependedType: ISwapBroadcasterType {
+    static func make(blockchainType _: BlockchainType, account _: Account) -> ISwapBroadcaster? {
+        StubBroadcaster(id: "prepended")
+    }
+}
+
+private enum DecliningType: ISwapBroadcasterType {
+    static func make(blockchainType _: BlockchainType, account _: Account) -> ISwapBroadcaster? {
+        nil
+    }
+}

--- a/Unstoppable/Tests/Modules/MultiSwap/SwapBroadcasterFactoryTests.swift
+++ b/Unstoppable/Tests/Modules/MultiSwap/SwapBroadcasterFactoryTests.swift
@@ -74,11 +74,11 @@ private struct StubBroadcaster: ISwapBroadcaster {
     let id: String
 
     func prepare(_ executable: ISwapExecutable) async throws -> IPrepared {
-        EoaPrepared(executable: executable)
+        DirectPrepared(executable: executable)
     }
 
     func submit(_: IPrepared) async throws -> BroadcastResult {
-        BroadcastResult(onChainTxHash: nil, trackingHandle: nil)
+        BroadcastResult(txHash: nil, trackingHandle: nil)
     }
 }
 

--- a/Unstoppable/Tests/Modules/MultiSwap/SwapExecutableTests.swift
+++ b/Unstoppable/Tests/Modules/MultiSwap/SwapExecutableTests.swift
@@ -41,8 +41,10 @@ struct SwapExecutableTests {
             toAddress: "to"
         )
 
-        let executable = try #require(quote.executable(tokenIn: Self.token()) as? EvmExecutable)
+        let token = Self.token()
+        let executable = try #require(quote.executable(tokenIn: token) as? EvmExecutable)
 
+        #expect(executable.token == token)
         #expect(executable.transactionData == transactionData)
         #expect(executable.gasPrice == gasPrice)
         #expect(executable.gasLimit == 110_000) // surchargedGasLimit, not gasLimit

--- a/Unstoppable/Tests/Modules/MultiSwap/SwapExecutableTests.swift
+++ b/Unstoppable/Tests/Modules/MultiSwap/SwapExecutableTests.swift
@@ -10,7 +10,7 @@ import TronKit
 @testable import Unstoppable
 @testable import WalletCore
 
-// build-argument equivalence oracle: executable(tokenIn:privateSend:) must repackage
+// build-argument equivalence oracle: executable(tokenIn:) must repackage
 // exactly the fields MultiSwapSendHandler.send reads from each quote today
 struct SwapExecutableTests {
     private static func token(blockchainType: BlockchainType = .ethereum) -> Token {
@@ -37,20 +37,21 @@ struct SwapExecutableTests {
             gasPrice: gasPrice,
             evmFeeData: EvmFeeData(gasLimit: 100_000, surchargedGasLimit: 110_000),
             nonce: 7,
+            mevProtectionAllowed: true,
             toAddress: "to"
         )
 
-        let executable = try #require(quote.executable(tokenIn: Self.token(), privateSend: true) as? EvmExecutable)
+        let executable = try #require(quote.executable(tokenIn: Self.token()) as? EvmExecutable)
 
         #expect(executable.transactionData == transactionData)
         #expect(executable.gasPrice == gasPrice)
         #expect(executable.gasLimit == 110_000) // surchargedGasLimit, not gasLimit
         #expect(executable.nonce == 7)
-        #expect(executable.privateSend == true)
+        #expect(executable.mevProtectionAllowed == true)
         #expect(executable.approval == nil)
     }
 
-    @Test func evmQuotePreservesNilOptionalsAndPrivateSendOff() throws {
+    @Test func evmQuotePreservesNilOptionalsAndMevDefaultOff() throws {
         let quote = EvmSwapFinalQuote(
             expectedBuyAmount: 1,
             transactionData: nil,
@@ -62,13 +63,13 @@ struct SwapExecutableTests {
             toAddress: "to"
         )
 
-        let executable = try #require(quote.executable(tokenIn: Self.token(), privateSend: false) as? EvmExecutable)
+        let executable = try #require(quote.executable(tokenIn: Self.token()) as? EvmExecutable)
 
         #expect(executable.transactionData == nil)
         #expect(executable.gasPrice == nil)
         #expect(executable.gasLimit == nil)
         #expect(executable.nonce == nil)
-        #expect(executable.privateSend == false)
+        #expect(executable.mevProtectionAllowed == false)
     }
 
     @Test func utxoQuoteCarriesTokenAndSendParameters() throws {
@@ -84,7 +85,7 @@ struct SwapExecutableTests {
         )
         let token = Self.token(blockchainType: .bitcoin)
 
-        let executable = try #require(quote.executable(tokenIn: token, privateSend: false) as? UtxoExecutable)
+        let executable = try #require(quote.executable(tokenIn: token) as? UtxoExecutable)
 
         #expect(executable.token == token)
         #expect(executable.sendParameters === sendParameters)
@@ -103,7 +104,7 @@ struct SwapExecutableTests {
         )
         let token = Self.token(blockchainType: .zcash)
 
-        let executable = try #require(quote.executable(tokenIn: token, privateSend: false) as? ZcashExecutable)
+        let executable = try #require(quote.executable(tokenIn: token) as? ZcashExecutable)
 
         #expect(executable.token == token)
         #expect(executable.proposal == nil)
@@ -125,7 +126,7 @@ struct SwapExecutableTests {
             toAddress: "to"
         )
 
-        let executable = try #require(quote.executable(tokenIn: Self.token(blockchainType: .ton), privateSend: false) as? TonExecutable)
+        let executable = try #require(quote.executable(tokenIn: Self.token(blockchainType: .ton)) as? TonExecutable)
 
         #expect(executable.transactionParam.validUntil == 123)
         #expect(executable.transactionParam.messages.isEmpty)
@@ -155,7 +156,7 @@ struct SwapExecutableTests {
             toAddress: "to"
         )
 
-        let executable = try #require(quote.executable(tokenIn: Self.token(blockchainType: .tron), privateSend: false) as? TronExecutable)
+        let executable = try #require(quote.executable(tokenIn: Self.token(blockchainType: .tron)) as? TronExecutable)
 
         #expect(executable.created.txID == created.txID)
         #expect(executable.created.rawDataHex == created.rawDataHex)
@@ -183,7 +184,7 @@ struct SwapExecutableTests {
             toAddress: "to"
         )
 
-        let executable = try #require(quote.executable(tokenIn: tokenIn, privateSend: false) as? StellarExecutable)
+        let executable = try #require(quote.executable(tokenIn: tokenIn) as? StellarExecutable)
 
         #expect(executable.token == tokenIn)
         guard case let .envelope(envelope) = executable.transactionData else {
@@ -210,7 +211,7 @@ struct SwapExecutableTests {
         )
         let token = Self.token(blockchainType: .monero)
 
-        let executable = try #require(quote.executable(tokenIn: token, privateSend: false) as? MoneroExecutable)
+        let executable = try #require(quote.executable(tokenIn: token) as? MoneroExecutable)
 
         #expect(executable.token == token)
         #expect(executable.address == "monero-addr")
@@ -233,7 +234,7 @@ struct SwapExecutableTests {
         )
         let token = Self.token(blockchainType: .zano)
 
-        let executable = try #require(quote.executable(tokenIn: token, privateSend: false) as? ZanoExecutable)
+        let executable = try #require(quote.executable(tokenIn: token) as? ZanoExecutable)
 
         #expect(executable.token == token)
         #expect(executable.address == "zano-addr")
@@ -256,7 +257,7 @@ struct SwapExecutableTests {
         )
         let token = Self.token(blockchainType: .solana)
 
-        let executable = try #require(quote.executable(tokenIn: token, privateSend: false) as? SolanaExecutable)
+        let executable = try #require(quote.executable(tokenIn: token) as? SolanaExecutable)
 
         #expect(executable.token == token)
         #expect(executable.rawTransaction == rawTransaction)
@@ -271,7 +272,7 @@ struct SwapExecutableTests {
             toAddress: "to"
         )
 
-        let executable = quote.executable(tokenIn: Self.token(), privateSend: false)
+        let executable = quote.executable(tokenIn: Self.token())
 
         #expect(executable is UnsupportedExecutable)
     }

--- a/Unstoppable/Tests/Modules/MultiSwap/SwapExecutableTests.swift
+++ b/Unstoppable/Tests/Modules/MultiSwap/SwapExecutableTests.swift
@@ -72,6 +72,31 @@ struct SwapExecutableTests {
         #expect(executable.mevProtectionAllowed == false)
     }
 
+    @Test func evmQuoteCarriesApprovalIntent() throws {
+        let approval = try SwapApproval(
+            spender: EvmKit.Address(hex: "0x1111111111111111111111111111111111111111"),
+            token: EvmKit.Address(hex: "0x2222222222222222222222222222222222222222"),
+            amount: BigUInt(500)
+        )
+        let quote = EvmSwapFinalQuote(
+            expectedBuyAmount: 1,
+            transactionData: nil,
+            slippage: nil,
+            recipient: nil,
+            gasPrice: nil,
+            evmFeeData: nil,
+            nonce: nil,
+            approval: approval,
+            toAddress: "to"
+        )
+
+        let executable = try #require(quote.executable(tokenIn: Self.token()) as? EvmExecutable)
+
+        #expect(executable.approval?.spender == approval.spender)
+        #expect(executable.approval?.token == approval.token)
+        #expect(executable.approval?.amount == approval.amount)
+    }
+
     @Test func utxoQuoteCarriesTokenAndSendParameters() throws {
         let sendParameters = SendParameters(address: "addr", value: 1000, feeRate: 10, memo: "m")
         let quote = UtxoSwapFinalQuote(
@@ -161,6 +186,43 @@ struct SwapExecutableTests {
         #expect(executable.created.txID == created.txID)
         #expect(executable.created.rawDataHex == created.rawDataHex)
         #expect(executable.transferIntent == nil)
+    }
+
+    @Test func tronQuoteCarriesTransferIntent() throws {
+        let created = try Mapper<CreatedTransactionResponse>().map(JSON: [
+            "visible": false,
+            "txID": "aabbcc",
+            "raw_data": [
+                "ref_block_bytes": "0000",
+                "ref_block_hash": "1122",
+                "expiration": 1,
+                "fee_limit": 1000,
+                "timestamp": 2,
+            ],
+            "raw_data_hex": "deadbeef",
+        ])
+        let intent = try TronTransferIntent(
+            token: TronKit.Address(address: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t"),
+            receiver: TronKit.Address(address: "TN3W4H6rK2ce4vX9YnFQHwKENnHjoxb3m9"),
+            value: BigUInt(1000)
+        )
+        let quote = TronSwapFinalQuote(
+            amountIn: 1,
+            expectedAmountOut: 2,
+            recipient: nil,
+            slippage: nil,
+            createdTransaction: created,
+            transferIntent: intent,
+            fees: [],
+            transactionError: nil,
+            toAddress: "to"
+        )
+
+        let executable = try #require(quote.executable(tokenIn: Self.token(blockchainType: .tron)) as? TronExecutable)
+
+        #expect(executable.transferIntent?.token == intent.token)
+        #expect(executable.transferIntent?.receiver == intent.receiver)
+        #expect(executable.transferIntent?.value == intent.value)
     }
 
     @Test func stellarQuoteCarriesTokenInAndTransactionData() throws {

--- a/Unstoppable/Tests/Modules/MultiSwap/SwapExecutableTests.swift
+++ b/Unstoppable/Tests/Modules/MultiSwap/SwapExecutableTests.swift
@@ -1,0 +1,278 @@
+import BigInt
+import BitcoinCore
+import EvmKit
+import Foundation
+import MarketKit
+import MoneroKit
+import ObjectMapper
+import Testing
+import TronKit
+@testable import Unstoppable
+@testable import WalletCore
+
+// build-argument equivalence oracle: executable(tokenIn:privateSend:) must repackage
+// exactly the fields MultiSwapSendHandler.send reads from each quote today
+struct SwapExecutableTests {
+    private static func token(blockchainType: BlockchainType = .ethereum) -> Token {
+        Token(
+            coin: Coin(uid: "test-coin", name: "Test", code: "TST"),
+            blockchain: Blockchain(type: blockchainType, name: "Test", explorerUrl: nil),
+            type: .native,
+            decimals: 8
+        )
+    }
+
+    @Test func evmQuoteMapsAllSendArguments() throws {
+        let transactionData = try TransactionData(
+            to: EvmKit.Address(hex: "0x1234567890123456789012345678901234567890"),
+            value: BigUInt(100),
+            input: Data([0x01, 0x02])
+        )
+        let gasPrice = GasPrice.legacy(gasPrice: 1_000_000_000)
+        let quote = EvmSwapFinalQuote(
+            expectedBuyAmount: 1,
+            transactionData: transactionData,
+            slippage: nil,
+            recipient: nil,
+            gasPrice: gasPrice,
+            evmFeeData: EvmFeeData(gasLimit: 100_000, surchargedGasLimit: 110_000),
+            nonce: 7,
+            toAddress: "to"
+        )
+
+        let executable = try #require(quote.executable(tokenIn: Self.token(), privateSend: true) as? EvmExecutable)
+
+        #expect(executable.transactionData == transactionData)
+        #expect(executable.gasPrice == gasPrice)
+        #expect(executable.gasLimit == 110_000) // surchargedGasLimit, not gasLimit
+        #expect(executable.nonce == 7)
+        #expect(executable.privateSend == true)
+        #expect(executable.approval == nil)
+    }
+
+    @Test func evmQuotePreservesNilOptionalsAndPrivateSendOff() throws {
+        let quote = EvmSwapFinalQuote(
+            expectedBuyAmount: 1,
+            transactionData: nil,
+            slippage: nil,
+            recipient: nil,
+            gasPrice: nil,
+            evmFeeData: nil,
+            nonce: nil,
+            toAddress: "to"
+        )
+
+        let executable = try #require(quote.executable(tokenIn: Self.token(), privateSend: false) as? EvmExecutable)
+
+        #expect(executable.transactionData == nil)
+        #expect(executable.gasPrice == nil)
+        #expect(executable.gasLimit == nil)
+        #expect(executable.nonce == nil)
+        #expect(executable.privateSend == false)
+    }
+
+    @Test func utxoQuoteCarriesTokenAndSendParameters() throws {
+        let sendParameters = SendParameters(address: "addr", value: 1000, feeRate: 10, memo: "m")
+        let quote = UtxoSwapFinalQuote(
+            expectedBuyAmount: 1,
+            sendParameters: sendParameters,
+            slippage: 1,
+            recipient: nil,
+            transactionError: nil,
+            fee: 0.1,
+            toAddress: "to"
+        )
+        let token = Self.token(blockchainType: .bitcoin)
+
+        let executable = try #require(quote.executable(tokenIn: token, privateSend: false) as? UtxoExecutable)
+
+        #expect(executable.token == token)
+        #expect(executable.sendParameters === sendParameters)
+    }
+
+    @Test func zcashQuoteCarriesTokenAndProposal() throws {
+        // Proposal wraps an FFI type and is not constructible in tests; nil verifies the pass-through shape
+        let quote = ZcashSwapFinalQuote(
+            expectedBuyAmount: 1,
+            proposal: nil,
+            slippage: 1,
+            recipient: nil,
+            transactionError: nil,
+            fee: 0.001,
+            toAddress: "to"
+        )
+        let token = Self.token(blockchainType: .zcash)
+
+        let executable = try #require(quote.executable(tokenIn: token, privateSend: false) as? ZcashExecutable)
+
+        #expect(executable.token == token)
+        #expect(executable.proposal == nil)
+    }
+
+    @Test func tonQuoteCarriesTransactionParam() throws {
+        let json = """
+        {"messages": [], "valid_until": 123, "from": "0:0000000000000000000000000000000000000000000000000000000000000000", "network": "-239"}
+        """
+        let param = try JSONDecoder().decode(SendTransactionParam.self, from: Data(json.utf8))
+        let quote = TonSwapFinalQuote(
+            amountIn: 1,
+            expectedAmountOut: 2,
+            recipient: nil,
+            slippage: 1,
+            transactionParam: param,
+            fee: 0.01,
+            transactionError: nil,
+            toAddress: "to"
+        )
+
+        let executable = try #require(quote.executable(tokenIn: Self.token(blockchainType: .ton), privateSend: false) as? TonExecutable)
+
+        #expect(executable.transactionParam.validUntil == 123)
+        #expect(executable.transactionParam.messages.isEmpty)
+    }
+
+    @Test func tronQuoteCarriesCreatedTransactionAndNilTransferIntent() throws {
+        let created = try Mapper<CreatedTransactionResponse>().map(JSON: [
+            "visible": false,
+            "txID": "aabbcc",
+            "raw_data": [
+                "ref_block_bytes": "0000",
+                "ref_block_hash": "1122",
+                "expiration": 1,
+                "fee_limit": 1000,
+                "timestamp": 2,
+            ],
+            "raw_data_hex": "deadbeef",
+        ])
+        let quote = TronSwapFinalQuote(
+            amountIn: 1,
+            expectedAmountOut: 2,
+            recipient: nil,
+            slippage: nil,
+            createdTransaction: created,
+            fees: [],
+            transactionError: nil,
+            toAddress: "to"
+        )
+
+        let executable = try #require(quote.executable(tokenIn: Self.token(blockchainType: .tron), privateSend: false) as? TronExecutable)
+
+        #expect(executable.created.txID == created.txID)
+        #expect(executable.created.rawDataHex == created.rawDataHex)
+        #expect(executable.transferIntent == nil)
+    }
+
+    @Test func stellarQuoteCarriesTokenInAndTransactionData() throws {
+        // the switch passes the handler's tokenIn to StellarSendHelper.send, NOT the quote's stored token
+        let storedToken = Self.token(blockchainType: .stellar)
+        let tokenIn = Token(
+            coin: Coin(uid: "other-coin", name: "Other", code: "OTH"),
+            blockchain: Blockchain(type: .stellar, name: "Stellar", explorerUrl: nil),
+            type: .native,
+            decimals: 7
+        )
+        let quote = StellarSwapFinalQuote(
+            amountIn: 1,
+            expectedAmountOut: 2,
+            recipient: nil,
+            slippage: nil,
+            transactionData: .envelope("xdr-envelope"),
+            token: storedToken,
+            fee: 0.1,
+            transactionError: nil,
+            toAddress: "to"
+        )
+
+        let executable = try #require(quote.executable(tokenIn: tokenIn, privateSend: false) as? StellarExecutable)
+
+        #expect(executable.token == tokenIn)
+        guard case let .envelope(envelope) = executable.transactionData else {
+            Issue.record("expected .envelope")
+            return
+        }
+        #expect(envelope == "xdr-envelope")
+    }
+
+    @Test func moneroQuoteMapsAllSendArguments() throws {
+        let quote = MoneroSwapFinalQuote(
+            amountIn: 1,
+            expectedAmountOut: 2,
+            recipient: nil,
+            slippage: nil,
+            amount: .value(3),
+            address: "monero-addr",
+            memo: "memo",
+            token: Self.token(blockchainType: .monero),
+            priority: .low,
+            fee: 0.1,
+            transactionError: nil,
+            toAddress: "to"
+        )
+        let token = Self.token(blockchainType: .monero)
+
+        let executable = try #require(quote.executable(tokenIn: token, privateSend: false) as? MoneroExecutable)
+
+        #expect(executable.token == token)
+        #expect(executable.address == "monero-addr")
+        #expect(executable.amount.value == 3)
+        #expect(executable.priority == .low)
+        #expect(executable.memo == "memo")
+    }
+
+    @Test func zanoQuoteMapsAllSendArguments() throws {
+        let quote = ZanoSwapFinalQuote(
+            expectedAmountOut: 2,
+            recipient: nil,
+            slippage: nil,
+            amount: .value(4),
+            address: "zano-addr",
+            memo: "memo",
+            fee: 0.1,
+            transactionError: nil,
+            toAddress: "to"
+        )
+        let token = Self.token(blockchainType: .zano)
+
+        let executable = try #require(quote.executable(tokenIn: token, privateSend: false) as? ZanoExecutable)
+
+        #expect(executable.token == token)
+        #expect(executable.address == "zano-addr")
+        #expect(executable.amount.value == 4)
+        #expect(executable.memo == "memo")
+    }
+
+    @Test func solanaQuoteCarriesTokenAndRawTransaction() throws {
+        let rawTransaction = Data([0xAA, 0xBB])
+        let quote = SolanaSwapFinalQuote(
+            rawTransaction: rawTransaction,
+            expectedAmountOut: 2,
+            recipient: nil,
+            slippage: nil,
+            fee: 0.1,
+            transactionError: nil,
+            toAddress: "to",
+            depositAddress: nil,
+            providerSwapId: nil
+        )
+        let token = Self.token(blockchainType: .solana)
+
+        let executable = try #require(quote.executable(tokenIn: token, privateSend: false) as? SolanaExecutable)
+
+        #expect(executable.token == token)
+        #expect(executable.rawTransaction == rawTransaction)
+    }
+
+    @Test func baseQuoteReturnsUnsupportedExecutable() {
+        let quote = SwapFinalQuote(
+            expectedBuyAmount: 1,
+            slippage: nil,
+            recipient: nil,
+            transactionError: nil,
+            toAddress: "to"
+        )
+
+        let executable = quote.executable(tokenIn: Self.token(), privateSend: false)
+
+        #expect(executable is UnsupportedExecutable)
+    }
+}

--- a/Unstoppable/Tests/Modules/MultiSwap/SwapProviderFactoryTests.swift
+++ b/Unstoppable/Tests/Modules/MultiSwap/SwapProviderFactoryTests.swift
@@ -1,0 +1,89 @@
+import Combine
+import Foundation
+import MarketKit
+import SwiftUI
+import Testing
+@testable import Unstoppable
+@testable import WalletCore
+
+@Suite(.serialized)
+struct SwapProviderFactoryTests {
+    init() {
+        SwapProviderFactory.reset()
+    }
+
+    @Test func resolvesRegisteredResolver() throws {
+        SwapProviderFactory.register([MatchingResolver.self])
+
+        let provider = try #require(SwapProviderFactory.provider(id: "matching") as? StubProvider)
+
+        #expect(provider.id == "matching")
+    }
+
+    @Test func prependWinsOverRegisteredResolver() throws {
+        SwapProviderFactory.register([MatchingResolver.self])
+        SwapProviderFactory.prepend(PrependedResolver.self)
+
+        let provider = try #require(SwapProviderFactory.provider(id: "matching") as? StubProvider)
+
+        #expect(provider.id == "prepended")
+    }
+
+    @Test func emptyRegistryReturnsNil() {
+        #expect(SwapProviderFactory.provider(id: "matching") == nil)
+    }
+
+    @Test func decliningResolverIsSkipped() throws {
+        SwapProviderFactory.register([DecliningResolver.self, MatchingResolver.self])
+
+        let provider = try #require(SwapProviderFactory.provider(id: "matching") as? StubProvider)
+
+        #expect(provider.id == "matching")
+    }
+}
+
+private struct StubProvider: IMultiSwapProvider {
+    let id: String
+
+    var name: String { id }
+    var type: SwapProviderType { .good }
+    var icon: String { "stub" }
+
+    func supports(tokenIn _: Token, tokenOut _: Token) -> Bool {
+        false
+    }
+
+    func quote(tokenIn _: Token, tokenOut _: Token, amountIn _: Decimal) async throws -> MultiSwapQuote {
+        fatalError("not used")
+    }
+
+    func confirmationQuote(multiSwapQuote _: MultiSwapQuote, tokenIn _: Token, tokenOut _: Token, amountIn _: Decimal, slippage _: Decimal, recipient _: String?, transactionSettings _: TransactionSettings?) async throws -> SwapFinalQuote {
+        fatalError("not used")
+    }
+
+    func preSwapView(step _: MultiSwapPreSwapStep, tokenIn _: Token, tokenOut _: Token, amount _: Decimal, isPresented _: Binding<Bool>, onSuccess _: @escaping () -> Void) -> AnyView {
+        AnyView(EmptyView())
+    }
+
+    func track(swap: Swap) async throws -> Swap {
+        swap
+    }
+}
+
+private enum MatchingResolver: ISwapProviderResolver {
+    static func provider(id: String) -> IMultiSwapProvider? {
+        id == "matching" ? StubProvider(id: "matching") : nil
+    }
+}
+
+private enum PrependedResolver: ISwapProviderResolver {
+    static func provider(id: String) -> IMultiSwapProvider? {
+        id == "matching" ? StubProvider(id: "prepended") : nil
+    }
+}
+
+private enum DecliningResolver: ISwapProviderResolver {
+    static func provider(id _: String) -> IMultiSwapProvider? {
+        nil
+    }
+}

--- a/Unstoppable/Tests/Modules/MultiSwap/SwapRequestRefundTests.swift
+++ b/Unstoppable/Tests/Modules/MultiSwap/SwapRequestRefundTests.swift
@@ -15,8 +15,8 @@ struct SwapRequestRefundTests {
             "fromAsset": "btc",
             "toAsset": "eth",
             "toAmount": "1.23",
+            "providers": ["PEGASUS"],
             "meta": [
-                "provider": "PEGASUS",
                 "pauseReason": "aml",
             ],
             "legs": [

--- a/Unstoppable/Tests/Modules/MultiSwap/SwapSendDataTests.swift
+++ b/Unstoppable/Tests/Modules/MultiSwap/SwapSendDataTests.swift
@@ -74,6 +74,35 @@ struct SwapSendDataTests {
         #expect(data.rateCoins.map(\.uid) == ["in", "out", "fee-coin"])
     }
 
+    @Test func directSectionsAppendQuoteFeeFields() {
+        let quote = Self.evmQuote()
+        let data = Self.sendData(quote: quote, prepared: DirectPrepared(executable: StubExecutable()))
+        let baseToken = Self.token(uid: "base")
+        let currency = Currency(code: "USD", symbol: "$", decimal: 2)
+
+        let sections = data.sections(baseToken: baseToken, currency: currency, rates: [:])
+        let quoteFields = quote.fields(tokenIn: data.tokenIn, tokenOut: data.tokenOut, baseToken: baseToken, currency: currency, tokenInRate: nil, tokenOutRate: nil, baseTokenRate: nil)
+        let feeFields = quote.feeFields(baseToken: baseToken, currency: currency, baseTokenRate: nil)
+
+        #expect(sections.count == 2) // flow + info(+fee), no otherSections
+        #expect(feeFields.isEmpty == false) // populated EVM quote produces fee rows
+        #expect(sections[1].fields.count == 1 + quoteFields.count + feeFields.count) // price + quote + fee
+    }
+
+    @Test func displaySectionsReplaceQuoteFeeRowsWithFeeSections() {
+        let quote = Self.evmQuote()
+        let prepared = StubDisplayPrepared(canSend: true, extraRateCoins: [], stubFeeSections: [SendDataSection([])])
+        let data = Self.sendData(quote: quote, prepared: prepared)
+        let baseToken = Self.token(uid: "base")
+        let currency = Currency(code: "USD", symbol: "$", decimal: 2)
+
+        let sections = data.sections(baseToken: baseToken, currency: currency, rates: [:])
+        let quoteFields = quote.fields(tokenIn: data.tokenIn, tokenOut: data.tokenOut, baseToken: baseToken, currency: currency, tokenInRate: nil, tokenOutRate: nil, baseTokenRate: nil)
+
+        #expect(sections.count == 3) // flow + info + the display fee section
+        #expect(sections[1].fields.count == 1 + quoteFields.count) // price + quote, NO quote fee rows
+    }
+
     @Test func displayPreparedSuppressesQuoteFeeData() {
         let prepared = StubDisplayPrepared(canSend: false, extraRateCoins: [])
         // quote CAN swap and has feeData — display prepared must suppress it (no "Edit Fee")
@@ -89,9 +118,10 @@ private struct StubExecutable: ISwapExecutable {}
 private struct StubDisplayPrepared: IPreparedDisplay {
     let canSend: Bool
     let extraRateCoins: [Coin]
+    var stubFeeSections: [SendDataSection] = []
 
     func feeSections(baseToken _: Token, currency _: Currency, rates _: [String: Decimal]) -> [SendDataSection] {
-        []
+        stubFeeSections
     }
 }
 

--- a/Unstoppable/Tests/Modules/MultiSwap/SwapSendDataTests.swift
+++ b/Unstoppable/Tests/Modules/MultiSwap/SwapSendDataTests.swift
@@ -1,0 +1,106 @@
+import BigInt
+import EvmKit
+import Foundation
+import MarketKit
+import Testing
+@testable import Unstoppable
+@testable import WalletCore
+
+// Step-2 type-selection: DirectPrepared keeps quote-based fee/canSend,
+// an IPreparedDisplay prepared overrides them
+struct SwapSendDataTests {
+    private static func token(uid: String = "test-coin") -> Token {
+        Token(
+            coin: Coin(uid: uid, name: "Test", code: "TST"),
+            blockchain: Blockchain(type: .ethereum, name: "Test", explorerUrl: nil),
+            type: .native,
+            decimals: 8
+        )
+    }
+
+    private static func evmQuote(canSwap: Bool = true) -> EvmSwapFinalQuote {
+        EvmSwapFinalQuote(
+            expectedBuyAmount: 1,
+            transactionData: canSwap ? try? TransactionData(
+                to: EvmKit.Address(hex: "0x1234567890123456789012345678901234567890"),
+                value: 100,
+                input: Data()
+            ) : nil,
+            slippage: nil,
+            recipient: nil,
+            gasPrice: canSwap ? .legacy(gasPrice: 1_000_000_000) : nil,
+            evmFeeData: canSwap ? EvmFeeData(gasLimit: 100_000, surchargedGasLimit: 110_000) : nil,
+            nonce: nil,
+            toAddress: "to"
+        )
+    }
+
+    private static func sendData(quote: SwapFinalQuote, prepared: IPrepared) -> MultiSwapSendHandler.SendData {
+        MultiSwapSendHandler.SendData(
+            tokenIn: token(uid: "in"),
+            tokenOut: token(uid: "out"),
+            amountIn: 1,
+            quote: quote,
+            prepared: prepared,
+            broadcaster: StubBroadcaster(),
+            otherSections: []
+        )
+    }
+
+    @Test func directPreparedKeepsQuoteBehaviour() {
+        let quote = Self.evmQuote()
+        let data = Self.sendData(quote: quote, prepared: DirectPrepared(executable: StubExecutable()))
+
+        #expect(data.feeData != nil)
+        #expect(data.canSend == quote.canSwap)
+        #expect(data.rateCoins.map(\.uid) == ["in", "out"])
+    }
+
+    @Test func directPreparedReflectsQuoteCanSwapFalse() {
+        let data = Self.sendData(quote: Self.evmQuote(canSwap: false), prepared: DirectPrepared(executable: StubExecutable()))
+
+        #expect(data.canSend == false)
+        #expect(data.feeData == nil)
+    }
+
+    @Test func displayPreparedOverridesFeeAndCanSend() {
+        let extraCoin = Coin(uid: "fee-coin", name: "Fee", code: "FEE")
+        let prepared = StubDisplayPrepared(canSend: true, extraRateCoins: [extraCoin])
+        // quote CANNOT swap (nil evmFeeData) and carries no feeData, but display prepared rules
+        let data = Self.sendData(quote: Self.evmQuote(canSwap: false), prepared: prepared)
+
+        #expect(data.canSend == true)
+        #expect(data.feeData == nil)
+        #expect(data.rateCoins.map(\.uid) == ["in", "out", "fee-coin"])
+    }
+
+    @Test func displayPreparedSuppressesQuoteFeeData() {
+        let prepared = StubDisplayPrepared(canSend: false, extraRateCoins: [])
+        // quote CAN swap and has feeData — display prepared must suppress it (no "Edit Fee")
+        let data = Self.sendData(quote: Self.evmQuote(), prepared: prepared)
+
+        #expect(data.feeData == nil)
+        #expect(data.canSend == false)
+    }
+}
+
+private struct StubExecutable: ISwapExecutable {}
+
+private struct StubDisplayPrepared: IPreparedDisplay {
+    let canSend: Bool
+    let extraRateCoins: [Coin]
+
+    func feeSections(baseToken _: Token, currency _: Currency, rates _: [String: Decimal]) -> [SendDataSection] {
+        []
+    }
+}
+
+private struct StubBroadcaster: ISwapBroadcaster {
+    func prepare(_ executable: ISwapExecutable) async throws -> IPrepared {
+        DirectPrepared(executable: executable)
+    }
+
+    func submit(_: IPrepared) async throws -> BroadcastResult {
+        BroadcastResult(txHash: nil, trackingHandle: nil)
+    }
+}

--- a/Unstoppable/Tests/Modules/MultiSwap/SwapSendDataTests.swift
+++ b/Unstoppable/Tests/Modules/MultiSwap/SwapSendDataTests.swift
@@ -18,7 +18,7 @@ struct SwapSendDataTests {
         )
     }
 
-    private static func evmQuote(canSwap: Bool = true) -> EvmSwapFinalQuote {
+    private static func evmQuote(canSwap: Bool = true, transactionError: Error? = nil) -> EvmSwapFinalQuote {
         EvmSwapFinalQuote(
             expectedBuyAmount: 1,
             transactionData: canSwap ? try? TransactionData(
@@ -26,6 +26,7 @@ struct SwapSendDataTests {
                 value: 100,
                 input: Data()
             ) : nil,
+            transactionError: transactionError,
             slippage: nil,
             recipient: nil,
             gasPrice: canSwap ? .legacy(gasPrice: 1_000_000_000) : nil,
@@ -33,6 +34,10 @@ struct SwapSendDataTests {
             nonce: nil,
             toAddress: "to"
         )
+    }
+
+    private enum TestError: Error {
+        case estimateFailed
     }
 
     private static func sendData(quote: SwapFinalQuote, prepared: IPrepared) -> MultiSwapSendHandler.SendData {
@@ -103,6 +108,36 @@ struct SwapSendDataTests {
         #expect(sections[1].fields.count == 1 + quoteFields.count) // price + quote, NO quote fee rows
     }
 
+    @Test func directPreparedKeepsQuoteTransactionErrorCaution() {
+        let quote = Self.evmQuote(canSwap: false, transactionError: TestError.estimateFailed)
+        let data = Self.sendData(quote: quote, prepared: DirectPrepared(executable: StubExecutable()))
+
+        let cautions = data.cautions(baseToken: Self.token(uid: "base"), currency: Currency(code: "USD", symbol: "$", decimal: 2), rates: [:])
+
+        #expect(cautions.isEmpty == false) // native-path caution rendered for EOA
+    }
+
+    @Test func displayPreparedDropsQuoteTransactionErrorCaution() {
+        let quote = Self.evmQuote(canSwap: false, transactionError: TestError.estimateFailed)
+        let prepared = StubDisplayPrepared(canSend: true, extraRateCoins: [])
+        let data = Self.sendData(quote: quote, prepared: prepared)
+
+        let cautions = data.cautions(baseToken: Self.token(uid: "base"), currency: Currency(code: "USD", symbol: "$", decimal: 2), rates: [:])
+
+        #expect(cautions.isEmpty) // the prepared owns the payment view; quote's native caution not rendered
+    }
+
+    @Test func displayPreparedSurfacesItsOwnCautions() {
+        let quote = Self.evmQuote(canSwap: false, transactionError: TestError.estimateFailed)
+        let prepared = StubDisplayPrepared(canSend: false, extraRateCoins: [], stubCautions: [CautionNew(title: "Reserve", text: "not enough", type: .error)])
+        let data = Self.sendData(quote: quote, prepared: prepared)
+
+        let cautions = data.cautions(baseToken: Self.token(uid: "base"), currency: Currency(code: "USD", symbol: "$", decimal: 2), rates: [:])
+
+        #expect(cautions.count == 1)
+        #expect(cautions[0].title == "Reserve")
+    }
+
     @Test func displayPreparedSuppressesQuoteFeeData() {
         let prepared = StubDisplayPrepared(canSend: false, extraRateCoins: [])
         // quote CAN swap and has feeData — display prepared must suppress it (no "Edit Fee")
@@ -119,9 +154,14 @@ private struct StubDisplayPrepared: IPreparedDisplay {
     let canSend: Bool
     let extraRateCoins: [Coin]
     var stubFeeSections: [SendDataSection] = []
+    var stubCautions: [CautionNew] = []
 
     func feeSections(baseToken _: Token, currency _: Currency, rates _: [String: Decimal]) -> [SendDataSection] {
         stubFeeSections
+    }
+
+    func cautions(baseToken _: Token) -> [CautionNew] {
+        stubCautions
     }
 }
 

--- a/Unstoppable/Tests/Modules/MultiSwap/SwapTrackingGateTests.swift
+++ b/Unstoppable/Tests/Modules/MultiSwap/SwapTrackingGateTests.swift
@@ -42,12 +42,12 @@ struct SwapTrackingGateTests {
     }
 
     @Test func mechanismPendingIsGated() {
-        let awaiting = SwapHistoryManager.isAwaitingTxHash(Self.swap(txHash: nil, trackingHandle: "userOpHash"))
+        let awaiting = SwapHistoryManager.isAwaitingTxHash(Self.swap(txHash: nil, trackingHandle: "tracking-handle"))
         #expect(awaiting == true)
     }
 
     @Test func resolvedMechanismSwapIsTracked() {
-        let awaiting = SwapHistoryManager.isAwaitingTxHash(Self.swap(txHash: "0xabc", trackingHandle: "userOpHash"))
+        let awaiting = SwapHistoryManager.isAwaitingTxHash(Self.swap(txHash: "0xabc", trackingHandle: "tracking-handle"))
         #expect(awaiting == false)
     }
 

--- a/Unstoppable/Tests/Modules/MultiSwap/SwapTrackingGateTests.swift
+++ b/Unstoppable/Tests/Modules/MultiSwap/SwapTrackingGateTests.swift
@@ -1,0 +1,63 @@
+import Foundation
+import MarketKit
+import Testing
+@testable import Unstoppable
+@testable import WalletCore
+
+// track-gate matrix: only mechanism-pending swaps (handle set, no txHash yet) are
+// skipped; nil-txHash swaps WITHOUT a handle keep today's tracking (deposit-based
+// providers track by providerSwapId alone)
+struct SwapTrackingGateTests {
+    private static func swap(txHash: String?, trackingHandle: String?) -> Swap {
+        let token = Token(
+            coin: Coin(uid: "test-coin", name: "Test", code: "TST"),
+            blockchain: Blockchain(type: .ethereum, name: "Test", explorerUrl: nil),
+            type: .native,
+            decimals: 8
+        )
+
+        return Swap(
+            uid: "uid",
+            txHash: txHash,
+            trackingHandle: trackingHandle,
+            accountId: "account",
+            providerId: "provider",
+            status: .pending,
+            tokenIn: token,
+            tokenOut: token,
+            amountIn: 1,
+            amountOut: 2,
+            recipient: nil,
+            toAddress: "to",
+            depositAddress: nil,
+            providerSwapId: "swap-id",
+            sourceAddress: nil,
+            refundAddress: nil,
+            date: Date(),
+            fromAsset: nil,
+            toAsset: nil,
+            legs: nil,
+            pauseReason: nil
+        )
+    }
+
+    @Test func mechanismPendingIsGated() {
+        let awaiting = SwapHistoryManager.isAwaitingTxHash(Self.swap(txHash: nil, trackingHandle: "userOpHash"))
+        #expect(awaiting == true)
+    }
+
+    @Test func resolvedMechanismSwapIsTracked() {
+        let awaiting = SwapHistoryManager.isAwaitingTxHash(Self.swap(txHash: "0xabc", trackingHandle: "userOpHash"))
+        #expect(awaiting == false)
+    }
+
+    @Test func directSwapWithNilTxHashKeepsTracking() {
+        let awaiting = SwapHistoryManager.isAwaitingTxHash(Self.swap(txHash: nil, trackingHandle: nil))
+        #expect(awaiting == false)
+    }
+
+    @Test func directSwapWithTxHashKeepsTracking() {
+        let awaiting = SwapHistoryManager.isAwaitingTxHash(Self.swap(txHash: "0xabc", trackingHandle: nil))
+        #expect(awaiting == false)
+    }
+}

--- a/Unstoppable/Unstoppable/App/UnstoppableApp.swift
+++ b/Unstoppable/Unstoppable/App/UnstoppableApp.swift
@@ -36,6 +36,8 @@ struct UnstoppableApp: App {
     }
 
     private static func initCore() throws {
+        SwapProviderFactory.register([DefaultSwapProviderResolver.self])
+
         try Core.initApp(config: Core.Config(), widgetRefresher: WidgetRefresher())
 
         EvmKitConfigFactory.register(UnstoppableEvmKitConfigProvider.self)

--- a/packages/WalletCore/Package.swift
+++ b/packages/WalletCore/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         .package(url: "https://github.com/horizontalsystems/DashKit.Swift", exact: "3.1.0"),
         .package(url: "https://github.com/johnxnguyen/Down", from: "0.11.0"),
         .package(url: "https://github.com/horizontalsystems/ECashKit.Swift.git", exact: "3.0.2"),
-        .package(url: "https://github.com/horizontalsystems/Eip20Kit.Swift", exact: "2.1.0"),
+        .package(url: "https://github.com/horizontalsystems/Eip20Kit.Swift", exact: "2.1.1"),
         .package(url: "https://github.com/horizontalsystems/EvmKit.Swift", exact: "2.5.0"),
         .package(url: "https://github.com/horizontalsystems/FeeRateKit.Swift", exact: "2.1.1"),
         .package(url: "https://github.com/horizontalsystems/HCaptcha-ios-sdk.git", exact: "1.0.0"),

--- a/packages/WalletCore/Sources/WalletCore/Core/Adapters/Tron/BaseTronAdapter.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Adapters/Tron/BaseTronAdapter.swift
@@ -20,7 +20,7 @@ public class BaseTronAdapter {
         tronKitWrapper.tronKit
     }
 
-    /// `true` for on-chain-active accounts AND for gas-token-payment accounts (passkey-AA / GasFree)
+    /// `true` for on-chain-active accounts AND for gas-token-payment accounts (passkey / GasFree)
     /// whose wallet may not be on-chain yet but still semantically usable for receive/send via the
     /// abstraction layer. Use this for UI activation cues, not raw `tronKit.accountActive`.
     var effectiveAccountActive: Bool {

--- a/packages/WalletCore/Sources/WalletCore/Core/Core.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Core.swift
@@ -13,6 +13,7 @@ public class Core {
         SendHandlerFactory.unstoppableHandlers.forEach { SendHandlerFactory.register($0) }
         SendHandlerFactory.unstoppablePreSendHandlers.forEach { SendHandlerFactory.register($0) }
         TransactionServiceFactory.unstoppableTransactionServices.forEach { TransactionServiceFactory.register($0) }
+        SwapBroadcasterFactory.register(SwapBroadcasterFactory.unstoppableBroadcasters)
         // EvmKit syncers/decorators are registered by each app (no shared fallback): stable in StableCore, the
         // unstoppable app in its own initCore (registers a provider over defaultSyncers/defaultDecorators).
     }

--- a/packages/WalletCore/Sources/WalletCore/Core/Core.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Core.swift
@@ -141,7 +141,7 @@ public class Core {
 
     let valueFormatter: CurrencyValueFormatter
 
-    let swapAssetStorage: SwapAssetStorage
+    public let swapAssetStorage: SwapAssetStorage
     let swapProviderManager: MultiSwapProviderManager
     let swapProviderInfoManager: SwapProviderInfoManager
     public let swapHistoryManager: SwapHistoryManager

--- a/packages/WalletCore/Sources/WalletCore/Core/Core.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Core.swift
@@ -144,7 +144,7 @@ public class Core {
     let swapAssetStorage: SwapAssetStorage
     let swapProviderManager: MultiSwapProviderManager
     let swapProviderInfoManager: SwapProviderInfoManager
-    let swapHistoryManager: SwapHistoryManager
+    public let swapHistoryManager: SwapHistoryManager
 
     public let createPasskeyAccountService: CreatePasskeyAccountService
 

--- a/packages/WalletCore/Sources/WalletCore/Core/Factories/SwapProviderFactory.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Factories/SwapProviderFactory.swift
@@ -1,10 +1,55 @@
-import OneInchKit
-import UniswapKit
+public protocol ISwapProviderResolver {
+    static func provider(id: String) -> IMultiSwapProvider?
+}
 
-class SwapProviderFactory {
-    static func provider(id: String) -> IMultiSwapProvider? {
+public class SwapProviderFactory {
+    private static var resolvers: [ISwapProviderResolver.Type] = []
+
+    public static func register(_ resolvers: [ISwapProviderResolver.Type]) {
+        self.resolvers.append(contentsOf: resolvers)
+    }
+
+    public static func prepend(_ resolver: ISwapProviderResolver.Type) {
+        resolvers.insert(resolver, at: 0)
+    }
+
+    public static func provider(id: String) -> IMultiSwapProvider? {
+        for resolver in resolvers {
+            if let provider = resolver.provider(id: id) {
+                return provider
+            }
+        }
+
+        return nil
+    }
+
+    public static func providerName(id: String) -> String? {
+        if let provider = USwapProvider(rawValue: id) {
+            return provider.title
+        }
+
+        let names: [String: String] = [
+            OneInchMultiSwapProvider.id: OneInchMultiSwapProvider.name,
+            ThorChainMultiSwapProvider.id: ThorChainMultiSwapProvider.name,
+            MayaMultiSwapProvider.id: MayaMultiSwapProvider.name,
+            AllBridgeMultiSwapProvider.id: AllBridgeMultiSwapProvider.name,
+            UniswapV3MultiSwapProvider.id: UniswapV3MultiSwapProvider.name,
+            PancakeV3MultiSwapProvider.id: PancakeV3MultiSwapProvider.name,
+        ]
+
+        return names[id]
+    }
+
+    // test seam: registry is global mutable state
+    static func reset() {
+        resolvers = []
+    }
+}
+
+public enum DefaultSwapProviderResolver: ISwapProviderResolver {
+    public static func provider(id: String) -> IMultiSwapProvider? {
         if id == OneInchMultiSwapProvider.id, let apiKey = AppConfig.oneInchApiKey {
-            return OneInchMultiSwapProvider(kit: OneInchKit.Kit.instance(apiKey: apiKey))
+            return OneInchMultiSwapProvider(apiKey: apiKey)
         }
 
         if id == ThorChainMultiSwapProvider.id {
@@ -19,35 +64,18 @@ class SwapProviderFactory {
             return AllBridgeMultiSwapProvider()
         }
 
-        if id == UniswapV3MultiSwapProvider.id, let kit = try? UniswapKit.KitV3.instance(dexType: .uniswap) {
-            return UniswapV3MultiSwapProvider(kit: kit)
+        if id == UniswapV3MultiSwapProvider.id, let provider = try? UniswapV3MultiSwapProvider() {
+            return provider
         }
 
-        if id == PancakeV3MultiSwapProvider.id, let kit = try? UniswapKit.KitV3.instance(dexType: .pancakeSwap) {
-            return PancakeV3MultiSwapProvider(kit: kit)
+        if id == PancakeV3MultiSwapProvider.id, let provider = try? PancakeV3MultiSwapProvider() {
+            return provider
         }
 
-        if let provider = USwapMultiSwapProvider.Provider(rawValue: id) {
+        if let provider = USwapProvider(rawValue: id), USwapMultiSwapProvider.supportedProviders.contains(provider) {
             return USwapMultiSwapProvider(provider: provider)
         }
 
         return nil
-    }
-
-    static func providerName(id: String) -> String? {
-        if let provider = USwapMultiSwapProvider.Provider(rawValue: id) {
-            return provider.title
-        }
-
-        let names: [String: String] = [
-            OneInchMultiSwapProvider.id: OneInchMultiSwapProvider.name,
-            ThorChainMultiSwapProvider.id: ThorChainMultiSwapProvider.name,
-            MayaMultiSwapProvider.id: MayaMultiSwapProvider.name,
-            AllBridgeMultiSwapProvider.id: AllBridgeMultiSwapProvider.name,
-            UniswapV3MultiSwapProvider.id: UniswapV3MultiSwapProvider.name,
-            PancakeV3MultiSwapProvider.id: PancakeV3MultiSwapProvider.name,
-        ]
-
-        return names[id]
     }
 }

--- a/packages/WalletCore/Sources/WalletCore/Core/Managers/SwapHistoryManager.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Managers/SwapHistoryManager.swift
@@ -1,7 +1,7 @@
 import Combine
 import Foundation
 
-class SwapHistoryManager {
+public class SwapHistoryManager {
     private let accountManager: AccountManager
     private let storage: SwapStorage
     private var cancellables = Set<AnyCancellable>()
@@ -31,6 +31,14 @@ class SwapHistoryManager {
         var hasStillPendingSwaps = false
 
         for swap in pendingSwaps {
+            // mechanism-pending: there is no on-chain hash to track by yet; resolve() will supply it.
+            // Swaps without a trackingHandle keep today's behaviour even with a nil txHash
+            // (deposit-based providers track by providerSwapId alone)
+            if Self.isAwaitingTxHash(swap) {
+                hasStillPendingSwaps = true
+                continue
+            }
+
             guard let provider = SwapProviderFactory.provider(id: swap.providerId) else {
                 continue
             }
@@ -108,5 +116,23 @@ extension SwapHistoryManager {
         } catch {
             print(error)
         }
+    }
+
+    // mechanism-agnostic hook: attaches the on-chain txHash to the swap saved with
+    // this trackingHandle and starts tracking it
+    public func resolve(trackingHandle: String, txHash: String) {
+        do {
+            guard try storage.setTxHash(txHash, trackingHandle: trackingHandle) else {
+                return
+            }
+
+            sync()
+        } catch {
+            print(error)
+        }
+    }
+
+    static func isAwaitingTxHash(_ swap: Swap) -> Bool {
+        swap.trackingHandle != nil && swap.txHash == nil
     }
 }

--- a/packages/WalletCore/Sources/WalletCore/Core/Managers/TronKitManager.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Managers/TronKitManager.swift
@@ -133,7 +133,7 @@ extension TronKitManager {
 public class TronKitWrapper {
     let tronKit: TronKit.Kit
     let signer: Signer?
-    /// True when this wrapper serves a gas-token-payment account (currently passkey-AA / GasFree).
+    /// True when this wrapper serves a gas-token-payment account (currently passkey / GasFree).
     /// UI uses it to bypass on-chain `accountActive == false` cosmetic ("not activated") for accounts
     /// whose wallet is a CREATE2 BeaconProxy not yet deployed on chain.
     let gasTokenPayment: Bool

--- a/packages/WalletCore/Sources/WalletCore/Core/Storage/StorageMigrator.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Storage/StorageMigrator.swift
@@ -958,6 +958,12 @@ public enum StorageMigrator {
             }
         }
 
+        migrator.registerMigration("Add trackingHandle to SwapRecord") { db in
+            try db.alter(table: SwapRecord.databaseTableName) { t in
+                t.add(column: SwapRecord.Columns.trackingHandle.name, .text)
+            }
+        }
+
         try migrator.migrate(dbPool)
     }
 

--- a/packages/WalletCore/Sources/WalletCore/Core/Storage/SwapAssetStorage.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Storage/SwapAssetStorage.swift
@@ -1,7 +1,7 @@
 import Foundation
 import GRDB
 
-class SwapAssetStorage {
+public class SwapAssetStorage {
     private let dbPool: DatabasePool
 
     init(dbPool: DatabasePool) {
@@ -9,7 +9,7 @@ class SwapAssetStorage {
     }
 }
 
-extension SwapAssetStorage {
+public extension SwapAssetStorage {
     func swapAssetMap<T: Decodable>(provider: String, as type: T.Type) throws -> [String: T] {
         let swapAssets: [SwapAsset] = try dbPool.read { db in
             try SwapAsset.filter(SwapAsset.Columns.provider == provider).fetchAll(db)

--- a/packages/WalletCore/Sources/WalletCore/Core/Storage/SwapStorage.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Storage/SwapStorage.swift
@@ -31,6 +31,7 @@ class SwapStorage {
             return Swap(
                 uid: record.uid,
                 txHash: record.txHash,
+                trackingHandle: record.trackingHandle,
                 accountId: record.accountId,
                 providerId: record.providerId,
                 status: Swap.Status(rawValue: record.status) ?? .unknown,
@@ -66,6 +67,7 @@ class SwapStorage {
         SwapRecord(
             uid: swap.uid,
             txHash: swap.txHash,
+            trackingHandle: swap.trackingHandle,
             accountId: swap.accountId,
             providerId: swap.providerId,
             status: swap.status.rawValue,
@@ -148,6 +150,16 @@ extension SwapStorage {
     func save(swap: Swap) throws {
         _ = try dbPool.write { db in
             try record(swap: swap).insert(db)
+        }
+    }
+
+    // attaches the on-chain hash to a mechanism-pending swap; returns false when
+    // the handle is unknown or the hash is already set
+    func setTxHash(_ txHash: String, trackingHandle: String) throws -> Bool {
+        try dbPool.write { db in
+            try SwapRecord
+                .filter(SwapRecord.Columns.trackingHandle == trackingHandle && SwapRecord.Columns.txHash == nil)
+                .updateAll(db, SwapRecord.Columns.txHash.set(to: txHash)) > 0
         }
     }
 }

--- a/packages/WalletCore/Sources/WalletCore/Models/AccountType.swift
+++ b/packages/WalletCore/Sources/WalletCore/Models/AccountType.swift
@@ -374,7 +374,7 @@ extension AccountType {
         case .stellarSecretKey:
             return AccountType.stellarSecretKey(secretSeed: string)
         case .passkeyOwned:
-            return nil // device-bound passkey + separate aa.sqlite: not restorable from a portable backup
+            return nil // device-bound passkey + separate local storage: not restorable from a portable backup
         case .hdExtendedKey:
             do {
                 return try AccountType.hdExtendedKey(key: HDExtendedKey(data: uniqueId))

--- a/packages/WalletCore/Sources/WalletCore/Models/Stubs/CoreDebugStubs.swift
+++ b/packages/WalletCore/Sources/WalletCore/Models/Stubs/CoreDebugStubs.swift
@@ -10,6 +10,7 @@ enum CoreDebugStubs {
         return Swap(
             uid: swap.uid,
             txHash: Constants.txHash,
+            trackingHandle: nil,
             accountId: swap.accountId,
             providerId: Constants.providerId,
             status: .actionRequired,

--- a/packages/WalletCore/Sources/WalletCore/Models/Swap.swift
+++ b/packages/WalletCore/Sources/WalletCore/Models/Swap.swift
@@ -6,6 +6,9 @@ import SwiftUI
 public struct Swap: Hashable {
     let uid: String
     let txHash: String?
+    // opaque mechanism handle (set by the broadcaster) used by resolve() to attach
+    // the on-chain txHash later; nil for directly-broadcast swaps
+    let trackingHandle: String?
     let accountId: String
     let providerId: String
     var status: Status
@@ -82,6 +85,7 @@ extension Swap {
 struct SwapRecord: Codable {
     let uid: String
     let txHash: String?
+    let trackingHandle: String?
     let accountId: String
     let providerId: String
     let status: String
@@ -121,6 +125,7 @@ extension SwapRecord: FetchableRecord, PersistableRecord {
     enum Columns {
         static let uid = Column(CodingKeys.uid)
         static let txHash = Column(CodingKeys.txHash)
+        static let trackingHandle = Column(CodingKeys.trackingHandle)
         static let accountId = Column(CodingKeys.accountId)
         static let providerId = Column(CodingKeys.providerId)
         static let status = Column(CodingKeys.status)

--- a/packages/WalletCore/Sources/WalletCore/Models/Swap.swift
+++ b/packages/WalletCore/Sources/WalletCore/Models/Swap.swift
@@ -5,7 +5,7 @@ import SwiftUI
 
 public struct Swap: Hashable {
     let uid: String
-    let txHash: String?
+    public let txHash: String?
     // opaque mechanism handle (set by the broadcaster) used by resolve() to attach
     // the on-chain txHash later; nil for directly-broadcast swaps
     let trackingHandle: String?
@@ -19,7 +19,7 @@ public struct Swap: Hashable {
     let recipient: String?
     let toAddress: String
     let depositAddress: String?
-    let providerSwapId: String?
+    public let providerSwapId: String?
     let sourceAddress: String?
     let refundAddress: String?
     let date: Date

--- a/packages/WalletCore/Sources/WalletCore/Modules/Backup/AppBackupProvider.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/Backup/AppBackupProvider.swift
@@ -384,7 +384,7 @@ extension AppBackupProvider {
     }
 
     static func encrypt(account: Account, wallets: [WalletBackup.EnabledWallet], passphrase: String) throws -> WalletBackup {
-        // Passkey/AA accounts aren't portable-backup-able (device-bound credential + separate aa.sqlite);
+        // Passkey accounts aren't portable-backup-able (device-bound credential + separate local storage);
         // the UI must not offer backup for them. Data-layer guard (moved off AccountType.Abstract).
         if case .passkeyOwned = account.type {
             throw CodingError.unsupportedAccountType

--- a/packages/WalletCore/Sources/WalletCore/Modules/CreatePasskeyAccount/CreatePasskeyAccountService.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/CreatePasskeyAccount/CreatePasskeyAccountService.swift
@@ -4,7 +4,7 @@ import MarketKit
 
 // Credential material handed to a provisioner: a fresh registration's attestation (which carries the
 // credential's public key) on create, or nothing on restore (the provisioner recovers the public key
-// out-of-band). Neutral WebAuthn/account-creation type — no AA specifics.
+// out-of-band). Neutral WebAuthn/account-creation type.
 public enum ProvisioningCredentials {
     case create(attestation: Data)
     case restore

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Broadcaster/Direct/EvmSwapBroadcaster.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Broadcaster/Direct/EvmSwapBroadcaster.swift
@@ -4,9 +4,11 @@ import MarketKit
 
 class EvmSwapBroadcaster: ISwapBroadcaster {
     private let evmKitWrapper: EvmKitWrapper
+    private let securityManager: SecurityManager
 
-    init(evmKitWrapper: EvmKitWrapper) {
+    init(evmKitWrapper: EvmKitWrapper, securityManager: SecurityManager) {
         self.evmKitWrapper = evmKitWrapper
+        self.securityManager = securityManager
     }
 
     func prepare(_ executable: ISwapExecutable) async throws -> IPrepared {
@@ -27,11 +29,12 @@ class EvmSwapBroadcaster: ISwapBroadcaster {
             throw MultiSwapSendHandler.SendError.noGasPrice
         }
 
+        // routing flag read live at send-tap: MEV toggle state is the persisted setting
         let fullTransaction = try await evmKitWrapper.send(
             transactionData: transactionData,
             gasPrice: gasPrice,
             gasLimit: gasLimit,
-            privateSend: executable.privateSend,
+            privateSend: executable.mevProtectionAllowed && securityManager.swapProtectionEnabled,
             nonce: executable.nonce
         )
 
@@ -47,6 +50,6 @@ extension EvmSwapBroadcaster: ISwapBroadcasterType {
             return nil
         }
 
-        return EvmSwapBroadcaster(evmKitWrapper: evmKitWrapper)
+        return EvmSwapBroadcaster(evmKitWrapper: evmKitWrapper, securityManager: Core.shared.securityManager)
     }
 }

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Broadcaster/Direct/EvmSwapBroadcaster.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Broadcaster/Direct/EvmSwapBroadcaster.swift
@@ -1,0 +1,52 @@
+import EvmKit
+import Foundation
+import MarketKit
+
+class EvmSwapBroadcaster: ISwapBroadcaster {
+    private let evmKitWrapper: EvmKitWrapper
+
+    init(evmKitWrapper: EvmKitWrapper) {
+        self.evmKitWrapper = evmKitWrapper
+    }
+
+    func prepare(_ executable: ISwapExecutable) async throws -> IPrepared {
+        DirectPrepared(executable: executable)
+    }
+
+    func submit(_ prepared: IPrepared) async throws -> BroadcastResult {
+        guard let prepared = prepared as? DirectPrepared, let executable = prepared.executable as? EvmExecutable else {
+            throw SwapBroadcasterError.dataMismatch
+        }
+        guard let transactionData = executable.transactionData else {
+            throw MultiSwapSendHandler.SendError.invalidTransactionData
+        }
+        guard let gasLimit = executable.gasLimit else {
+            throw MultiSwapSendHandler.SendError.noGasLimit
+        }
+        guard let gasPrice = executable.gasPrice else {
+            throw MultiSwapSendHandler.SendError.noGasPrice
+        }
+
+        let fullTransaction = try await evmKitWrapper.send(
+            transactionData: transactionData,
+            gasPrice: gasPrice,
+            gasLimit: gasLimit,
+            privateSend: executable.privateSend,
+            nonce: executable.nonce
+        )
+
+        return BroadcastResult(txHash: fullTransaction.transaction.hash.hs.hexString, trackingHandle: nil)
+    }
+}
+
+extension EvmSwapBroadcaster: ISwapBroadcasterType {
+    static func make(blockchainType: BlockchainType, account _: Account) -> ISwapBroadcaster? {
+        guard let evmKitWrapper = try? Core.shared.evmBlockchainManager.evmKitManager(blockchainType: blockchainType).evmKitWrapper,
+              evmKitWrapper.signer != nil
+        else {
+            return nil
+        }
+
+        return EvmSwapBroadcaster(evmKitWrapper: evmKitWrapper)
+    }
+}

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Broadcaster/Direct/MoneroSwapBroadcaster.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Broadcaster/Direct/MoneroSwapBroadcaster.swift
@@ -1,0 +1,42 @@
+import Foundation
+import MarketKit
+
+class MoneroSwapBroadcaster: ISwapBroadcaster {
+    private let adapterManager: AdapterManager
+
+    init(adapterManager: AdapterManager) {
+        self.adapterManager = adapterManager
+    }
+
+    func prepare(_ executable: ISwapExecutable) async throws -> IPrepared {
+        DirectPrepared(executable: executable)
+    }
+
+    func submit(_ prepared: IPrepared) async throws -> BroadcastResult {
+        guard let prepared = prepared as? DirectPrepared, let executable = prepared.executable as? MoneroExecutable else {
+            throw SwapBroadcasterError.dataMismatch
+        }
+        guard let adapter = adapterManager.adapter(for: executable.token) as? MoneroAdapter else {
+            throw MultiSwapSendHandler.SendError.noMoneroAdapter
+        }
+
+        try adapter.send(
+            to: executable.address,
+            amount: executable.amount,
+            priority: executable.priority,
+            memo: executable.memo
+        )
+
+        return BroadcastResult(txHash: nil, trackingHandle: nil)
+    }
+}
+
+extension MoneroSwapBroadcaster: ISwapBroadcasterType {
+    static func make(blockchainType: BlockchainType, account _: Account) -> ISwapBroadcaster? {
+        guard blockchainType == .monero else {
+            return nil
+        }
+
+        return MoneroSwapBroadcaster(adapterManager: Core.shared.adapterManager)
+    }
+}

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Broadcaster/Direct/SolanaSwapBroadcaster.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Broadcaster/Direct/SolanaSwapBroadcaster.swift
@@ -1,0 +1,42 @@
+import Foundation
+import MarketKit
+
+class SolanaSwapBroadcaster: ISwapBroadcaster {
+    private let account: Account
+    private let adapterManager: AdapterManager
+
+    init(account: Account, adapterManager: AdapterManager) {
+        self.account = account
+        self.adapterManager = adapterManager
+    }
+
+    func prepare(_ executable: ISwapExecutable) async throws -> IPrepared {
+        DirectPrepared(executable: executable)
+    }
+
+    func submit(_ prepared: IPrepared) async throws -> BroadcastResult {
+        guard let prepared = prepared as? DirectPrepared, let executable = prepared.executable as? SolanaExecutable else {
+            throw SwapBroadcasterError.dataMismatch
+        }
+
+        let signer = try SolanaKitManager.signer(accountType: account.type)
+
+        guard let adapter = adapterManager.adapter(for: executable.token) as? ISendSolanaAdapter else {
+            throw MultiSwapSendHandler.SendError.noSolanaAdapter
+        }
+
+        let fullTransaction = try await adapter.sendRawTransaction(rawTransaction: executable.rawTransaction, signer: signer)
+
+        return BroadcastResult(txHash: fullTransaction.transaction.hash, trackingHandle: nil)
+    }
+}
+
+extension SolanaSwapBroadcaster: ISwapBroadcasterType {
+    static func make(blockchainType: BlockchainType, account: Account) -> ISwapBroadcaster? {
+        guard blockchainType == .solana else {
+            return nil
+        }
+
+        return SolanaSwapBroadcaster(account: account, adapterManager: Core.shared.adapterManager)
+    }
+}

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Broadcaster/Direct/StellarSwapBroadcaster.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Broadcaster/Direct/StellarSwapBroadcaster.swift
@@ -1,0 +1,41 @@
+import Foundation
+import MarketKit
+
+class StellarSwapBroadcaster: ISwapBroadcaster {
+    private let account: Account
+
+    init(account: Account) {
+        self.account = account
+    }
+
+    func prepare(_ executable: ISwapExecutable) async throws -> IPrepared {
+        DirectPrepared(executable: executable)
+    }
+
+    func submit(_ prepared: IPrepared) async throws -> BroadcastResult {
+        guard let prepared = prepared as? DirectPrepared, let executable = prepared.executable as? StellarExecutable else {
+            throw SwapBroadcasterError.dataMismatch
+        }
+
+        let keyPair = try StellarKitManager.keyPair(accountType: account.type)
+
+        try await StellarSendHelper.send(
+            transactionData: executable.transactionData,
+            token: executable.token,
+            adjustNativeBalance: false,
+            keyPair: keyPair
+        )
+
+        return BroadcastResult(txHash: nil, trackingHandle: nil)
+    }
+}
+
+extension StellarSwapBroadcaster: ISwapBroadcasterType {
+    static func make(blockchainType: BlockchainType, account: Account) -> ISwapBroadcaster? {
+        guard blockchainType == .stellar else {
+            return nil
+        }
+
+        return StellarSwapBroadcaster(account: account)
+    }
+}

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Broadcaster/Direct/TonSwapBroadcaster.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Broadcaster/Direct/TonSwapBroadcaster.swift
@@ -1,0 +1,46 @@
+import Foundation
+import MarketKit
+
+class TonSwapBroadcaster: ISwapBroadcaster {
+    private let account: Account
+
+    init(account: Account) {
+        self.account = account
+    }
+
+    func prepare(_ executable: ISwapExecutable) async throws -> IPrepared {
+        DirectPrepared(executable: executable)
+    }
+
+    func submit(_ prepared: IPrepared) async throws -> BroadcastResult {
+        guard let prepared = prepared as? DirectPrepared, let executable = prepared.executable as? TonExecutable else {
+            throw SwapBroadcasterError.dataMismatch
+        }
+
+        let (publicKey, secretKey) = try TonKitManager.keyPair(accountType: account.type)
+        let contract = TonKitManager.contract(publicKey: publicKey)
+
+        let transferData = try TonSendHelper.transferData(
+            param: executable.transactionParam,
+            contract: contract
+        )
+
+        _ = try await TonSendHelper.send(
+            transferData: transferData,
+            contract: contract,
+            secretKey: secretKey
+        )
+
+        return BroadcastResult(txHash: nil, trackingHandle: nil)
+    }
+}
+
+extension TonSwapBroadcaster: ISwapBroadcasterType {
+    static func make(blockchainType: BlockchainType, account: Account) -> ISwapBroadcaster? {
+        guard blockchainType == .ton else {
+            return nil
+        }
+
+        return TonSwapBroadcaster(account: account)
+    }
+}

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Broadcaster/Direct/TronSwapBroadcaster.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Broadcaster/Direct/TronSwapBroadcaster.swift
@@ -1,0 +1,37 @@
+import Foundation
+import MarketKit
+
+class TronSwapBroadcaster: ISwapBroadcaster {
+    private let tronKitWrapper: TronKitWrapper
+
+    init(tronKitWrapper: TronKitWrapper) {
+        self.tronKitWrapper = tronKitWrapper
+    }
+
+    func prepare(_ executable: ISwapExecutable) async throws -> IPrepared {
+        DirectPrepared(executable: executable)
+    }
+
+    func submit(_ prepared: IPrepared) async throws -> BroadcastResult {
+        guard let prepared = prepared as? DirectPrepared, let executable = prepared.executable as? TronExecutable else {
+            throw SwapBroadcasterError.dataMismatch
+        }
+
+        _ = try await tronKitWrapper.send(createdTranaction: executable.created)
+
+        return BroadcastResult(txHash: nil, trackingHandle: nil)
+    }
+}
+
+extension TronSwapBroadcaster: ISwapBroadcasterType {
+    static func make(blockchainType: BlockchainType, account _: Account) -> ISwapBroadcaster? {
+        guard blockchainType == .tron,
+              let tronKitWrapper = Core.shared.tronAccountManager.tronKitManager.tronKitWrapper,
+              tronKitWrapper.signer != nil
+        else {
+            return nil
+        }
+
+        return TronSwapBroadcaster(tronKitWrapper: tronKitWrapper)
+    }
+}

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Broadcaster/Direct/UtxoSwapBroadcaster.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Broadcaster/Direct/UtxoSwapBroadcaster.swift
@@ -1,0 +1,40 @@
+import Foundation
+import MarketKit
+
+class UtxoSwapBroadcaster: ISwapBroadcaster {
+    private let adapterManager: AdapterManager
+
+    init(adapterManager: AdapterManager) {
+        self.adapterManager = adapterManager
+    }
+
+    func prepare(_ executable: ISwapExecutable) async throws -> IPrepared {
+        DirectPrepared(executable: executable)
+    }
+
+    func submit(_ prepared: IPrepared) async throws -> BroadcastResult {
+        guard let prepared = prepared as? DirectPrepared, let executable = prepared.executable as? UtxoExecutable else {
+            throw SwapBroadcasterError.dataMismatch
+        }
+        guard let adapter = adapterManager.adapter(for: executable.token) as? BitcoinBaseAdapter else {
+            throw MultiSwapSendHandler.SendError.noBitcoinAdapter
+        }
+        guard let sendParameters = executable.sendParameters else {
+            throw MultiSwapSendHandler.SendError.noSendParameters
+        }
+
+        let fullTransaction = try adapter.send(params: sendParameters)
+
+        return BroadcastResult(txHash: fullTransaction.header.dataHash.hs.reversedHex, trackingHandle: nil)
+    }
+}
+
+extension UtxoSwapBroadcaster: ISwapBroadcasterType {
+    static func make(blockchainType: BlockchainType, account _: Account) -> ISwapBroadcaster? {
+        guard BtcBlockchainManager.blockchainTypes.contains(blockchainType) else {
+            return nil
+        }
+
+        return UtxoSwapBroadcaster(adapterManager: Core.shared.adapterManager)
+    }
+}

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Broadcaster/Direct/ZanoSwapBroadcaster.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Broadcaster/Direct/ZanoSwapBroadcaster.swift
@@ -1,0 +1,37 @@
+import Foundation
+import MarketKit
+
+class ZanoSwapBroadcaster: ISwapBroadcaster {
+    private let adapterManager: AdapterManager
+
+    init(adapterManager: AdapterManager) {
+        self.adapterManager = adapterManager
+    }
+
+    func prepare(_ executable: ISwapExecutable) async throws -> IPrepared {
+        DirectPrepared(executable: executable)
+    }
+
+    func submit(_ prepared: IPrepared) async throws -> BroadcastResult {
+        guard let prepared = prepared as? DirectPrepared, let executable = prepared.executable as? ZanoExecutable else {
+            throw SwapBroadcasterError.dataMismatch
+        }
+        guard let adapter = adapterManager.adapter(for: executable.token) as? ZanoAdapter else {
+            throw MultiSwapSendHandler.SendError.noZanoAdapter
+        }
+
+        try adapter.send(to: executable.address, amount: executable.amount, memo: executable.memo)
+
+        return BroadcastResult(txHash: nil, trackingHandle: nil)
+    }
+}
+
+extension ZanoSwapBroadcaster: ISwapBroadcasterType {
+    static func make(blockchainType: BlockchainType, account _: Account) -> ISwapBroadcaster? {
+        guard blockchainType == .zano else {
+            return nil
+        }
+
+        return ZanoSwapBroadcaster(adapterManager: Core.shared.adapterManager)
+    }
+}

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Broadcaster/Direct/ZcashSwapBroadcaster.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Broadcaster/Direct/ZcashSwapBroadcaster.swift
@@ -1,0 +1,40 @@
+import Foundation
+import MarketKit
+
+class ZcashSwapBroadcaster: ISwapBroadcaster {
+    private let adapterManager: AdapterManager
+
+    init(adapterManager: AdapterManager) {
+        self.adapterManager = adapterManager
+    }
+
+    func prepare(_ executable: ISwapExecutable) async throws -> IPrepared {
+        DirectPrepared(executable: executable)
+    }
+
+    func submit(_ prepared: IPrepared) async throws -> BroadcastResult {
+        guard let prepared = prepared as? DirectPrepared, let executable = prepared.executable as? ZcashExecutable else {
+            throw SwapBroadcasterError.dataMismatch
+        }
+        guard let adapter = adapterManager.adapter(for: executable.token) as? ZcashAdapter else {
+            throw MultiSwapSendHandler.SendError.noZcashAdapter
+        }
+        guard let proposal = executable.proposal else {
+            throw MultiSwapSendHandler.SendError.noProposal
+        }
+
+        let hash = try await adapter.send(proposal: proposal)
+
+        return BroadcastResult(txHash: hash, trackingHandle: nil)
+    }
+}
+
+extension ZcashSwapBroadcaster: ISwapBroadcasterType {
+    static func make(blockchainType: BlockchainType, account _: Account) -> ISwapBroadcaster? {
+        guard blockchainType == .zcash else {
+            return nil
+        }
+
+        return ZcashSwapBroadcaster(adapterManager: Core.shared.adapterManager)
+    }
+}

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Broadcaster/ISwapBroadcaster.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Broadcaster/ISwapBroadcaster.swift
@@ -5,16 +5,16 @@ public protocol ISwapExecutable {}
 
 public protocol IPrepared {}
 
-public struct EoaPrepared: IPrepared {
+public struct DirectPrepared: IPrepared {
     let executable: ISwapExecutable
 }
 
 public struct BroadcastResult {
-    public let onChainTxHash: String?
+    public let txHash: String?
     public let trackingHandle: String?
 
-    public init(onChainTxHash: String?, trackingHandle: String?) {
-        self.onChainTxHash = onChainTxHash
+    public init(txHash: String?, trackingHandle: String?) {
+        self.txHash = txHash
         self.trackingHandle = trackingHandle
     }
 }
@@ -43,4 +43,5 @@ public struct SwapBroadcasterError: Error, Equatable, RawRepresentable {
     }
 
     public static var noBroadcaster: Self { .init(rawValue: "noBroadcaster") }
+    public static var dataMismatch: Self { .init(rawValue: "dataMismatch") }
 }

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Broadcaster/ISwapBroadcaster.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Broadcaster/ISwapBroadcaster.swift
@@ -1,0 +1,46 @@
+import Foundation
+import MarketKit
+
+public protocol ISwapExecutable {}
+
+public protocol IPrepared {}
+
+public struct EoaPrepared: IPrepared {
+    let executable: ISwapExecutable
+}
+
+public struct BroadcastResult {
+    public let onChainTxHash: String?
+    public let trackingHandle: String?
+
+    public init(onChainTxHash: String?, trackingHandle: String?) {
+        self.onChainTxHash = onChainTxHash
+        self.trackingHandle = trackingHandle
+    }
+}
+
+public protocol ISwapBroadcaster {
+    func prepare(_ executable: ISwapExecutable) async throws -> IPrepared
+    func submit(_ prepared: IPrepared) async throws -> BroadcastResult
+}
+
+public protocol ISwapBroadcasterType {
+    static func make(blockchainType: BlockchainType, account: Account) -> ISwapBroadcaster?
+}
+
+public protocol IPreparedDisplay: IPrepared {
+    var canSend: Bool { get }
+    var extraRateCoins: [Coin] { get }
+    func feeSections(baseToken: Token, currency: Currency, rates: [String: Decimal]) -> [SendDataSection]
+}
+
+// extensible: downstream apps add errors via `extension SwapBroadcasterError { static var ... }`
+public struct SwapBroadcasterError: Error, Equatable, RawRepresentable {
+    public let rawValue: String
+
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    public static var noBroadcaster: Self { .init(rawValue: "noBroadcaster") }
+}

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Broadcaster/ISwapBroadcaster.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Broadcaster/ISwapBroadcaster.swift
@@ -20,8 +20,14 @@ public struct BroadcastResult {
 }
 
 public protocol ISwapBroadcaster {
+    // how often the confirm screen may re-run prepare; nil = handler default
+    var expirationDuration: Int? { get }
     func prepare(_ executable: ISwapExecutable) async throws -> IPrepared
     func submit(_ prepared: IPrepared) async throws -> BroadcastResult
+}
+
+public extension ISwapBroadcaster {
+    var expirationDuration: Int? { nil }
 }
 
 public protocol ISwapBroadcasterType {

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Broadcaster/ISwapBroadcaster.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Broadcaster/ISwapBroadcaster.swift
@@ -34,10 +34,21 @@ public protocol ISwapBroadcasterType {
     static func make(blockchainType: BlockchainType, account: Account) -> ISwapBroadcaster?
 }
 
+// A self-rendering prepared owns the payment view wholesale: fee, canSend, fee rows AND validity
+// cautions (the quote's transactionError cautions describe the native path it does not use).
+// CONTRACT: since the quote's cautions are fully replaced, a conformer MUST re-validate the swap
+// input itself (canSend and/or cautions) — e.g. a balance/reserve check in the fee token.
 public protocol IPreparedDisplay: IPrepared {
     var canSend: Bool { get }
     var extraRateCoins: [Coin] { get }
     func feeSections(baseToken: Token, currency: Currency, rates: [String: Decimal]) -> [SendDataSection]
+    func cautions(baseToken: Token) -> [CautionNew]
+}
+
+public extension IPreparedDisplay {
+    func cautions(baseToken _: Token) -> [CautionNew] {
+        []
+    }
 }
 
 // extensible: downstream apps add errors via `extension SwapBroadcasterError { static var ... }`

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Broadcaster/SwapBroadcasterFactory.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Broadcaster/SwapBroadcasterFactory.swift
@@ -1,0 +1,28 @@
+import MarketKit
+
+public enum SwapBroadcasterFactory {
+    private static var types: [ISwapBroadcasterType.Type] = []
+
+    public static func register(_ types: [ISwapBroadcasterType.Type]) {
+        Self.types.append(contentsOf: types)
+    }
+
+    public static func prepend(_ type: ISwapBroadcasterType.Type) {
+        types.insert(type, at: 0)
+    }
+
+    static func broadcaster(blockchainType: BlockchainType, account: Account) throws -> ISwapBroadcaster {
+        for type in types {
+            if let broadcaster = type.make(blockchainType: blockchainType, account: account) {
+                return broadcaster
+            }
+        }
+
+        throw SwapBroadcasterError.noBroadcaster
+    }
+
+    // test seam: registry is global mutable state
+    static func reset() {
+        types = []
+    }
+}

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Broadcaster/SwapBroadcasterFactory.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Broadcaster/SwapBroadcasterFactory.swift
@@ -26,3 +26,17 @@ public enum SwapBroadcasterFactory {
         types = []
     }
 }
+
+public extension SwapBroadcasterFactory {
+    static let unstoppableBroadcasters: [ISwapBroadcasterType.Type] = [
+        EvmSwapBroadcaster.self,
+        UtxoSwapBroadcaster.self,
+        ZcashSwapBroadcaster.self,
+        TronSwapBroadcaster.self,
+        TonSwapBroadcaster.self,
+        StellarSwapBroadcaster.self,
+        SolanaSwapBroadcaster.self,
+        MoneroSwapBroadcaster.self,
+        ZanoSwapBroadcaster.self,
+    ]
+}

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Broadcaster/SwapExecutables.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Broadcaster/SwapExecutables.swift
@@ -1,0 +1,80 @@
+import BigInt
+import BitcoinCore
+import EvmKit
+import Foundation
+import MarketKit
+import MoneroKit
+import TronKit
+import ZcashLightClientKit
+
+// returned by the SwapFinalQuote base class; no broadcaster accepts it
+struct UnsupportedExecutable: ISwapExecutable {}
+
+public struct EvmExecutable: ISwapExecutable {
+    public let transactionData: TransactionData?
+    public let gasPrice: GasPrice?
+    public let gasLimit: Int?
+    public let nonce: Int?
+    public let privateSend: Bool
+    public let approval: SwapApproval?
+}
+
+// router-approve intent, exact amount; how it turns into on-chain approve call(s)
+// is the consuming broadcaster's decision, not encoded here
+public struct SwapApproval {
+    public let spender: EvmKit.Address
+    public let token: EvmKit.Address
+    public let amount: BigUInt
+}
+
+public struct TronExecutable: ISwapExecutable {
+    public let created: CreatedTransactionResponse
+    public let transferIntent: TronTransferIntent?
+}
+
+// plain p2p transfer description for routes that are a single token transfer;
+// how it is broadcast is the consuming broadcaster's decision
+public struct TronTransferIntent {
+    public let token: TronKit.Address
+    public let receiver: TronKit.Address
+    public let value: BigUInt
+}
+
+public struct UtxoExecutable: ISwapExecutable {
+    public let token: Token
+    public let sendParameters: SendParameters?
+}
+
+public struct ZcashExecutable: ISwapExecutable {
+    public let token: Token
+    public let proposal: Proposal?
+}
+
+public struct TonExecutable: ISwapExecutable {
+    public let transactionParam: SendTransactionParam
+}
+
+public struct StellarExecutable: ISwapExecutable {
+    public let token: Token
+    let transactionData: StellarSendHelper.TransactionData
+}
+
+public struct MoneroExecutable: ISwapExecutable {
+    public let token: Token
+    public let address: String
+    public let amount: MoneroSendAmount
+    public let priority: SendPriority
+    public let memo: String?
+}
+
+public struct ZanoExecutable: ISwapExecutable {
+    public let token: Token
+    public let address: String
+    public let amount: ZanoSendAmount
+    public let memo: String?
+}
+
+public struct SolanaExecutable: ISwapExecutable {
+    public let token: Token
+    public let rawTransaction: Data
+}

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Broadcaster/SwapExecutables.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Broadcaster/SwapExecutables.swift
@@ -11,6 +11,7 @@ import ZcashLightClientKit
 struct UnsupportedExecutable: ISwapExecutable {}
 
 public struct EvmExecutable: ISwapExecutable {
+    public let token: Token
     public let transactionData: TransactionData?
     public let gasPrice: GasPrice?
     public let gasLimit: Int?
@@ -25,6 +26,28 @@ public struct SwapApproval {
     public let spender: EvmKit.Address
     public let token: EvmKit.Address
     public let amount: BigUInt
+}
+
+public extension SwapApproval {
+    // eip20 router-approve intent for the exact swap input; nil for a native tokenIn (no approve needed,
+    // and not AA-eligible since the paymaster fee token must be an eip20).
+    static func build(spender: EvmKit.Address, tokenIn: Token, amountIn: Decimal) -> SwapApproval? {
+        guard case let .eip20(tokenAddress) = tokenIn.type else {
+            NSLog("[AASWAP] SwapApproval.build: tokenIn NOT eip20 (type=\(tokenIn.type)) -> nil approval")
+            return nil
+        }
+        guard let token = try? EvmKit.Address(hex: tokenAddress) else {
+            NSLog("[AASWAP] SwapApproval.build: bad token address \(tokenAddress) -> nil approval")
+            return nil
+        }
+        guard let amount = tokenIn.rawAmount(amountIn) else {
+            NSLog("[AASWAP] SwapApproval.build: rawAmount(\(amountIn)) nil -> nil approval")
+            return nil
+        }
+
+        NSLog("[AASWAP] SwapApproval.build: OK spender=\(spender.eip55) amount=\(amount)")
+        return SwapApproval(spender: spender, token: token, amount: amount)
+    }
 }
 
 public struct TronExecutable: ISwapExecutable {

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Broadcaster/SwapExecutables.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Broadcaster/SwapExecutables.swift
@@ -33,19 +33,15 @@ public extension SwapApproval {
     // and not AA-eligible since the paymaster fee token must be an eip20).
     static func build(spender: EvmKit.Address, tokenIn: Token, amountIn: Decimal) -> SwapApproval? {
         guard case let .eip20(tokenAddress) = tokenIn.type else {
-            NSLog("[AASWAP] SwapApproval.build: tokenIn NOT eip20 (type=\(tokenIn.type)) -> nil approval")
             return nil
         }
         guard let token = try? EvmKit.Address(hex: tokenAddress) else {
-            NSLog("[AASWAP] SwapApproval.build: bad token address \(tokenAddress) -> nil approval")
             return nil
         }
         guard let amount = tokenIn.rawAmount(amountIn) else {
-            NSLog("[AASWAP] SwapApproval.build: rawAmount(\(amountIn)) nil -> nil approval")
             return nil
         }
 
-        NSLog("[AASWAP] SwapApproval.build: OK spender=\(spender.eip55) amount=\(amount)")
         return SwapApproval(spender: spender, token: token, amount: amount)
     }
 }

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Broadcaster/SwapExecutables.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Broadcaster/SwapExecutables.swift
@@ -15,7 +15,7 @@ public struct EvmExecutable: ISwapExecutable {
     public let gasPrice: GasPrice?
     public let gasLimit: Int?
     public let nonce: Int?
-    public let privateSend: Bool
+    public let mevProtectionAllowed: Bool
     public let approval: SwapApproval?
 }
 

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Broadcaster/SwapExecutables.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Broadcaster/SwapExecutables.swift
@@ -29,8 +29,7 @@ public struct SwapApproval {
 }
 
 public extension SwapApproval {
-    // eip20 router-approve intent for the exact swap input; nil for a native tokenIn (no approve needed,
-    // and not AA-eligible since the paymaster fee token must be an eip20).
+    // eip20 router-approve intent for the exact swap input; nil for a native tokenIn (no approve needed).
     static func build(spender: EvmKit.Address, tokenIn: Token, amountIn: Decimal) -> SwapApproval? {
         guard case let .eip20(tokenAddress) = tokenIn.type else {
             return nil

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/MultiSwapHelpers.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/MultiSwapHelpers.swift
@@ -1,8 +1,8 @@
 import Foundation
 import MarketKit
 
-class MultiSwapHelpers {
-    static func estimate(tokenIn: Token, tokenOut: Token) -> TimeInterval? {
+public class MultiSwapHelpers {
+    public static func estimate(tokenIn: Token, tokenOut: Token) -> TimeInterval? {
         if tokenIn.blockchainType == tokenOut.blockchainType {
             return tokenIn.blockchainType.blockTime
         }

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/MultiSwapSendHandler.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/MultiSwapSendHandler.swift
@@ -1,11 +1,6 @@
-import BigInt
 import Combine
-import Eip20Kit
-import EvmKit
 import Foundation
 import MarketKit
-import SolanaKit
-import ZanoKit
 
 class MultiSwapSendHandler: SendHandler {
     override class func instance(sendData: WalletCore.SendData) -> ISendHandler? {
@@ -17,9 +12,6 @@ class MultiSwapSendHandler: SendHandler {
     private let marketKit = Core.shared.marketKit
     private let accountManager = Core.shared.accountManager
     private let walletManager = Core.shared.walletManager
-    private let evmBlockchainManager = Core.shared.evmBlockchainManager
-    private let adapterManager = Core.shared.adapterManager
-    private let tronKitManager = Core.shared.tronAccountManager.tronKitManager
     private let swapHistoryManager = Core.shared.swapHistoryManager
     private let mevProtectionHelper = MevProtectionHelper()
 
@@ -117,9 +109,18 @@ extension MultiSwapSendHandler: ISendHandler {
             transactionSettings: transactionSettings
         )
 
+        guard let account = accountManager.activeAccount else {
+            throw SendError.noActiveAccount
+        }
+
+        // MEV eligibility rides on the EVM quote (set by the provider); the toggle itself
+        // is read live at submit-time by the broadcaster (routing flag, not tx content)
         let otherSections = provider.mevProtectionAllowed(tokenIn: tokenIn, tokenOut: tokenOut) ? [mevProtectionHelper.section()] : []
 
-        return SendData(tokenIn: tokenIn, tokenOut: tokenOut, amountIn: amountIn, quote: quote, otherSections: otherSections)
+        let broadcaster = try SwapBroadcasterFactory.broadcaster(blockchainType: tokenIn.blockchainType, account: account)
+        let prepared = try await broadcaster.prepare(quote.executable(tokenIn: tokenIn))
+
+        return SendData(tokenIn: tokenIn, tokenOut: tokenOut, amountIn: amountIn, quote: quote, prepared: prepared, broadcaster: broadcaster, otherSections: otherSections)
     }
 
     func send(data: ISendData) async throws {
@@ -127,125 +128,8 @@ extension MultiSwapSendHandler: ISendHandler {
             throw SendError.invalidData
         }
 
-        var txHash: String?
-
-        if let quote = data.quote as? EvmSwapFinalQuote {
-            guard let transactionData = quote.transactionData else {
-                throw SendError.invalidTransactionData
-            }
-
-            guard let gasLimit = quote.evmFeeData?.surchargedGasLimit else {
-                throw SendError.noGasLimit
-            }
-
-            guard let gasPrice = quote.gasPrice else {
-                throw SendError.noGasPrice
-            }
-
-            guard let evmKitWrapper = try evmBlockchainManager.evmKitManager(blockchainType: tokenIn.blockchainType).evmKitWrapper else {
-                throw SendError.noEvmKitWrapper
-            }
-
-            let fullTransaction = try await evmKitWrapper.send(
-                transactionData: transactionData,
-                gasPrice: gasPrice,
-                gasLimit: gasLimit,
-                privateSend: provider.mevProtectionAllowed(tokenIn: tokenIn, tokenOut: tokenOut) && mevProtectionHelper.isActive,
-                nonce: quote.nonce
-            )
-
-            txHash = fullTransaction.transaction.hash.hs.hexString
-        } else if let quote = data.quote as? UtxoSwapFinalQuote {
-            guard let adapter = adapterManager.adapter(for: tokenIn) as? BitcoinBaseAdapter else {
-                throw SendError.noBitcoinAdapter
-            }
-
-            guard let sendParameters = quote.sendParameters else {
-                throw SendError.noSendParameters
-            }
-
-            let fullTransaction = try adapter.send(params: sendParameters)
-
-            txHash = fullTransaction.header.dataHash.hs.reversedHex
-        } else if let quote = data.quote as? ZcashSwapFinalQuote {
-            guard let adapter = adapterManager.adapter(for: tokenIn) as? ZcashAdapter else {
-                throw SendError.noZcashAdapter
-            }
-
-            guard let proposal = quote.proposal else {
-                throw SendError.noProposal
-            }
-
-            let hash = try await adapter.send(proposal: proposal)
-
-            txHash = hash
-        } else if let quote = data.quote as? TonSwapFinalQuote {
-            guard let account = Core.shared.accountManager.activeAccount else {
-                throw SendError.noTonAdapter
-            }
-
-            let (publicKey, secretKey) = try TonKitManager.keyPair(accountType: account.type)
-            let contract = TonKitManager.contract(publicKey: publicKey)
-
-            let transferData = try TonSendHelper.transferData(
-                param: quote.transactionParam,
-                contract: contract
-            )
-
-            _ = try await TonSendHelper.send(
-                transferData: transferData,
-                contract: contract,
-                secretKey: secretKey
-            )
-        } else if let quote = data.quote as? TronSwapFinalQuote {
-            guard let tronKitWrapper = tronKitManager.tronKitWrapper else {
-                throw SendError.noTronKitWrapper
-            }
-
-            _ = try await tronKitWrapper.send(createdTranaction: quote.createdTransaction)
-        } else if let quote = data.quote as? StellarSwapFinalQuote {
-            guard let account = accountManager.activeAccount else {
-                throw SendError.noActiveAccount
-            }
-
-            let keyPair = try StellarKitManager.keyPair(accountType: account.type)
-            try await StellarSendHelper.send(
-                transactionData: quote.transactionData,
-                token: tokenIn,
-                adjustNativeBalance: false,
-                keyPair: keyPair
-            )
-        } else if let quote = data.quote as? MoneroSwapFinalQuote {
-            guard let adapter = adapterManager.adapter(for: tokenIn) as? MoneroAdapter else {
-                throw SendError.noMoneroAdapter
-            }
-
-            try adapter.send(
-                to: quote.address,
-                amount: quote.amount,
-                priority: quote.priority,
-                memo: quote.memo
-            )
-        } else if let quote = data.quote as? ZanoSwapFinalQuote {
-            guard let adapter = adapterManager.adapter(for: tokenIn) as? ZanoAdapter else {
-                throw SendError.noZanoAdapter
-            }
-
-            try adapter.send(to: quote.address, amount: quote.amount, memo: quote.memo)
-        } else if let quote = data.quote as? SolanaSwapFinalQuote {
-            guard let account = accountManager.activeAccount else {
-                throw SendError.noActiveAccount
-            }
-
-            let signer = try SolanaKitManager.signer(accountType: account.type)
-
-            guard let adapter = adapterManager.adapter(for: tokenIn) as? ISendSolanaAdapter else {
-                throw SendError.noSolanaAdapter
-            }
-
-            let fullTransaction = try await adapter.sendRawTransaction(rawTransaction: quote.rawTransaction, signer: signer)
-            txHash = fullTransaction.transaction.hash
-        }
+        let result = try await data.broadcaster.submit(data.prepared)
+        let txHash = result.txHash
 
         if let account = accountManager.activeAccount {
             let swap = Swap(
@@ -287,26 +171,32 @@ extension MultiSwapSendHandler {
         let tokenOut: Token
         let amountIn: Decimal
         let quote: SwapFinalQuote
+        let prepared: IPrepared
+        let broadcaster: ISwapBroadcaster
         let otherSections: [SendDataSection]
 
-        init(tokenIn: Token, tokenOut: Token, amountIn: Decimal, quote: SwapFinalQuote, otherSections: [SendDataSection]) {
+        init(tokenIn: Token, tokenOut: Token, amountIn: Decimal, quote: SwapFinalQuote, prepared: IPrepared, broadcaster: ISwapBroadcaster, otherSections: [SendDataSection]) {
             self.tokenIn = tokenIn
             self.tokenOut = tokenOut
             self.amountIn = amountIn
             self.quote = quote
+            self.prepared = prepared
+            self.broadcaster = broadcaster
             self.otherSections = otherSections
         }
 
+        // fee and canSend are type-selected: a prepared that renders itself (IPreparedDisplay)
+        // is the source of truth; DirectPrepared keeps the quote-based behaviour
         var feeData: FeeData? {
-            quote.feeData
+            prepared is IPreparedDisplay ? nil : quote.feeData
         }
 
         var canSend: Bool {
-            quote.canSwap
+            (prepared as? IPreparedDisplay)?.canSend ?? quote.canSwap
         }
 
         var rateCoins: [Coin] {
-            [tokenIn.coin, tokenOut.coin]
+            [tokenIn.coin, tokenOut.coin] + ((prepared as? IPreparedDisplay)?.extraRateCoins ?? [])
         }
 
         var customSendButtonTitle: String? {
@@ -413,15 +303,12 @@ extension MultiSwapSendHandler {
         case invalidTransactionData
         case noGasLimit
         case noGasPrice
-        case noEvmKitWrapper
-        case noTronKitWrapper
         case noBitcoinAdapter
         case noSendParameters
         case noZcashAdapter
         case noMoneroAdapter
         case noZanoAdapter
         case noProposal
-        case noTonAdapter
         case noActiveAccount
         case noSolanaAdapter
 

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/MultiSwapSendHandler.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/MultiSwapSendHandler.swift
@@ -104,7 +104,6 @@ extension MultiSwapSendHandler: ISendHandler {
     }
 
     func sendData(transactionSettings: TransactionSettings?) async throws -> ISendData {
-        NSLog("[AASWAP] sendData ENTRY: provider=\(provider.id) tokenIn=\(tokenIn.coin.code)/\(tokenIn.type) tokenOut=\(tokenOut.coin.code) broadcaster=\(broadcaster.map { String(describing: type(of: $0)) } ?? "nil")")
         let quote = try await provider.confirmationQuote(
             multiSwapQuote: multiSwapQuote,
             tokenIn: tokenIn,
@@ -120,7 +119,6 @@ extension MultiSwapSendHandler: ISendHandler {
         }
 
         guard let broadcaster else {
-            NSLog("[AASWAP] sendData: no broadcaster resolved -> noBroadcaster")
             throw SwapBroadcasterError.noBroadcaster
         }
 
@@ -129,7 +127,6 @@ extension MultiSwapSendHandler: ISendHandler {
         let otherSections = provider.mevProtectionAllowed(tokenIn: tokenIn, tokenOut: tokenOut) ? [mevProtectionHelper.section()] : []
 
         let executable = quote.executable(tokenIn: tokenIn)
-        NSLog("[AASWAP] sendData: provider=\(provider.id) quote=\(type(of: quote)) broadcaster=\(type(of: broadcaster)) executable=\(type(of: executable))")
         let prepared = try await broadcaster.prepare(executable)
 
         return SendData(tokenIn: tokenIn, tokenOut: tokenOut, amountIn: amountIn, quote: quote, prepared: prepared, broadcaster: broadcaster, otherSections: otherSections)

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/MultiSwapSendHandler.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/MultiSwapSendHandler.swift
@@ -104,6 +104,7 @@ extension MultiSwapSendHandler: ISendHandler {
     }
 
     func sendData(transactionSettings: TransactionSettings?) async throws -> ISendData {
+        NSLog("[AASWAP] sendData ENTRY: provider=\(provider.id) tokenIn=\(tokenIn.coin.code)/\(tokenIn.type) tokenOut=\(tokenOut.coin.code) broadcaster=\(broadcaster.map { String(describing: type(of: $0)) } ?? "nil")")
         let quote = try await provider.confirmationQuote(
             multiSwapQuote: multiSwapQuote,
             tokenIn: tokenIn,
@@ -119,6 +120,7 @@ extension MultiSwapSendHandler: ISendHandler {
         }
 
         guard let broadcaster else {
+            NSLog("[AASWAP] sendData: no broadcaster resolved -> noBroadcaster")
             throw SwapBroadcasterError.noBroadcaster
         }
 
@@ -126,7 +128,9 @@ extension MultiSwapSendHandler: ISendHandler {
         // is read live at submit-time by the broadcaster (routing flag, not tx content)
         let otherSections = provider.mevProtectionAllowed(tokenIn: tokenIn, tokenOut: tokenOut) ? [mevProtectionHelper.section()] : []
 
-        let prepared = try await broadcaster.prepare(quote.executable(tokenIn: tokenIn))
+        let executable = quote.executable(tokenIn: tokenIn)
+        NSLog("[AASWAP] sendData: provider=\(provider.id) quote=\(type(of: quote)) broadcaster=\(type(of: broadcaster)) executable=\(type(of: executable))")
+        let prepared = try await broadcaster.prepare(executable)
 
         return SendData(tokenIn: tokenIn, tokenOut: tokenOut, amountIn: amountIn, quote: quote, prepared: prepared, broadcaster: broadcaster, otherSections: otherSections)
     }
@@ -213,7 +217,14 @@ extension MultiSwapSendHandler {
         }
 
         func cautions(baseToken: Token, currency: Currency, rates: [String: Decimal]) -> [CautionNew] {
-            quote.cautions(baseToken: baseToken) + priceImpactCautions(baseToken: baseToken, currency: currency, rates: rates)
+            // a self-rendering prepared owns the payment view including its validity cautions; the quote's
+            // transactionError cautions describe the native path it does not use. price-impact cautions
+            // are swap-level and shared by both paths
+            if let display = prepared as? IPreparedDisplay {
+                return display.cautions(baseToken: baseToken) + priceImpactCautions(baseToken: baseToken, currency: currency, rates: rates)
+            }
+
+            return quote.cautions(baseToken: baseToken) + priceImpactCautions(baseToken: baseToken, currency: currency, rates: rates)
         }
 
         private func priceImpact(baseToken _: Token, currency _: Currency, rates: [String: Decimal]) -> Decimal? {

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/MultiSwapSendHandler.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/MultiSwapSendHandler.swift
@@ -143,6 +143,7 @@ extension MultiSwapSendHandler: ISendHandler {
             let swap = Swap(
                 uid: UUID().uuidString,
                 txHash: txHash,
+                trackingHandle: result.trackingHandle,
                 accountId: account.id,
                 providerId: provider.id,
                 status: .pending,

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/MultiSwapSendHandler.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/MultiSwapSendHandler.swift
@@ -291,6 +291,17 @@ extension MultiSwapSendHandler {
                 baseTokenRate: rates[baseToken.coin.uid]
             ))
 
+            // a self-rendering prepared (IPreparedDisplay) supplies its own fee sections;
+            // the quote's fee rows are shown only on the direct path
+            if let display = prepared as? IPreparedDisplay {
+                return [
+                    flowSection(baseToken: baseToken, currency: currency, rates: rates),
+                    .init(fields, isMain: false),
+                ] + display.feeSections(baseToken: baseToken, currency: currency, rates: rates) + otherSections
+            }
+
+            fields.append(contentsOf: quote.feeFields(baseToken: baseToken, currency: currency, baseTokenRate: rates[baseToken.coin.uid]))
+
             return [
                 flowSection(baseToken: baseToken, currency: currency, rates: rates),
                 .init(fields, isMain: false),

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/MultiSwapSendHandler.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/MultiSwapSendHandler.swift
@@ -28,6 +28,11 @@ class MultiSwapSendHandler: SendHandler {
     private var slippage = MultiSwapSlippage.default
     private var recipient: String?
 
+    // resolved once per confirmation: the mechanism is fixed by (chain, account)
+    private lazy var broadcaster: ISwapBroadcaster? = accountManager.activeAccount.flatMap {
+        try? SwapBroadcasterFactory.broadcaster(blockchainType: tokenIn.blockchainType, account: $0)
+    }
+
     private let refreshSubject = PassthroughSubject<Void, Never>()
 
     init(baseToken: Token, tokenIn: Token, tokenOut: Token, amountIn: Decimal, provider: IMultiSwapProvider, multiSwapQuote: MultiSwapQuote) {
@@ -46,7 +51,7 @@ extension MultiSwapSendHandler: ISendHandler {
     }
 
     var expirationDuration: Int? {
-        15
+        broadcaster?.expirationDuration ?? 15
     }
 
     // The swap confirm screen holds a committed provider quote (USwap's /v2/swap, and the
@@ -109,15 +114,18 @@ extension MultiSwapSendHandler: ISendHandler {
             transactionSettings: transactionSettings
         )
 
-        guard let account = accountManager.activeAccount else {
+        guard accountManager.activeAccount != nil else {
             throw SendError.noActiveAccount
+        }
+
+        guard let broadcaster else {
+            throw SwapBroadcasterError.noBroadcaster
         }
 
         // MEV eligibility rides on the EVM quote (set by the provider); the toggle itself
         // is read live at submit-time by the broadcaster (routing flag, not tx content)
         let otherSections = provider.mevProtectionAllowed(tokenIn: tokenIn, tokenOut: tokenOut) ? [mevProtectionHelper.section()] : []
 
-        let broadcaster = try SwapBroadcasterFactory.broadcaster(blockchainType: tokenIn.blockchainType, account: account)
         let prepared = try await broadcaster.prepare(quote.executable(tokenIn: tokenIn))
 
         return SendData(tokenIn: tokenIn, tokenOut: tokenOut, amountIn: amountIn, quote: quote, prepared: prepared, broadcaster: broadcaster, otherSections: otherSections)

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/AllBridgeProvider/AllBridgeMultiSwapProvider.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/AllBridgeProvider/AllBridgeMultiSwapProvider.swift
@@ -347,7 +347,7 @@ class AllBridgeMultiSwapProvider: IMultiSwapProvider {
             var evmFeeData: EvmFeeData?
             var transactionError: Error?
 
-            if let evmKitWrapper = try evmBlockchainManager.evmKitManager(blockchainType: blockchainType).evmKitWrapper, let gasPriceData {
+            if let evmKitWrapper = try evmBlockchainManager.evmKitManager(blockchainType: blockchainType).evmKitWrapper, evmKitWrapper.signer != nil, let gasPriceData {
                 do {
                     let _evmFeeData = try await evmFeeEstimator.estimateFee(evmKitWrapper: evmKitWrapper, transactionData: transactionData, gasPriceData: gasPriceData)
                     evmFeeData = _evmFeeData

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/AllBridgeProvider/AllBridgeMultiSwapProvider.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/AllBridgeProvider/AllBridgeMultiSwapProvider.swift
@@ -361,7 +361,6 @@ class AllBridgeMultiSwapProvider: IMultiSwapProvider {
             }
 
             // router-approve intent for the AA broadcaster: the bridge router pulls eip20 via transferFrom
-            NSLog("[AASWAP] AllBridge confirmationQuote: router=\(router) tokenIn.type=\(tokenIn.type)")
             let approval = (try? EvmKit.Address(hex: router)).flatMap { SwapApproval.build(spender: $0, tokenIn: tokenIn, amountIn: amountIn) }
 
             return EvmSwapFinalQuote(

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/AllBridgeProvider/AllBridgeMultiSwapProvider.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/AllBridgeProvider/AllBridgeMultiSwapProvider.swift
@@ -347,7 +347,7 @@ class AllBridgeMultiSwapProvider: IMultiSwapProvider {
             var evmFeeData: EvmFeeData?
             var transactionError: Error?
 
-            if let evmKitWrapper = try evmBlockchainManager.evmKitManager(blockchainType: blockchainType).evmKitWrapper, evmKitWrapper.signer != nil, let gasPriceData {
+            if let evmKitWrapper = try evmBlockchainManager.evmKitManager(blockchainType: blockchainType).evmKitWrapper, let gasPriceData {
                 do {
                     let _evmFeeData = try await evmFeeEstimator.estimateFee(evmKitWrapper: evmKitWrapper, transactionData: transactionData, gasPriceData: gasPriceData)
                     evmFeeData = _evmFeeData
@@ -360,6 +360,10 @@ class AllBridgeMultiSwapProvider: IMultiSwapProvider {
                 }
             }
 
+            // router-approve intent for the AA broadcaster: the bridge router pulls eip20 via transferFrom
+            NSLog("[AASWAP] AllBridge confirmationQuote: router=\(router) tokenIn.type=\(tokenIn.type)")
+            let approval = (try? EvmKit.Address(hex: router)).flatMap { SwapApproval.build(spender: $0, tokenIn: tokenIn, amountIn: amountIn) }
+
             return EvmSwapFinalQuote(
                 expectedBuyAmount: amountOut,
                 transactionData: transactionData,
@@ -371,6 +375,7 @@ class AllBridgeMultiSwapProvider: IMultiSwapProvider {
                 evmFeeData: evmFeeData,
                 nonce: transactionSettings?.nonce,
                 mevProtectionAllowed: mevProtectionAllowed(tokenIn: tokenIn, tokenOut: tokenOut),
+                approval: approval,
                 toAddress: recipient
             )
         } else if tokenIn.blockchainType == .tron {

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/AllBridgeProvider/AllBridgeMultiSwapProvider.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/AllBridgeProvider/AllBridgeMultiSwapProvider.swift
@@ -370,6 +370,7 @@ class AllBridgeMultiSwapProvider: IMultiSwapProvider {
                 gasPrice: gasPriceData?.userDefined,
                 evmFeeData: evmFeeData,
                 nonce: transactionSettings?.nonce,
+                mevProtectionAllowed: mevProtectionAllowed(tokenIn: tokenIn, tokenOut: tokenOut),
                 toAddress: recipient
             )
         } else if tokenIn.blockchainType == .tron {

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/AllBridgeProvider/AllBridgeMultiSwapProvider.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/AllBridgeProvider/AllBridgeMultiSwapProvider.swift
@@ -360,7 +360,7 @@ class AllBridgeMultiSwapProvider: IMultiSwapProvider {
                 }
             }
 
-            // router-approve intent for the AA broadcaster: the bridge router pulls eip20 via transferFrom
+            // router-approve intent: the bridge router pulls eip20 via transferFrom
             let approval = (try? EvmKit.Address(hex: router)).flatMap { SwapApproval.build(spender: $0, tokenIn: tokenIn, amountIn: amountIn) }
 
             return EvmSwapFinalQuote(

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/AllowancePolicy.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/AllowancePolicy.swift
@@ -1,0 +1,35 @@
+import Foundation
+import MarketKit
+
+public enum AllowancePolicyState: Equatable {
+    case notRequired
+}
+
+public protocol IAllowancePolicy {
+    static func allowanceState(spenderAddress: Address, token: Token, amount: Decimal) async -> AllowancePolicyState?
+}
+
+// registry of externally-supplied allowance policies; first non-nil verdict wins,
+// otherwise MultiSwapAllowanceHelper falls through to its own on-chain check
+public enum AllowancePolicy {
+    private static var policies: [IAllowancePolicy.Type] = []
+
+    public static func prepend(_ policy: IAllowancePolicy.Type) {
+        policies.insert(policy, at: 0)
+    }
+
+    static func state(spenderAddress: Address, token: Token, amount: Decimal) async -> AllowancePolicyState? {
+        for policy in policies {
+            if let state = await policy.allowanceState(spenderAddress: spenderAddress, token: token, amount: amount) {
+                return state
+            }
+        }
+
+        return nil
+    }
+
+    // test seam: registry is global mutable state
+    static func reset() {
+        policies = []
+    }
+}

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/ApprovalReset.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/ApprovalReset.swift
@@ -1,8 +1,7 @@
 import MarketKit
 
 // Tokens that revert on a non-zero -> non-zero approve (canonical USDT): such an approve must be
-// preceded by an approve(0). Pure domain rule, shared by the EOA pre-swap flow (MultiSwapAllowanceHelper)
-// and the AA swap broadcaster.
+// preceded by an approve(0). Pure domain rule, shared by swap flows that build approvals.
 public enum ApprovalReset {
     private static let addressesForRevoke: [BlockchainType: String] = [
         .ethereum: "0xdac17f958d2ee523a2206206994597c13d831ec7",

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/ApprovalReset.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/ApprovalReset.swift
@@ -1,0 +1,21 @@
+import MarketKit
+
+// Tokens that revert on a non-zero -> non-zero approve (canonical USDT): such an approve must be
+// preceded by an approve(0). Pure domain rule, shared by the EOA pre-swap flow (MultiSwapAllowanceHelper)
+// and the AA swap broadcaster.
+public enum ApprovalReset {
+    private static let addressesForRevoke: [BlockchainType: String] = [
+        .ethereum: "0xdac17f958d2ee523a2206206994597c13d831ec7",
+        .tron: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+    ]
+
+    public static func required(token: Token) -> Bool {
+        for (blockchainType, addressToRevoke) in addressesForRevoke {
+            if blockchainType == token.blockchainType, case let .eip20(address) = token.type, address.lowercased() == addressToRevoke.lowercased() {
+                return true
+            }
+        }
+
+        return false
+    }
+}

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/BaseEvmMultiSwapProvider.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/BaseEvmMultiSwapProvider.swift
@@ -4,42 +4,55 @@ import Foundation
 import MarketKit
 import SwiftUI
 
-class BaseEvmMultiSwapProvider: IMultiSwapProvider {
+public class BaseEvmMultiSwapProvider: IMultiSwapProvider {
     private let adapterManager = Core.shared.adapterManager
     private let localStorage = Core.shared.localStorage
     let evmBlockchainManager = Core.shared.evmBlockchainManager
     private let allowanceHelper = MultiSwapAllowanceHelper()
 
-    var id: String { fatalError("Must be implemented in subclass") }
-    var name: String { fatalError("Must be implemented in subclass") }
-    var type: SwapProviderType { fatalError("Must be implemented in subclass") }
-    var icon: String { fatalError("Must be implemented in subclass") }
+    public var id: String { fatalError("Must be implemented in subclass") }
+    public var name: String { fatalError("Must be implemented in subclass") }
+    public var type: SwapProviderType { fatalError("Must be implemented in subclass") }
+    public var icon: String { fatalError("Must be implemented in subclass") }
+    public var requireTerms: Bool { false }
+    public var syncPublisher: AnyPublisher<Void, Never>? { nil }
 
-    func supports(tokenIn _: Token, tokenOut _: Token) -> Bool {
+    public func slippageSupported(tokenIn _: Token, tokenOut _: Token) -> Bool {
+        true
+    }
+
+    public func supports(tokenIn _: Token, tokenOut _: Token) -> Bool {
         fatalError("Must be implemented in subclass")
     }
 
-    func mevProtectionAllowed(tokenIn: Token, tokenOut: Token) -> Bool {
+    public func mevProtectionAllowed(tokenIn: Token, tokenOut: Token) -> Bool {
         MerkleTransactionAdapter.allowProtection(blockchainTypeIn: tokenIn.blockchainType, blockchainTypeOut: tokenOut.blockchainType)
     }
 
-    func quote(tokenIn _: Token, tokenOut _: Token, amountIn _: Decimal) async throws -> MultiSwapQuote {
+    public func quote(tokenIn _: Token, tokenOut _: Token, amountIn _: Decimal) async throws -> MultiSwapQuote {
         fatalError("Must be implemented in subclass")
     }
 
-    func confirmationQuote(multiSwapQuote _: MultiSwapQuote, tokenIn _: Token, tokenOut _: Token, amountIn _: Decimal, slippage _: Decimal, recipient _: String?, transactionSettings _: TransactionSettings?) async throws -> SwapFinalQuote {
+    public func confirmationQuote(multiSwapQuote _: MultiSwapQuote, tokenIn _: Token, tokenOut _: Token, amountIn _: Decimal, slippage _: Decimal, recipient _: String?, transactionSettings _: TransactionSettings?) async throws -> SwapFinalQuote {
         fatalError("Must be implemented in subclass")
+    }
+
+    public func validateTrustedProvider(tokenIn _: Token, amountIn _: Decimal) async throws -> Bool? {
+        if let result = Core.instance?.localStorage.debuggingAmlCheckResult {
+            return result == .dirty ? false : nil
+        }
+        return true
     }
 
     func settingsView(tokenIn _: Token, tokenOut _: Token, quote _: MultiSwapQuote, onChangeSettings _: @escaping () -> Void) -> AnyView {
         fatalError("settingsView(tokenIn:tokenOut:onChangeSettings:) has not been implemented")
     }
 
-    func preSwapView(step: MultiSwapPreSwapStep, tokenIn: Token, tokenOut _: Token, amount: Decimal, isPresented: Binding<Bool>, onSuccess: @escaping () -> Void) -> AnyView {
+    public func preSwapView(step: MultiSwapPreSwapStep, tokenIn: Token, tokenOut _: Token, amount: Decimal, isPresented: Binding<Bool>, onSuccess: @escaping () -> Void) -> AnyView {
         allowanceHelper.preSwapView(step: step, tokenIn: tokenIn, amount: amount, isPresented: isPresented, onSuccess: onSuccess)
     }
 
-    func track(swap _: Swap) async throws -> Swap {
+    public func track(swap _: Swap) async throws -> Swap {
         fatalError("Must be implemented in subclass")
     }
 

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/BaseUniswapMultiSwapProvider.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/BaseUniswapMultiSwapProvider.swift
@@ -28,7 +28,7 @@ class BaseUniswapMultiSwapProvider: BaseEvmMultiSwapProvider {
 
         let evmKit = evmKitWrapper.evmKit
 
-        if let gasPriceData {
+        if evmKitWrapper.signer != nil, let gasPriceData {
             do {
                 let transactionData = try transactionData(receiveAddress: evmKit.receiveAddress, chain: evmKit.chain, trade: quote.trade, tradeOptions: quote.tradeOptions)
                 txData = transactionData

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/BaseUniswapMultiSwapProvider.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/BaseUniswapMultiSwapProvider.swift
@@ -4,16 +4,16 @@ import MarketKit
 import SwiftUI
 import UniswapKit
 
-class BaseUniswapMultiSwapProvider: BaseEvmMultiSwapProvider {
+public class BaseUniswapMultiSwapProvider: BaseEvmMultiSwapProvider {
     let marketKit = Core.shared.marketKit
     let evmSyncSourceManager = Core.shared.evmSyncSourceManager
     let evmFeeEstimator = EvmFeeEstimator()
 
-    override func quote(tokenIn: MarketKit.Token, tokenOut: MarketKit.Token, amountIn: Decimal) async throws -> MultiSwapQuote {
+    override public func quote(tokenIn: MarketKit.Token, tokenOut: MarketKit.Token, amountIn: Decimal) async throws -> MultiSwapQuote {
         try await internalQuote(tokenIn: tokenIn, tokenOut: tokenOut, amountIn: amountIn, slippage: MultiSwapSlippage.default)
     }
 
-    override func confirmationQuote(multiSwapQuote _: MultiSwapQuote, tokenIn: MarketKit.Token, tokenOut: MarketKit.Token, amountIn: Decimal, slippage: Decimal, recipient: String?, transactionSettings: TransactionSettings?) async throws -> SwapFinalQuote {
+    override public func confirmationQuote(multiSwapQuote _: MultiSwapQuote, tokenIn: MarketKit.Token, tokenOut: MarketKit.Token, amountIn: Decimal, slippage: Decimal, recipient: String?, transactionSettings: TransactionSettings?) async throws -> SwapFinalQuote {
         let quote = try await internalQuote(tokenIn: tokenIn, tokenOut: tokenOut, amountIn: amountIn, slippage: slippage, recipient: recipient)
 
         let blockchainType = tokenIn.blockchainType
@@ -40,7 +40,6 @@ class BaseUniswapMultiSwapProvider: BaseEvmMultiSwapProvider {
 
         // router-approve intent for the AA broadcaster (ignored by the EOA direct broadcaster)
         let spender = try? spenderAddress(chain: evmKit.chain)
-        NSLog("[AASWAP] BaseUniswap confirmationQuote: spender=\(spender?.eip55 ?? "nil") tokenIn.type=\(tokenIn.type) txData=\(txData != nil)")
         let approval = spender.flatMap { SwapApproval.build(spender: $0, tokenIn: tokenIn, amountIn: amountIn) }
 
         return EvmSwapFinalQuote(

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/BaseUniswapMultiSwapProvider.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/BaseUniswapMultiSwapProvider.swift
@@ -47,6 +47,7 @@ class BaseUniswapMultiSwapProvider: BaseEvmMultiSwapProvider {
             gasPrice: gasPriceData?.userDefined,
             evmFeeData: evmFeeData,
             nonce: transactionSettings?.nonce,
+            mevProtectionAllowed: mevProtectionAllowed(tokenIn: tokenIn, tokenOut: tokenOut),
             toAddress: evmKit.receiveAddress.eip55
         )
     }

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/BaseUniswapMultiSwapProvider.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/BaseUniswapMultiSwapProvider.swift
@@ -38,7 +38,7 @@ public class BaseUniswapMultiSwapProvider: BaseEvmMultiSwapProvider {
             }
         }
 
-        // router-approve intent for the AA broadcaster (ignored by the EOA direct broadcaster)
+        // router-approve intent for broadcasters that submit approvals with the swap
         let spender = try? spenderAddress(chain: evmKit.chain)
         let approval = spender.flatMap { SwapApproval.build(spender: $0, tokenIn: tokenIn, amountIn: amountIn) }
 

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/BaseUniswapMultiSwapProvider.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/BaseUniswapMultiSwapProvider.swift
@@ -28,7 +28,7 @@ class BaseUniswapMultiSwapProvider: BaseEvmMultiSwapProvider {
 
         let evmKit = evmKitWrapper.evmKit
 
-        if evmKitWrapper.signer != nil, let gasPriceData {
+        if let gasPriceData {
             do {
                 let transactionData = try transactionData(receiveAddress: evmKit.receiveAddress, chain: evmKit.chain, trade: quote.trade, tradeOptions: quote.tradeOptions)
                 txData = transactionData
@@ -37,6 +37,11 @@ class BaseUniswapMultiSwapProvider: BaseEvmMultiSwapProvider {
                 transactionError = error
             }
         }
+
+        // router-approve intent for the AA broadcaster (ignored by the EOA direct broadcaster)
+        let spender = try? spenderAddress(chain: evmKit.chain)
+        NSLog("[AASWAP] BaseUniswap confirmationQuote: spender=\(spender?.eip55 ?? "nil") tokenIn.type=\(tokenIn.type) txData=\(txData != nil)")
+        let approval = spender.flatMap { SwapApproval.build(spender: $0, tokenIn: tokenIn, amountIn: amountIn) }
 
         return EvmSwapFinalQuote(
             expectedBuyAmount: quote.trade.amountOut ?? 0,
@@ -48,6 +53,7 @@ class BaseUniswapMultiSwapProvider: BaseEvmMultiSwapProvider {
             evmFeeData: evmFeeData,
             nonce: transactionSettings?.nonce,
             mevProtectionAllowed: mevProtectionAllowed(tokenIn: tokenIn, tokenOut: tokenOut),
+            approval: approval,
             toAddress: evmKit.receiveAddress.eip55
         )
     }

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/BaseUniswapV3MultiSwapProvider.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/BaseUniswapV3MultiSwapProvider.swift
@@ -4,11 +4,11 @@ import Foundation
 import MarketKit
 import UniswapKit
 
-class BaseUniswapV3MultiSwapProvider: BaseUniswapMultiSwapProvider {
+public class BaseUniswapV3MultiSwapProvider: BaseUniswapMultiSwapProvider {
     private let networkManager = Core.shared.networkManager
     private let kit: UniswapKit.KitV3
 
-    init(kit: UniswapKit.KitV3) {
+    public init(kit: UniswapKit.KitV3) {
         self.kit = kit
 
         super.init()
@@ -39,7 +39,7 @@ class BaseUniswapV3MultiSwapProvider: BaseUniswapMultiSwapProvider {
         return try kit.transactionData(receiveAddress: receiveAddress, chain: chain, bestTrade: bestTrade, tradeOptions: tradeOptions)
     }
 
-    override func track(swap: Swap) async throws -> Swap {
+    override public func track(swap: Swap) async throws -> Swap {
         let blockchainType = swap.tokenIn.blockchainType
 
         var parameters: Parameters = [

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/DestinationHelper.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/DestinationHelper.swift
@@ -3,8 +3,8 @@ import EvmKit
 import Foundation
 import MarketKit
 
-enum DestinationHelper {
-    static func resolveDestinationUnified(token: Token, temporary: Destination? = nil) async throws -> Destination {
+public enum DestinationHelper {
+    public static func resolveDestinationUnified(token: Token, temporary: Destination? = nil) async throws -> Destination {
         if let adapter = Core.shared.adapterManager.adapter(for: token) as? ZcashAdapter,
            let uAddress = adapter.uAddress?.stringEncoded
         {
@@ -23,7 +23,7 @@ enum DestinationHelper {
         return .init(address: address, type: .nonExisting)
     }
 
-    static func resolveDestination(token: Token, temporary: Destination? = nil) async throws -> Destination {
+    public static func resolveDestination(token: Token, temporary: Destination? = nil) async throws -> Destination {
         let blockchainType = token.blockchainType
 
         switch Core.shared.adapterManager.adapter(for: token) {
@@ -83,7 +83,7 @@ enum DestinationHelper {
         return .init(address: address, type: .nonExisting)
     }
 
-    static func sourceAddresses(token: Token, amountIn: Decimal, destinationAddress: String?) async -> [String] {
+    public static func sourceAddresses(token: Token, amountIn: Decimal, destinationAddress: String?) async -> [String] {
         let adapterManager = Core.shared.adapterManager
 
         // UTXO chains: select the UTXOs that will actually cover amountIn
@@ -125,8 +125,8 @@ enum DestinationHelper {
 }
 
 extension DestinationHelper {
-    struct Destination {
-        let address: String
+    public struct Destination {
+        public let address: String
         let type: ResolvedType
     }
 

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/EvmSwapFinalQuote.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/EvmSwapFinalQuote.swift
@@ -7,6 +7,7 @@ class EvmSwapFinalQuote: SwapFinalQuote {
     let gasPrice: GasPrice?
     let evmFeeData: EvmFeeData?
     let nonce: Int?
+    let mevProtectionAllowed: Bool
 
     init(
         expectedBuyAmount: Decimal,
@@ -18,6 +19,7 @@ class EvmSwapFinalQuote: SwapFinalQuote {
         gasPrice: GasPrice?,
         evmFeeData: EvmFeeData?,
         nonce: Int?,
+        mevProtectionAllowed: Bool = false,
         toAddress: String,
         depositAddress: String? = nil,
         providerSwapId: String? = nil
@@ -26,6 +28,7 @@ class EvmSwapFinalQuote: SwapFinalQuote {
         self.gasPrice = gasPrice
         self.evmFeeData = evmFeeData
         self.nonce = nonce
+        self.mevProtectionAllowed = mevProtectionAllowed
 
         super.init(
             expectedBuyAmount: expectedBuyAmount,
@@ -47,13 +50,13 @@ class EvmSwapFinalQuote: SwapFinalQuote {
         super.canSwap && gasPrice != nil && evmFeeData != nil && transactionData != nil
     }
 
-    override func executable(tokenIn _: Token, privateSend: Bool) -> ISwapExecutable {
+    override func executable(tokenIn _: Token) -> ISwapExecutable {
         EvmExecutable(
             transactionData: transactionData,
             gasPrice: gasPrice,
             gasLimit: evmFeeData?.surchargedGasLimit,
             nonce: nonce,
-            privateSend: privateSend,
+            mevProtectionAllowed: mevProtectionAllowed,
             approval: nil
         )
     }

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/EvmSwapFinalQuote.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/EvmSwapFinalQuote.swift
@@ -47,6 +47,17 @@ class EvmSwapFinalQuote: SwapFinalQuote {
         super.canSwap && gasPrice != nil && evmFeeData != nil && transactionData != nil
     }
 
+    override func executable(tokenIn _: Token, privateSend: Bool) -> ISwapExecutable {
+        EvmExecutable(
+            transactionData: transactionData,
+            gasPrice: gasPrice,
+            gasLimit: evmFeeData?.surchargedGasLimit,
+            nonce: nonce,
+            privateSend: privateSend,
+            approval: nil
+        )
+    }
+
     override func caution(transactionError: Error, baseToken: Token) -> CautionNew? {
         EvmSendHelper.caution(transactionError: transactionError, feeToken: baseToken)
     }

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/EvmSwapFinalQuote.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/EvmSwapFinalQuote.swift
@@ -2,7 +2,7 @@ import EvmKit
 import Foundation
 import MarketKit
 
-class EvmSwapFinalQuote: SwapFinalQuote {
+public class EvmSwapFinalQuote: SwapFinalQuote {
     let transactionData: TransactionData?
     let gasPrice: GasPrice?
     let evmFeeData: EvmFeeData?
@@ -10,7 +10,7 @@ class EvmSwapFinalQuote: SwapFinalQuote {
     let mevProtectionAllowed: Bool
     let approval: SwapApproval?
 
-    init(
+    public init(
         expectedBuyAmount: Decimal,
         transactionData: TransactionData?,
         transactionError: Error? = nil,

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/EvmSwapFinalQuote.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/EvmSwapFinalQuote.swift
@@ -8,6 +8,7 @@ class EvmSwapFinalQuote: SwapFinalQuote {
     let evmFeeData: EvmFeeData?
     let nonce: Int?
     let mevProtectionAllowed: Bool
+    let approval: SwapApproval?
 
     init(
         expectedBuyAmount: Decimal,
@@ -20,6 +21,7 @@ class EvmSwapFinalQuote: SwapFinalQuote {
         evmFeeData: EvmFeeData?,
         nonce: Int?,
         mevProtectionAllowed: Bool = false,
+        approval: SwapApproval? = nil,
         toAddress: String,
         depositAddress: String? = nil,
         providerSwapId: String? = nil
@@ -29,6 +31,7 @@ class EvmSwapFinalQuote: SwapFinalQuote {
         self.evmFeeData = evmFeeData
         self.nonce = nonce
         self.mevProtectionAllowed = mevProtectionAllowed
+        self.approval = approval
 
         super.init(
             expectedBuyAmount: expectedBuyAmount,
@@ -57,7 +60,7 @@ class EvmSwapFinalQuote: SwapFinalQuote {
             gasLimit: evmFeeData?.surchargedGasLimit,
             nonce: nonce,
             mevProtectionAllowed: mevProtectionAllowed,
-            approval: nil
+            approval: approval
         )
     }
 

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/EvmSwapFinalQuote.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/EvmSwapFinalQuote.swift
@@ -53,8 +53,9 @@ class EvmSwapFinalQuote: SwapFinalQuote {
         super.canSwap && gasPrice != nil && evmFeeData != nil && transactionData != nil
     }
 
-    override func executable(tokenIn _: Token) -> ISwapExecutable {
+    override func executable(tokenIn: Token) -> ISwapExecutable {
         EvmExecutable(
+            token: tokenIn,
             transactionData: transactionData,
             gasPrice: gasPrice,
             gasLimit: evmFeeData?.surchargedGasLimit,

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/EvmSwapFinalQuote.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/EvmSwapFinalQuote.swift
@@ -74,8 +74,10 @@ class EvmSwapFinalQuote: SwapFinalQuote {
             )
         }
 
-        fields.append(contentsOf: EvmSendHelper.feeFields(evmFeeData: evmFeeData, gasPrice: gasPrice, feeToken: baseToken, currency: currency, feeTokenRate: baseTokenRate))
-
         return fields
+    }
+
+    override func feeFields(baseToken: Token, currency: Currency, baseTokenRate: Decimal?) -> [SendField] {
+        EvmSendHelper.feeFields(evmFeeData: evmFeeData, gasPrice: gasPrice, feeToken: baseToken, currency: currency, feeTokenRate: baseTokenRate)
     }
 }

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/MoneroSwapFinalQuote.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/MoneroSwapFinalQuote.swift
@@ -52,7 +52,7 @@ class MoneroSwapFinalQuote: SwapFinalQuote {
         .monero(amount: amount, address: address)
     }
 
-    override func executable(tokenIn: Token, privateSend _: Bool) -> ISwapExecutable {
+    override func executable(tokenIn: Token) -> ISwapExecutable {
         MoneroExecutable(token: tokenIn, address: address, amount: amount, priority: priority, memo: memo)
     }
 

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/MoneroSwapFinalQuote.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/MoneroSwapFinalQuote.swift
@@ -60,17 +60,7 @@ class MoneroSwapFinalQuote: SwapFinalQuote {
         MoneroSendHelper.caution(transactionError: transactionError, feeToken: baseToken)
     }
 
-    override func fields(tokenIn: Token, tokenOut: Token, baseToken: Token, currency: Currency, tokenInRate: Decimal?, tokenOutRate: Decimal?, baseTokenRate: Decimal?) -> [SendField] {
-        var fields = super.fields(tokenIn: tokenIn, tokenOut: tokenOut, baseToken: baseToken, currency: currency, tokenInRate: tokenInRate, tokenOutRate: tokenOutRate, baseTokenRate: baseTokenRate)
-
-        fields.append(contentsOf: MoneroSendHelper.feeFields(
-            fee: fee,
-            feeToken: baseToken,
-            currency: currency,
-            feeTokenRate: baseTokenRate,
-            priority: priority
-        ))
-
-        return fields
+    override func feeFields(baseToken: Token, currency: Currency, baseTokenRate: Decimal?) -> [SendField] {
+        MoneroSendHelper.feeFields(fee: fee, feeToken: baseToken, currency: currency, feeTokenRate: baseTokenRate, priority: priority)
     }
 }

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/MoneroSwapFinalQuote.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/MoneroSwapFinalQuote.swift
@@ -52,6 +52,10 @@ class MoneroSwapFinalQuote: SwapFinalQuote {
         .monero(amount: amount, address: address)
     }
 
+    override func executable(tokenIn: Token, privateSend _: Bool) -> ISwapExecutable {
+        MoneroExecutable(token: tokenIn, address: address, amount: amount, priority: priority, memo: memo)
+    }
+
     override func caution(transactionError: Error, baseToken: Token) -> CautionNew? {
         MoneroSendHelper.caution(transactionError: transactionError, feeToken: baseToken)
     }

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/MultiSwapAllowanceHelper.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/MultiSwapAllowanceHelper.swift
@@ -26,6 +26,12 @@ class MultiSwapAllowanceHelper {
     }
 
     func allowanceState(spenderAddress: Address, token: Token, amount: Decimal) async -> AllowanceState {
+        if let policyState = await AllowancePolicy.state(spenderAddress: spenderAddress, token: token, amount: amount) {
+            switch policyState {
+            case .notRequired: return .notRequired
+            }
+        }
+
         if token.type.isNative {
             return .notRequired
         }

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/MultiSwapAllowanceHelper.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/MultiSwapAllowanceHelper.swift
@@ -5,10 +5,6 @@ import SwiftUI
 
 class MultiSwapAllowanceHelper {
     private let adapterManager = Core.shared.adapterManager
-    private let addressesForRevoke: [BlockchainType: String] = [
-        .ethereum: "0xdac17f958d2ee523a2206206994597c13d831ec7",
-        .tron: "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
-    ]
 
     func preSwapView(step: MultiSwapPreSwapStep, tokenIn: Token, amount: Decimal, isPresented: Binding<Bool>, onSuccess: @escaping () -> Void) -> AnyView {
         switch step {
@@ -75,13 +71,7 @@ class MultiSwapAllowanceHelper {
     }
 
     private func mustBeRevoked(token: Token) -> Bool {
-        for (blockchainType, addressToRevoke) in addressesForRevoke {
-            if blockchainType == token.blockchainType, case let .eip20(address) = token.type, address.lowercased() == addressToRevoke.lowercased() {
-                return true
-            }
-        }
-
-        return false
+        ApprovalReset.required(token: token)
     }
 }
 

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/MultiSwapQuote.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/MultiSwapQuote.swift
@@ -4,7 +4,7 @@ public class MultiSwapQuote {
     let expectedBuyAmount: Decimal
     let estimatedTime: TimeInterval?
 
-    init(expectedBuyAmount: Decimal, estimatedTime: TimeInterval? = nil) {
+    public init(expectedBuyAmount: Decimal, estimatedTime: TimeInterval? = nil) {
         self.expectedBuyAmount = expectedBuyAmount
         self.estimatedTime = estimatedTime
     }

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/OneInchMultiSwapProvider.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/OneInchMultiSwapProvider.swift
@@ -115,6 +115,11 @@ class OneInchMultiSwapProvider: BaseEvmMultiSwapProvider {
             predefinedGasLimit: swap.transaction.gasLimit
         )
 
+        // router-approve intent for the AA broadcaster (ignored by the EOA direct broadcaster)
+        let spender = try? spenderAddress(chain: evmKit.chain)
+        NSLog("[AASWAP] OneInch confirmationQuote: spender=\(spender?.eip55 ?? "nil") tokenIn.type=\(tokenIn.type)")
+        let approval = spender.flatMap { SwapApproval.build(spender: $0, tokenIn: tokenIn, amountIn: amountIn) }
+
         return EvmSwapFinalQuote(
             expectedBuyAmount: swap.amountOut ?? 0,
             transactionData: swap.transactionData,
@@ -126,6 +131,7 @@ class OneInchMultiSwapProvider: BaseEvmMultiSwapProvider {
             evmFeeData: evmFeeData,
             nonce: transactionSettings?.nonce,
             mevProtectionAllowed: mevProtectionAllowed(tokenIn: tokenIn, tokenOut: tokenOut),
+            approval: approval,
             toAddress: receiveAddress.eip55
         )
     }

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/OneInchMultiSwapProvider.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/OneInchMultiSwapProvider.swift
@@ -7,9 +7,9 @@ import MarketKit
 import OneInchKit
 import SwiftUI
 
-class OneInchMultiSwapProvider: BaseEvmMultiSwapProvider {
-    static let id = "ONEINCH"
-    static let name = "1Inch"
+public class OneInchMultiSwapProvider: BaseEvmMultiSwapProvider {
+    public static let id = "ONEINCH"
+    public static let name = "1Inch"
 
     private let networkManager = Core.shared.networkManager
 //    private let networkManager = NetworkManager(logger: Logger(minLogLevel: .debug))
@@ -20,18 +20,22 @@ class OneInchMultiSwapProvider: BaseEvmMultiSwapProvider {
     private let commission: Decimal? = AppConfig.oneInchCommission
     private let commissionAddress: String? = AppConfig.oneInchCommissionAddress
 
-    init(kit: OneInchKit.Kit) {
+    public init(kit: OneInchKit.Kit) {
         self.kit = kit
 
         super.init()
     }
 
-    override var id: String { Self.id }
-    override var name: String { Self.name }
-    override var type: SwapProviderType { .excellent }
-    override var icon: String { "swap_provider_1inch" }
+    public convenience init(apiKey: String) {
+        self.init(kit: OneInchKit.Kit.instance(apiKey: apiKey))
+    }
 
-    override func supports(tokenIn: MarketKit.Token, tokenOut: MarketKit.Token) -> Bool {
+    override public var id: String { Self.id }
+    override public var name: String { Self.name }
+    override public var type: SwapProviderType { .excellent }
+    override public var icon: String { "swap_provider_1inch" }
+
+    override public func supports(tokenIn: MarketKit.Token, tokenOut: MarketKit.Token) -> Bool {
         guard tokenIn.blockchainType == tokenOut.blockchainType else {
             return false
         }
@@ -42,7 +46,7 @@ class OneInchMultiSwapProvider: BaseEvmMultiSwapProvider {
         }
     }
 
-    override func quote(tokenIn: MarketKit.Token, tokenOut: MarketKit.Token, amountIn: Decimal) async throws -> MultiSwapQuote {
+    override public func quote(tokenIn: MarketKit.Token, tokenOut: MarketKit.Token, amountIn: Decimal) async throws -> MultiSwapQuote {
         let blockchainType = tokenIn.blockchainType
         let chain = try evmBlockchainManager.chain(blockchainType: blockchainType)
 
@@ -69,7 +73,7 @@ class OneInchMultiSwapProvider: BaseEvmMultiSwapProvider {
         )
     }
 
-    override func confirmationQuote(multiSwapQuote _: MultiSwapQuote, tokenIn: MarketKit.Token, tokenOut: MarketKit.Token, amountIn: Decimal, slippage: Decimal, recipient: String?, transactionSettings: TransactionSettings?) async throws -> SwapFinalQuote {
+    override public func confirmationQuote(multiSwapQuote _: MultiSwapQuote, tokenIn: MarketKit.Token, tokenOut: MarketKit.Token, amountIn: Decimal, slippage: Decimal, recipient: String?, transactionSettings: TransactionSettings?) async throws -> SwapFinalQuote {
         let blockchainType = tokenIn.blockchainType
 
         guard let evmKitWrapper = try evmBlockchainManager.evmKitManager(blockchainType: blockchainType).evmKitWrapper else {
@@ -117,7 +121,6 @@ class OneInchMultiSwapProvider: BaseEvmMultiSwapProvider {
 
         // router-approve intent for the AA broadcaster (ignored by the EOA direct broadcaster)
         let spender = try? spenderAddress(chain: evmKit.chain)
-        NSLog("[AASWAP] OneInch confirmationQuote: spender=\(spender?.eip55 ?? "nil") tokenIn.type=\(tokenIn.type)")
         let approval = spender.flatMap { SwapApproval.build(spender: $0, tokenIn: tokenIn, amountIn: amountIn) }
 
         return EvmSwapFinalQuote(
@@ -136,7 +139,7 @@ class OneInchMultiSwapProvider: BaseEvmMultiSwapProvider {
         )
     }
 
-    override func track(swap: Swap) async throws -> Swap {
+    override public func track(swap: Swap) async throws -> Swap {
         let blockchainType = swap.tokenIn.blockchainType
 
         var parameters: Parameters = try [

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/OneInchMultiSwapProvider.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/OneInchMultiSwapProvider.swift
@@ -119,7 +119,7 @@ public class OneInchMultiSwapProvider: BaseEvmMultiSwapProvider {
             predefinedGasLimit: swap.transaction.gasLimit
         )
 
-        // router-approve intent for the AA broadcaster (ignored by the EOA direct broadcaster)
+        // router-approve intent for broadcasters that submit approvals with the swap
         let spender = try? spenderAddress(chain: evmKit.chain)
         let approval = spender.flatMap { SwapApproval.build(spender: $0, tokenIn: tokenIn, amountIn: amountIn) }
 

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/OneInchMultiSwapProvider.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/OneInchMultiSwapProvider.swift
@@ -125,6 +125,7 @@ class OneInchMultiSwapProvider: BaseEvmMultiSwapProvider {
             gasPrice: swap.transaction.gasPrice,
             evmFeeData: evmFeeData,
             nonce: transactionSettings?.nonce,
+            mevProtectionAllowed: mevProtectionAllowed(tokenIn: tokenIn, tokenOut: tokenOut),
             toAddress: receiveAddress.eip55
         )
     }

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/PancakeV3MultiSwapProvider.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/PancakeV3MultiSwapProvider.swift
@@ -1,15 +1,21 @@
 import MarketKit
+import UniswapKit
 
-class PancakeV3MultiSwapProvider: BaseUniswapV3MultiSwapProvider {
-    static let id = "PANCAKESWAP"
-    static let name = "PancakeSwap v.3"
-    override var id: String { Self.id }
-    override var name: String { Self.name }
+public class PancakeV3MultiSwapProvider: BaseUniswapV3MultiSwapProvider {
+    public static let id = "PANCAKESWAP"
+    public static let name = "PancakeSwap v.3"
 
-    override var type: SwapProviderType { .excellent }
-    override var icon: String { "swap_provider_pancake" }
+    public init() throws {
+        try super.init(kit: UniswapKit.KitV3.instance(dexType: .pancakeSwap))
+    }
 
-    override func supports(tokenIn: MarketKit.Token, tokenOut: MarketKit.Token) -> Bool {
+    override public var id: String { Self.id }
+    override public var name: String { Self.name }
+
+    override public var type: SwapProviderType { .excellent }
+    override public var icon: String { "swap_provider_pancake" }
+
+    override public func supports(tokenIn: MarketKit.Token, tokenOut: MarketKit.Token) -> Bool {
         guard tokenIn.blockchainType == tokenOut.blockchainType else {
             return false
         }

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/SolanaSwapFinalQuote.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/SolanaSwapFinalQuote.swift
@@ -52,21 +52,19 @@ class SolanaSwapFinalQuote: SwapFinalQuote {
         return CautionNew(title: title, text: text, type: .error)
     }
 
-    override func fields(tokenIn: Token, tokenOut: Token, baseToken: Token, currency: Currency, tokenInRate: Decimal?, tokenOutRate: Decimal?, baseTokenRate: Decimal?) -> [SendField] {
-        var fields = super.fields(tokenIn: tokenIn, tokenOut: tokenOut, baseToken: baseToken, currency: currency, tokenInRate: tokenInRate, tokenOutRate: tokenOutRate, baseTokenRate: baseTokenRate)
-
-        if let fee {
-            let appValue = AppValue(token: baseToken, value: fee)
-            let currencyValue = baseTokenRate.map { CurrencyValue(currency: currency, value: fee * $0) }
-
-            fields.append(
-                .fee(
-                    title: ComponentInformedTitle("fee_settings.network_fee".localized, info: .fee),
-                    amountData: .init(appValue: appValue, currencyValue: currencyValue)
-                )
-            )
+    override func feeFields(baseToken: Token, currency: Currency, baseTokenRate: Decimal?) -> [SendField] {
+        guard let fee else {
+            return []
         }
 
-        return fields
+        let appValue = AppValue(token: baseToken, value: fee)
+        let currencyValue = baseTokenRate.map { CurrencyValue(currency: currency, value: fee * $0) }
+
+        return [
+            .fee(
+                title: ComponentInformedTitle("fee_settings.network_fee".localized, info: .fee),
+                amountData: .init(appValue: appValue, currencyValue: currencyValue)
+            ),
+        ]
     }
 }

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/SolanaSwapFinalQuote.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/SolanaSwapFinalQuote.swift
@@ -27,7 +27,7 @@ class SolanaSwapFinalQuote: SwapFinalQuote {
         super.canSwap && fee != nil
     }
 
-    override func executable(tokenIn: Token, privateSend _: Bool) -> ISwapExecutable {
+    override func executable(tokenIn: Token) -> ISwapExecutable {
         SolanaExecutable(token: tokenIn, rawTransaction: rawTransaction)
     }
 

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/SolanaSwapFinalQuote.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/SolanaSwapFinalQuote.swift
@@ -27,6 +27,10 @@ class SolanaSwapFinalQuote: SwapFinalQuote {
         super.canSwap && fee != nil
     }
 
+    override func executable(tokenIn: Token, privateSend _: Bool) -> ISwapExecutable {
+        SolanaExecutable(token: tokenIn, rawTransaction: rawTransaction)
+    }
+
     override func caution(transactionError: Error, baseToken: Token) -> CautionNew? {
         let title: String
         let text: String

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/StellarSwapFinalQuote.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/StellarSwapFinalQuote.swift
@@ -46,16 +46,7 @@ class StellarSwapFinalQuote: SwapFinalQuote {
         StellarSendHelper.caution(transactionError: transactionError, feeToken: baseToken)
     }
 
-    override func fields(tokenIn: Token, tokenOut: Token, baseToken: Token, currency: Currency, tokenInRate: Decimal?, tokenOutRate: Decimal?, baseTokenRate: Decimal?) -> [SendField] {
-        var fields = super.fields(tokenIn: tokenIn, tokenOut: tokenOut, baseToken: baseToken, currency: currency, tokenInRate: tokenInRate, tokenOutRate: tokenOutRate, baseTokenRate: baseTokenRate)
-
-        fields.append(contentsOf: StellarSendHelper.feeFields(
-            fee: fee,
-            feeToken: baseToken,
-            currency: currency,
-            feeTokenRate: baseTokenRate
-        ))
-
-        return fields
+    override func feeFields(baseToken: Token, currency: Currency, baseTokenRate: Decimal?) -> [SendField] {
+        StellarSendHelper.feeFields(fee: fee, feeToken: baseToken, currency: currency, feeTokenRate: baseTokenRate)
     }
 }

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/StellarSwapFinalQuote.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/StellarSwapFinalQuote.swift
@@ -38,6 +38,10 @@ class StellarSwapFinalQuote: SwapFinalQuote {
         )
     }
 
+    override func executable(tokenIn: Token, privateSend _: Bool) -> ISwapExecutable {
+        StellarExecutable(token: tokenIn, transactionData: transactionData)
+    }
+
     override func caution(transactionError: Error, baseToken: Token) -> CautionNew? {
         StellarSendHelper.caution(transactionError: transactionError, feeToken: baseToken)
     }

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/StellarSwapFinalQuote.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/StellarSwapFinalQuote.swift
@@ -38,7 +38,7 @@ class StellarSwapFinalQuote: SwapFinalQuote {
         )
     }
 
-    override func executable(tokenIn: Token, privateSend _: Bool) -> ISwapExecutable {
+    override func executable(tokenIn: Token) -> ISwapExecutable {
         StellarExecutable(token: tokenIn, transactionData: transactionData)
     }
 

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/ThorChain/BaseThorChainMultiSwapProvider.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/ThorChain/BaseThorChainMultiSwapProvider.swift
@@ -124,7 +124,7 @@ class BaseThorChainMultiSwapProvider: IMultiSwapProvider {
                 throw SwapError.noEvmKit
             }
 
-            if let gasPriceData {
+            if evmKitWrapper.signer != nil, let gasPriceData {
                 do {
                     let _evmFeeData = try await evmFeeEstimator.estimateFee(evmKitWrapper: evmKitWrapper, transactionData: transactionData, gasPriceData: gasPriceData)
                     evmFeeData = _evmFeeData

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/ThorChain/BaseThorChainMultiSwapProvider.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/ThorChain/BaseThorChainMultiSwapProvider.swift
@@ -137,7 +137,6 @@ class BaseThorChainMultiSwapProvider: IMultiSwapProvider {
 
             // router-approve intent for the AA broadcaster: eip20 deposits pull via the router's transferFrom
             // (native deposits transfer directly to the inbound address and carry no approval)
-            NSLog("[AASWAP] ThorChain confirmationQuote: router=\(router) tokenIn.type=\(tokenIn.type)")
             let approval = (try? EvmKit.Address(hex: router)).flatMap { SwapApproval.build(spender: $0, tokenIn: tokenIn, amountIn: amountIn) }
 
             return EvmSwapFinalQuote(

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/ThorChain/BaseThorChainMultiSwapProvider.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/ThorChain/BaseThorChainMultiSwapProvider.swift
@@ -135,7 +135,7 @@ class BaseThorChainMultiSwapProvider: IMultiSwapProvider {
                 }
             }
 
-            // router-approve intent for the AA broadcaster: eip20 deposits pull via the router's transferFrom
+            // router-approve intent: eip20 deposits pull via the router's transferFrom
             // (native deposits transfer directly to the inbound address and carry no approval)
             let approval = (try? EvmKit.Address(hex: router)).flatMap { SwapApproval.build(spender: $0, tokenIn: tokenIn, amountIn: amountIn) }
 

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/ThorChain/BaseThorChainMultiSwapProvider.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/ThorChain/BaseThorChainMultiSwapProvider.swift
@@ -124,7 +124,7 @@ class BaseThorChainMultiSwapProvider: IMultiSwapProvider {
                 throw SwapError.noEvmKit
             }
 
-            if evmKitWrapper.signer != nil, let gasPriceData {
+            if let gasPriceData {
                 do {
                     let _evmFeeData = try await evmFeeEstimator.estimateFee(evmKitWrapper: evmKitWrapper, transactionData: transactionData, gasPriceData: gasPriceData)
                     evmFeeData = _evmFeeData
@@ -134,6 +134,11 @@ class BaseThorChainMultiSwapProvider: IMultiSwapProvider {
                     transactionError = error
                 }
             }
+
+            // router-approve intent for the AA broadcaster: eip20 deposits pull via the router's transferFrom
+            // (native deposits transfer directly to the inbound address and carry no approval)
+            NSLog("[AASWAP] ThorChain confirmationQuote: router=\(router) tokenIn.type=\(tokenIn.type)")
+            let approval = (try? EvmKit.Address(hex: router)).flatMap { SwapApproval.build(spender: $0, tokenIn: tokenIn, amountIn: amountIn) }
 
             return EvmSwapFinalQuote(
                 expectedBuyAmount: swapQuote.expectedAmountOut,
@@ -145,6 +150,7 @@ class BaseThorChainMultiSwapProvider: IMultiSwapProvider {
                 gasPrice: gasPriceData?.userDefined,
                 evmFeeData: evmFeeData,
                 nonce: transactionSettings?.nonce,
+                approval: approval,
                 toAddress: toAddress
             )
         case .bitcoin, .bitcoinCash, .dash, .litecoin:

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/TonSwapFinalQuote.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/TonSwapFinalQuote.swift
@@ -40,7 +40,7 @@ class TonSwapFinalQuote: SwapFinalQuote {
         super.canSwap && fee != nil
     }
 
-    override func executable(tokenIn _: Token, privateSend _: Bool) -> ISwapExecutable {
+    override func executable(tokenIn _: Token) -> ISwapExecutable {
         TonExecutable(transactionParam: transactionParam)
     }
 

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/TonSwapFinalQuote.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/TonSwapFinalQuote.swift
@@ -48,16 +48,7 @@ class TonSwapFinalQuote: SwapFinalQuote {
         TonSendHelper.caution(transactionError: transactionError, feeToken: baseToken)
     }
 
-    override func fields(tokenIn: Token, tokenOut: Token, baseToken: Token, currency: Currency, tokenInRate: Decimal?, tokenOutRate: Decimal?, baseTokenRate: Decimal?) -> [SendField] {
-        var fields = super.fields(tokenIn: tokenIn, tokenOut: tokenOut, baseToken: baseToken, currency: currency, tokenInRate: tokenInRate, tokenOutRate: tokenOutRate, baseTokenRate: baseTokenRate)
-
-        fields.append(contentsOf: TonSendHelper.feeFields(
-            fee: fee,
-            feeToken: baseToken,
-            currency: currency,
-            feeTokenRate: baseTokenRate
-        ))
-
-        return fields
+    override func feeFields(baseToken: Token, currency: Currency, baseTokenRate: Decimal?) -> [SendField] {
+        TonSendHelper.feeFields(fee: fee, feeToken: baseToken, currency: currency, feeTokenRate: baseTokenRate)
     }
 }

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/TonSwapFinalQuote.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/TonSwapFinalQuote.swift
@@ -40,6 +40,10 @@ class TonSwapFinalQuote: SwapFinalQuote {
         super.canSwap && fee != nil
     }
 
+    override func executable(tokenIn _: Token, privateSend _: Bool) -> ISwapExecutable {
+        TonExecutable(transactionParam: transactionParam)
+    }
+
     override func caution(transactionError: Error, baseToken: Token) -> CautionNew? {
         TonSendHelper.caution(transactionError: transactionError, feeToken: baseToken)
     }

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/TronSwapFinalQuote.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/TronSwapFinalQuote.swift
@@ -50,11 +50,7 @@ class TronSwapFinalQuote: SwapFinalQuote {
         TronSendHelper.caution(transactionError: transactionError, feeToken: baseToken)
     }
 
-    override func fields(tokenIn: Token, tokenOut: Token, baseToken: Token, currency: Currency, tokenInRate: Decimal?, tokenOutRate: Decimal?, baseTokenRate: Decimal?) -> [SendField] {
-        var fields = super.fields(tokenIn: tokenIn, tokenOut: tokenOut, baseToken: baseToken, currency: currency, tokenInRate: tokenInRate, tokenOutRate: tokenOutRate, baseTokenRate: baseTokenRate)
-
-        fields.append(contentsOf: TronSendHelper.feeFields(baseToken: baseToken, totalFees: fees.calculateTotalFees(), fees: fees, currency: currency, feeTokenRate: baseTokenRate))
-
-        return fields
+    override func feeFields(baseToken: Token, currency: Currency, baseTokenRate: Decimal?) -> [SendField] {
+        TronSendHelper.feeFields(baseToken: baseToken, totalFees: fees.calculateTotalFees(), fees: fees, currency: currency, feeTokenRate: baseTokenRate)
     }
 }

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/TronSwapFinalQuote.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/TronSwapFinalQuote.swift
@@ -7,6 +7,7 @@ import TronKit
 class TronSwapFinalQuote: SwapFinalQuote {
     private let amountIn: Decimal
     let createdTransaction: CreatedTransactionResponse
+    let transferIntent: TronTransferIntent?
     private let fees: [Fee]
 
     init(
@@ -16,6 +17,7 @@ class TronSwapFinalQuote: SwapFinalQuote {
         slippage: Decimal?,
         estimatedTime: TimeInterval? = nil,
         createdTransaction: CreatedTransactionResponse,
+        transferIntent: TronTransferIntent? = nil,
         fees: [Fee],
         transactionError: Error?,
         toAddress: String,
@@ -24,6 +26,7 @@ class TronSwapFinalQuote: SwapFinalQuote {
     ) {
         self.amountIn = amountIn
         self.createdTransaction = createdTransaction
+        self.transferIntent = transferIntent
         self.fees = fees
 
         super.init(
@@ -43,7 +46,7 @@ class TronSwapFinalQuote: SwapFinalQuote {
     }
 
     override func executable(tokenIn _: Token) -> ISwapExecutable {
-        TronExecutable(created: createdTransaction, transferIntent: nil)
+        TronExecutable(created: createdTransaction, transferIntent: transferIntent)
     }
 
     override func caution(transactionError: Error, baseToken: Token) -> CautionNew? {

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/TronSwapFinalQuote.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/TronSwapFinalQuote.swift
@@ -42,7 +42,7 @@ class TronSwapFinalQuote: SwapFinalQuote {
         .tron(fees: fees)
     }
 
-    override func executable(tokenIn _: Token, privateSend _: Bool) -> ISwapExecutable {
+    override func executable(tokenIn _: Token) -> ISwapExecutable {
         TronExecutable(created: createdTransaction, transferIntent: nil)
     }
 

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/TronSwapFinalQuote.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/TronSwapFinalQuote.swift
@@ -42,6 +42,10 @@ class TronSwapFinalQuote: SwapFinalQuote {
         .tron(fees: fees)
     }
 
+    override func executable(tokenIn _: Token, privateSend _: Bool) -> ISwapExecutable {
+        TronExecutable(created: createdTransaction, transferIntent: nil)
+    }
+
     override func caution(transactionError: Error, baseToken: Token) -> CautionNew? {
         TronSendHelper.caution(transactionError: transactionError, feeToken: baseToken)
     }

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/USwap/USwapMultiSwapProvider.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/USwap/USwapMultiSwapProvider.swift
@@ -871,7 +871,7 @@ class USwapMultiSwapProvider: IMultiSwapProvider {
             transactionError = error
         }
 
-        return ZcashSwapFinalQuote(
+        return try ZcashSwapFinalQuote(
             expectedBuyAmount: amountOut,
             proposal: proposal,
             slippage: slippage,
@@ -879,7 +879,7 @@ class USwapMultiSwapProvider: IMultiSwapProvider {
             estimatedTime: quote.esimatedTime,
             transactionError: transactionError,
             fee: totalFeeRequired?.decimalValue.decimalValue,
-            toAddress: try deliveryAddress(quote: quote, recipient: recipient),
+            toAddress: deliveryAddress(quote: quote, recipient: recipient),
             depositAddress: quote.execution?.depositAddress,
             providerSwapId: quote.uuid
         )
@@ -947,7 +947,7 @@ class USwapMultiSwapProvider: IMultiSwapProvider {
             transactionParam: transactionParam,
             fee: fee,
             transactionError: transactionError,
-            toAddress: try deliveryAddress(quote: quote, recipient: recipient),
+            toAddress: deliveryAddress(quote: quote, recipient: recipient),
             depositAddress: quote.execution?.depositAddress,
             providerSwapId: quote.uuid
         )
@@ -1006,7 +1006,7 @@ class USwapMultiSwapProvider: IMultiSwapProvider {
             token: tokenIn,
             fee: fee,
             transactionError: transactionError,
-            toAddress: try deliveryAddress(quote: quote, recipient: recipient),
+            toAddress: deliveryAddress(quote: quote, recipient: recipient),
             depositAddress: quote.execution?.depositAddress,
             providerSwapId: quote.uuid
         )
@@ -1071,7 +1071,7 @@ class USwapMultiSwapProvider: IMultiSwapProvider {
             transferIntent: transferIntent,
             fees: fees,
             transactionError: transactionError,
-            toAddress: try deliveryAddress(quote: quote, recipient: recipient),
+            toAddress: deliveryAddress(quote: quote, recipient: recipient),
             depositAddress: quote.execution?.depositAddress,
             providerSwapId: quote.uuid
         )
@@ -1114,7 +1114,7 @@ class USwapMultiSwapProvider: IMultiSwapProvider {
             transactionError = error
         }
 
-        return MoneroSwapFinalQuote(
+        return try MoneroSwapFinalQuote(
             amountIn: amountIn,
             expectedAmountOut: amountOut,
             recipient: recipient,
@@ -1127,7 +1127,7 @@ class USwapMultiSwapProvider: IMultiSwapProvider {
             priority: priority,
             fee: fee,
             transactionError: transactionError,
-            toAddress: try deliveryAddress(quote: quote, recipient: recipient),
+            toAddress: deliveryAddress(quote: quote, recipient: recipient),
             depositAddress: quote.execution?.depositAddress,
             providerSwapId: quote.uuid
         )
@@ -1176,7 +1176,7 @@ class USwapMultiSwapProvider: IMultiSwapProvider {
             transactionError = error
         }
 
-        return ZanoSwapFinalQuote(
+        return try ZanoSwapFinalQuote(
             expectedAmountOut: amountOut,
             recipient: recipient,
             slippage: slippage,
@@ -1186,7 +1186,7 @@ class USwapMultiSwapProvider: IMultiSwapProvider {
             memo: deposit.memo,
             fee: fee,
             transactionError: transactionError,
-            toAddress: try deliveryAddress(quote: quote, recipient: recipient),
+            toAddress: deliveryAddress(quote: quote, recipient: recipient),
             depositAddress: quote.execution?.depositAddress,
             providerSwapId: quote.uuid
         )
@@ -1228,7 +1228,7 @@ class USwapMultiSwapProvider: IMultiSwapProvider {
             transactionError = error
         }
 
-        return SolanaSwapFinalQuote(
+        return try SolanaSwapFinalQuote(
             rawTransaction: rawTransaction,
             expectedAmountOut: amountOut,
             recipient: recipient,
@@ -1236,7 +1236,7 @@ class USwapMultiSwapProvider: IMultiSwapProvider {
             estimatedTime: quote.esimatedTime,
             fee: fee,
             transactionError: transactionError,
-            toAddress: try deliveryAddress(quote: quote, recipient: recipient),
+            toAddress: deliveryAddress(quote: quote, recipient: recipient),
             depositAddress: quote.execution?.depositAddress,
             providerSwapId: quote.uuid
         )

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/USwap/USwapMultiSwapProvider.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/USwap/USwapMultiSwapProvider.swift
@@ -692,7 +692,7 @@ class USwapMultiSwapProvider: IMultiSwapProvider {
     private func buildEvmConfirmationQuote(
         tokenIn: Token,
         tokenOut _: Token,
-        amountIn _: Decimal,
+        amountIn: Decimal,
         amountOut _: Decimal,
         amountOutMin _: Decimal,
         quote: Quote,
@@ -742,7 +742,19 @@ class USwapMultiSwapProvider: IMultiSwapProvider {
             }
         }
 
-        return EvmSwapFinalQuote(
+        // router-approve intent for broadcasters that batch the approve themselves;
+        // the direct broadcaster ignores it (approve happens in the pre-swap step)
+        var approval: SwapApproval?
+        if let approvalSpender = quote.approvalSpender,
+           case let .eip20(tokenAddress) = tokenIn.type,
+           let spender = try? EvmKit.Address(hex: approvalSpender),
+           let token = try? EvmKit.Address(hex: tokenAddress),
+           let amount = tokenIn.rawAmount(amountIn)
+        {
+            approval = SwapApproval(spender: spender, token: token, amount: amount)
+        }
+
+        return try EvmSwapFinalQuote(
             expectedBuyAmount: quote.expectedBuyAmount,
             transactionData: transactionData,
             transactionError: transactionError,
@@ -752,7 +764,8 @@ class USwapMultiSwapProvider: IMultiSwapProvider {
             gasPrice: gasPriceData?.userDefined,
             evmFeeData: evmFeeData,
             nonce: transactionSettings?.nonce,
-            toAddress: try deliveryAddress(quote: quote, recipient: recipient),
+            approval: approval,
+            toAddress: deliveryAddress(quote: quote, recipient: recipient),
             depositAddress: quote.execution?.depositAddress,
             providerSwapId: quote.uuid
         )
@@ -1028,13 +1041,26 @@ class USwapMultiSwapProvider: IMultiSwapProvider {
             }
         }
 
-        return TronSwapFinalQuote(
+        // plain-transfer description for broadcasters that deliver the transfer
+        // themselves; the direct broadcaster uses createdTransaction as before
+        var transferIntent: TronTransferIntent?
+        if let depositAddress = quote.execution?.depositAddress,
+           case let .eip20(tokenAddress) = tokenIn.type,
+           let token = try? TronKit.Address(address: tokenAddress),
+           let receiver = try? TronKit.Address(address: depositAddress),
+           let value = tokenIn.rawAmount(amountIn)
+        {
+            transferIntent = TronTransferIntent(token: token, receiver: receiver, value: value)
+        }
+
+        return try TronSwapFinalQuote(
             amountIn: amountIn,
             expectedAmountOut: amountOut,
             recipient: recipient,
             slippage: slippage,
             estimatedTime: quote.esimatedTime,
             createdTransaction: transaction,
+            transferIntent: transferIntent,
             fees: fees,
             transactionError: transactionError,
             toAddress: try deliveryAddress(quote: quote, recipient: recipient),

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/USwap/USwapMultiSwapProvider.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/USwap/USwapMultiSwapProvider.swift
@@ -731,7 +731,7 @@ class USwapMultiSwapProvider: IMultiSwapProvider {
         var evmFeeData: EvmFeeData?
         var transactionError: Error?
 
-        if let evmKitWrapper = try evmBlockchainManager.evmKitManager(blockchainType: blockchainType).evmKitWrapper, let gasPriceData {
+        if let evmKitWrapper = try evmBlockchainManager.evmKitManager(blockchainType: blockchainType).evmKitWrapper, evmKitWrapper.signer != nil, let gasPriceData {
             do {
                 let _evmFeeData = try await evmFeeEstimator.estimateFee(evmKitWrapper: evmKitWrapper, transactionData: transactionData, gasPriceData: gasPriceData, predefinedGasLimit: gasLimitData)
                 evmFeeData = _evmFeeData

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/USwap/USwapMultiSwapProvider.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/USwap/USwapMultiSwapProvider.swift
@@ -22,8 +22,8 @@ class USwapMultiSwapProvider: IMultiSwapProvider {
     private var headers: HTTPHeaders?
 
     private let provider: Provider
-    private let networkManager = Core.shared.networkManager
-//    private let networkManager = NetworkManager(logger: Logger(minLogLevel: .debug))
+//    private let networkManager = Core.shared.networkManager
+    private let networkManager = NetworkManager(logger: nil)
     private let evmBlockchainManager = Core.shared.evmBlockchainManager
     private let adapterManager = Core.shared.adapterManager
     private let swapAssetStorage = Core.shared.swapAssetStorage
@@ -361,16 +361,28 @@ class USwapMultiSwapProvider: IMultiSwapProvider {
         parameters["provider"] = provider.rawValue
         parameters["destinationAddress"] = variant.destination
 
-        let refund = try await refundAddress(tokenIn: tokenIn)
-        parameters.appendNotNil(key: "refundAddress", refund)
-
         // sourceAddress IS the build signal: we send it only for chains whose server-built
         // tx we actually consume (EVM/Tron/TON/Solana — exactly what `quoteSourceAddress`
         // resolves a `from` for). For UTXO/Monero/Stellar/Zcash/Zano we omit it and build
         // the tx locally (better txs, e.g. multi-UTXO) — preserving the pre-v2 behaviour.
-        try await parameters.appendNotNil(key: "sourceAddress", quoteSourceAddress(tokenIn: tokenIn))
+        let sourceAddress = try await quoteSourceAddress(tokenIn: tokenIn)
+        parameters.appendNotNil(key: "sourceAddress", sourceAddress)
 
-        let quote: Quote = try await networkManager.fetch(url: "\(Self.baseUrl)/swap", method: .post, parameters: parameters, encoding: JSONEncoding.default, headers: headers)
+        let refund = try await refundAddress(tokenIn: tokenIn)
+        parameters.appendNotNil(key: "refundAddress", refund)
+
+        NSLog("[AASWAP] USwap(\(provider.rawValue)) /swap REQUEST: tokenIn=\(tokenIn.coin.code)/\(tokenIn.type) chain=\(tokenIn.blockchainType.uid) sourceAddress=\(String(describing: parameters["sourceAddress"] ?? "nil")) destinationAddress=\(String(describing: parameters["destinationAddress"] ?? "nil")) refundAddress=\(String(describing: parameters["refundAddress"] ?? "nil")) parameterKeys=\(parameters.keys.sorted())")
+
+        let quote: Quote
+        do {
+            quote = try await networkManager.fetch(url: "\(Self.baseUrl)/swap", method: .post, parameters: parameters, encoding: JSONEncoding.default, headers: headers)
+        } catch {
+            let nsError = error as NSError
+            NSLog("[AASWAP] USwap(\(provider.rawValue)) /swap ERROR: sourceAddress=\(String(describing: parameters["sourceAddress"] ?? "nil")) domain=\(nsError.domain) code=\(nsError.code) message=\(nsError.localizedDescription)")
+            throw error
+        }
+
+        NSLog("[AASWAP] USwap(\(provider.rawValue)) /swap RESPONSE: uuid=\(quote.uuid ?? "nil") approvalSpender=\(quote.approvalSpender ?? "nil") execution=\(quote.execution != nil) primarySignable=\(quote.execution?.primarySignable?.kind ?? "nil") depositAddress=\(quote.execution?.depositAddress ?? "nil")")
 
         // A committed /v2/swap must carry the tracking handle; the 9 builders forward it as
         // `providerSwapId`. If the server couldn't record the swap (no `uuid`), it can't be
@@ -453,13 +465,14 @@ class USwapMultiSwapProvider: IMultiSwapProvider {
     }
 
     private func quoteSourceAddress(tokenIn: Token) async throws -> String? {
-        // must provide address for calculate tx-data
         if tokenIn.blockchain.type.isEvm ||
             tokenIn.blockchainType == .tron ||
             tokenIn.blockchainType == .ton ||
             tokenIn.blockchainType == .solana
         {
-            return try await DestinationHelper.resolveDestination(token: tokenIn).address
+            let address = try await DestinationHelper.resolveDestination(token: tokenIn).address
+            NSLog("[AASWAP] quoteSourceAddress: \(tokenIn.blockchainType.uid) -> \(address)")
+            return address
         }
 
         return nil
@@ -731,7 +744,7 @@ class USwapMultiSwapProvider: IMultiSwapProvider {
         var evmFeeData: EvmFeeData?
         var transactionError: Error?
 
-        if let evmKitWrapper = try evmBlockchainManager.evmKitManager(blockchainType: blockchainType).evmKitWrapper, evmKitWrapper.signer != nil, let gasPriceData {
+        if let evmKitWrapper = try evmBlockchainManager.evmKitManager(blockchainType: blockchainType).evmKitWrapper, let gasPriceData {
             do {
                 let _evmFeeData = try await evmFeeEstimator.estimateFee(evmKitWrapper: evmKitWrapper, transactionData: transactionData, gasPriceData: gasPriceData, predefinedGasLimit: gasLimitData)
                 evmFeeData = _evmFeeData
@@ -744,15 +757,10 @@ class USwapMultiSwapProvider: IMultiSwapProvider {
 
         // router-approve intent for broadcasters that batch the approve themselves;
         // the direct broadcaster ignores it (approve happens in the pre-swap step)
-        var approval: SwapApproval?
-        if let approvalSpender = quote.approvalSpender,
-           case let .eip20(tokenAddress) = tokenIn.type,
-           let spender = try? EvmKit.Address(hex: approvalSpender),
-           let token = try? EvmKit.Address(hex: tokenAddress),
-           let amount = tokenIn.rawAmount(amountIn)
-        {
-            approval = SwapApproval(spender: spender, token: token, amount: amount)
-        }
+        NSLog("[AASWAP] USwap(\(provider.rawValue)) buildEvm: approvalSpender=\(quote.approvalSpender ?? "nil") tokenIn.type=\(tokenIn.type)")
+        let approval = quote.approvalSpender
+            .flatMap { try? EvmKit.Address(hex: $0) }
+            .flatMap { SwapApproval.build(spender: $0, tokenIn: tokenIn, amountIn: amountIn) }
 
         return try EvmSwapFinalQuote(
             expectedBuyAmount: quote.expectedBuyAmount,

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/USwap/USwapMultiSwapProvider.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/USwap/USwapMultiSwapProvider.swift
@@ -21,7 +21,7 @@ class USwapMultiSwapProvider: IMultiSwapProvider {
     private let assetMapExpiration: TimeInterval = 60 * 60
     private var headers: HTTPHeaders?
 
-    private let provider: Provider
+    private let provider: USwapProvider
 //    private let networkManager = Core.shared.networkManager
     private let networkManager = NetworkManager(logger: nil)
     private let evmBlockchainManager = Core.shared.evmBlockchainManager
@@ -49,7 +49,7 @@ class USwapMultiSwapProvider: IMultiSwapProvider {
     private var temporaryDestinationAddresses = [DestinationCacheKey: String]() // primary (transparent for ZEC)
     private var temporaryUnifiedDestinationAddresses = [DestinationCacheKey: String]() // unified (ZEC only)
 
-    init(provider: Provider) {
+    init(provider: USwapProvider) {
         self.provider = provider
         headers = Self.headers
 
@@ -371,18 +371,12 @@ class USwapMultiSwapProvider: IMultiSwapProvider {
         let refund = try await refundAddress(tokenIn: tokenIn)
         parameters.appendNotNil(key: "refundAddress", refund)
 
-        NSLog("[AASWAP] USwap(\(provider.rawValue)) /swap REQUEST: tokenIn=\(tokenIn.coin.code)/\(tokenIn.type) chain=\(tokenIn.blockchainType.uid) sourceAddress=\(String(describing: parameters["sourceAddress"] ?? "nil")) destinationAddress=\(String(describing: parameters["destinationAddress"] ?? "nil")) refundAddress=\(String(describing: parameters["refundAddress"] ?? "nil")) parameterKeys=\(parameters.keys.sorted())")
-
         let quote: Quote
         do {
             quote = try await networkManager.fetch(url: "\(Self.baseUrl)/swap", method: .post, parameters: parameters, encoding: JSONEncoding.default, headers: headers)
         } catch {
-            let nsError = error as NSError
-            NSLog("[AASWAP] USwap(\(provider.rawValue)) /swap ERROR: sourceAddress=\(String(describing: parameters["sourceAddress"] ?? "nil")) domain=\(nsError.domain) code=\(nsError.code) message=\(nsError.localizedDescription)")
             throw error
         }
-
-        NSLog("[AASWAP] USwap(\(provider.rawValue)) /swap RESPONSE: uuid=\(quote.uuid ?? "nil") approvalSpender=\(quote.approvalSpender ?? "nil") execution=\(quote.execution != nil) primarySignable=\(quote.execution?.primarySignable?.kind ?? "nil") depositAddress=\(quote.execution?.depositAddress ?? "nil")")
 
         // A committed /v2/swap must carry the tracking handle; the 9 builders forward it as
         // `providerSwapId`. If the server couldn't record the swap (no `uuid`), it can't be
@@ -471,7 +465,6 @@ class USwapMultiSwapProvider: IMultiSwapProvider {
             tokenIn.blockchainType == .solana
         {
             let address = try await DestinationHelper.resolveDestination(token: tokenIn).address
-            NSLog("[AASWAP] quoteSourceAddress: \(tokenIn.blockchainType.uid) -> \(address)")
             return address
         }
 
@@ -757,7 +750,6 @@ class USwapMultiSwapProvider: IMultiSwapProvider {
 
         // router-approve intent for broadcasters that batch the approve themselves;
         // the direct broadcaster ignores it (approve happens in the pre-swap step)
-        NSLog("[AASWAP] USwap(\(provider.rawValue)) buildEvm: approvalSpender=\(quote.approvalSpender ?? "nil") tokenIn.type=\(tokenIn.type)")
         let approval = quote.approvalSpender
             .flatMap { try? EvmKit.Address(hex: $0) }
             .flatMap { SwapApproval.build(spender: $0, tokenIn: tokenIn, amountIn: amountIn) }
@@ -1315,72 +1307,18 @@ extension USwapMultiSwapProvider {
     }
 }
 
+public enum USwapTracker {
+    public static func track(swap: Swap, parameters: Parameters, networkManager: NetworkManager, endpoint: String = "track") async throws -> Swap {
+        try await USwapMultiSwapProvider.track(swap: swap, parameters: parameters, networkManager: networkManager, endpoint: endpoint)
+    }
+}
+
 extension USwapMultiSwapProvider {
+    static let supportedProviders: [USwapProvider] = USwapProvider.allCases
+
     struct Asset {
         let identifier: String
         let token: Token
-    }
-
-    enum Provider: String {
-        case near = "NEAR"
-        case quickEx = "QUICKEX"
-        case letsExchange = "LETSEXCHANGE"
-        case stealthex = "STEALTHEX"
-        case swapuz = "SWAPUZ"
-        case exolix = "EXOLIX"
-        case cce = "CCE"
-        case barter = "BARTER"
-        case pegasus = "PEGASUS"
-        case circle = "CIRCLE"
-
-        var icon: String {
-            switch self {
-            case .near: return "swap_provider_near"
-            case .quickEx: return "swap_provider_quickex"
-            case .letsExchange: return "swap_provider_letsexchange"
-            case .stealthex: return "swap_provider_stealthex"
-            case .swapuz: return "swap_provider_swapuz"
-            case .exolix: return "swap_provider_exolix"
-            case .cce: return "swap_provider_cce"
-            case .barter: return "swap_provider_barter"
-            case .pegasus: return "swap_provider_pegasus"
-            case .circle: return "swap_provider_circle"
-            }
-        }
-
-        var title: String {
-            switch self {
-            case .near: return "Near"
-            case .quickEx: return "QuickEx"
-            case .letsExchange: return "LetsExchange"
-            case .stealthex: return "StealthEX"
-            case .swapuz: return "Swapuz"
-            case .exolix: return "Exolix"
-            case .cce: return "CCE Cash"
-            case .barter: return "Barter"
-            case .pegasus: return "PegasusSwap"
-            case .circle: return "Circle CCTP"
-            }
-        }
-
-        var type: SwapProviderType {
-            switch self {
-            case .barter, .circle: return .excellent
-            case .quickEx, .exolix, .swapuz, .letsExchange, .cce, .pegasus: return .good
-            case .stealthex, .near: return .fair
-            }
-        }
-
-        var requireTerms: Bool {
-            true
-        }
-
-        var isEvm: Bool {
-            switch self {
-            case .barter: return true
-            default: return false
-            }
-        }
     }
 
     struct ProviderResponse: ImmutableMappable {
@@ -1642,6 +1580,72 @@ extension USwapMultiSwapProvider {
         let sellAsset: String
         let buyAsset: String
         let destinationAddress: String
+    }
+}
+
+public enum USwapProvider: String, CaseIterable {
+    case near = "NEAR"
+    case quickEx = "QUICKEX"
+    case letsExchange = "LETSEXCHANGE"
+    case stealthex = "STEALTHEX"
+    case swapuz = "SWAPUZ"
+    case exolix = "EXOLIX"
+    case cce = "CCE"
+    case barter = "BARTER"
+    case pegasus = "PEGASUS"
+    case circle = "CIRCLE"
+
+    public var icon: String {
+        switch self {
+        case .near: return "swap_provider_near"
+        case .quickEx: return "swap_provider_quickex"
+        case .letsExchange: return "swap_provider_letsexchange"
+        case .stealthex: return "swap_provider_stealthex"
+        case .swapuz: return "swap_provider_swapuz"
+        case .exolix: return "swap_provider_exolix"
+        case .cce: return "swap_provider_cce"
+        case .barter: return "swap_provider_barter"
+        case .pegasus: return "swap_provider_pegasus"
+        case .circle: return "swap_provider_circle"
+        }
+    }
+
+    public var title: String {
+        switch self {
+        case .near: return "Near"
+        case .quickEx: return "QuickEx"
+        case .letsExchange: return "LetsExchange"
+        case .stealthex: return "StealthEX"
+        case .swapuz: return "Swapuz"
+        case .exolix: return "Exolix"
+        case .cce: return "CCE Cash"
+        case .barter: return "Barter"
+        case .pegasus: return "PegasusSwap"
+        case .circle: return "Circle CCTP"
+        }
+    }
+
+    public var type: SwapProviderType {
+        switch self {
+        case .barter, .circle: return .excellent
+        case .quickEx, .exolix, .swapuz, .letsExchange, .cce, .pegasus: return .good
+        case .stealthex, .near: return .fair
+        }
+    }
+
+    public var requireTerms: Bool {
+        true
+    }
+
+    public var isEvm: Bool {
+        switch self {
+        case .barter: return true
+        default: return false
+        }
+    }
+
+    public var requiresSourceAddress: Bool {
+        self == .barter
     }
 }
 

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/UniswapV3MultiSwapProvider.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/UniswapV3MultiSwapProvider.swift
@@ -1,15 +1,21 @@
 import MarketKit
+import UniswapKit
 
-class UniswapV3MultiSwapProvider: BaseUniswapV3MultiSwapProvider {
-    static let id = "UNISWAP_V3"
-    static let name = "Uniswap v.3"
-    override var id: String { Self.id }
-    override var name: String { Self.name }
+public class UniswapV3MultiSwapProvider: BaseUniswapV3MultiSwapProvider {
+    public static let id = "UNISWAP_V3"
+    public static let name = "Uniswap v.3"
 
-    override var type: SwapProviderType { .excellent }
-    override var icon: String { "swap_provider_uniswap" }
+    public init() throws {
+        try super.init(kit: UniswapKit.KitV3.instance(dexType: .uniswap))
+    }
 
-    override func supports(tokenIn: MarketKit.Token, tokenOut: MarketKit.Token) -> Bool {
+    override public var id: String { Self.id }
+    override public var name: String { Self.name }
+
+    override public var type: SwapProviderType { .excellent }
+    override public var icon: String { "swap_provider_uniswap" }
+
+    override public func supports(tokenIn: MarketKit.Token, tokenOut: MarketKit.Token) -> Bool {
         guard tokenIn.blockchainType == tokenOut.blockchainType else {
             return false
         }

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/UtxoSwapFinalQuote.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/UtxoSwapFinalQuote.swift
@@ -49,11 +49,7 @@ class UtxoSwapFinalQuote: SwapFinalQuote {
         UtxoSendHelper.caution(transactionError: transactionError, feeToken: baseToken)
     }
 
-    override func fields(tokenIn: Token, tokenOut: Token, baseToken: Token, currency: Currency, tokenInRate: Decimal?, tokenOutRate: Decimal?, baseTokenRate: Decimal?) -> [SendField] {
-        var fields = super.fields(tokenIn: tokenIn, tokenOut: tokenOut, baseToken: baseToken, currency: currency, tokenInRate: tokenInRate, tokenOutRate: tokenOutRate, baseTokenRate: baseTokenRate)
-
-        fields.append(contentsOf: UtxoSendHelper.feeFields(fee: fee, feeToken: baseToken, currency: currency, feeTokenRate: baseTokenRate))
-
-        return fields
+    override func feeFields(baseToken: Token, currency: Currency, baseTokenRate: Decimal?) -> [SendField] {
+        UtxoSendHelper.feeFields(fee: fee, feeToken: baseToken, currency: currency, feeTokenRate: baseTokenRate)
     }
 }

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/UtxoSwapFinalQuote.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/UtxoSwapFinalQuote.swift
@@ -41,7 +41,7 @@ class UtxoSwapFinalQuote: SwapFinalQuote {
         super.canSwap && fee != nil && sendParameters != nil
     }
 
-    override func executable(tokenIn: Token, privateSend _: Bool) -> ISwapExecutable {
+    override func executable(tokenIn: Token) -> ISwapExecutable {
         UtxoExecutable(token: tokenIn, sendParameters: sendParameters)
     }
 

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/UtxoSwapFinalQuote.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/UtxoSwapFinalQuote.swift
@@ -41,6 +41,10 @@ class UtxoSwapFinalQuote: SwapFinalQuote {
         super.canSwap && fee != nil && sendParameters != nil
     }
 
+    override func executable(tokenIn: Token, privateSend _: Bool) -> ISwapExecutable {
+        UtxoExecutable(token: tokenIn, sendParameters: sendParameters)
+    }
+
     override func caution(transactionError: Error, baseToken: Token) -> CautionNew? {
         UtxoSendHelper.caution(transactionError: transactionError, feeToken: baseToken)
     }

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/ZanoSwapFinalQuote.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/ZanoSwapFinalQuote.swift
@@ -50,16 +50,7 @@ class ZanoSwapFinalQuote: SwapFinalQuote {
         ZanoSendHelper.caution(transactionError: transactionError, feeToken: baseToken)
     }
 
-    override func fields(tokenIn: Token, tokenOut: Token, baseToken: Token, currency: Currency, tokenInRate: Decimal?, tokenOutRate: Decimal?, baseTokenRate: Decimal?) -> [SendField] {
-        var fields = super.fields(tokenIn: tokenIn, tokenOut: tokenOut, baseToken: baseToken, currency: currency, tokenInRate: tokenInRate, tokenOutRate: tokenOutRate, baseTokenRate: baseTokenRate)
-
-        fields.append(contentsOf: ZanoSendHelper.feeFields(
-            fee: fee,
-            feeToken: baseToken,
-            currency: currency,
-            feeTokenRate: baseTokenRate
-        ))
-
-        return fields
+    override func feeFields(baseToken: Token, currency: Currency, baseTokenRate: Decimal?) -> [SendField] {
+        ZanoSendHelper.feeFields(fee: fee, feeToken: baseToken, currency: currency, feeTokenRate: baseTokenRate)
     }
 }

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/ZanoSwapFinalQuote.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/ZanoSwapFinalQuote.swift
@@ -42,7 +42,7 @@ class ZanoSwapFinalQuote: SwapFinalQuote {
         nil
     }
 
-    override func executable(tokenIn: Token, privateSend _: Bool) -> ISwapExecutable {
+    override func executable(tokenIn: Token) -> ISwapExecutable {
         ZanoExecutable(token: tokenIn, address: address, amount: amount, memo: memo)
     }
 

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/ZanoSwapFinalQuote.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/ZanoSwapFinalQuote.swift
@@ -42,6 +42,10 @@ class ZanoSwapFinalQuote: SwapFinalQuote {
         nil
     }
 
+    override func executable(tokenIn: Token, privateSend _: Bool) -> ISwapExecutable {
+        ZanoExecutable(token: tokenIn, address: address, amount: amount, memo: memo)
+    }
+
     override func caution(transactionError: Error, baseToken: Token) -> CautionNew? {
         ZanoSendHelper.caution(transactionError: transactionError, feeToken: baseToken)
     }

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/ZcashSwapFinalQuote.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/ZcashSwapFinalQuote.swift
@@ -42,6 +42,10 @@ class ZcashSwapFinalQuote: SwapFinalQuote {
         super.canSwap && proposal != nil && fee != nil
     }
 
+    override func executable(tokenIn: Token, privateSend _: Bool) -> ISwapExecutable {
+        ZcashExecutable(token: tokenIn, proposal: proposal)
+    }
+
     override func caution(transactionError: Error, baseToken: Token) -> CautionNew? {
         UtxoSendHelper.caution(transactionError: transactionError, feeToken: baseToken)
     }

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/ZcashSwapFinalQuote.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/ZcashSwapFinalQuote.swift
@@ -42,7 +42,7 @@ class ZcashSwapFinalQuote: SwapFinalQuote {
         super.canSwap && proposal != nil && fee != nil
     }
 
-    override func executable(tokenIn: Token, privateSend _: Bool) -> ISwapExecutable {
+    override func executable(tokenIn: Token) -> ISwapExecutable {
         ZcashExecutable(token: tokenIn, proposal: proposal)
     }
 

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/ZcashSwapFinalQuote.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/ZcashSwapFinalQuote.swift
@@ -50,11 +50,7 @@ class ZcashSwapFinalQuote: SwapFinalQuote {
         UtxoSendHelper.caution(transactionError: transactionError, feeToken: baseToken)
     }
 
-    override func fields(tokenIn: Token, tokenOut: Token, baseToken: Token, currency: Currency, tokenInRate: Decimal?, tokenOutRate: Decimal?, baseTokenRate: Decimal?) -> [SendField] {
-        var fields = super.fields(tokenIn: tokenIn, tokenOut: tokenOut, baseToken: baseToken, currency: currency, tokenInRate: tokenInRate, tokenOutRate: tokenOutRate, baseTokenRate: baseTokenRate)
-
-        fields.append(contentsOf: UtxoSendHelper.feeFields(fee: fee, feeToken: baseToken, currency: currency, feeTokenRate: baseTokenRate))
-
-        return fields
+    override func feeFields(baseToken: Token, currency: Currency, baseTokenRate: Decimal?) -> [SendField] {
+        UtxoSendHelper.feeFields(fee: fee, feeToken: baseToken, currency: currency, feeTokenRate: baseTokenRate)
     }
 }

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/SwapFinalQuote.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/SwapFinalQuote.swift
@@ -51,6 +51,10 @@ public class SwapFinalQuote {
         UnsupportedExecutable()
     }
 
+    func feeFields(baseToken _: Token, currency _: Currency, baseTokenRate _: Decimal?) -> [SendField] {
+        []
+    }
+
     func cautions(baseToken: Token) -> [CautionNew] {
         var cautions = [CautionNew]()
 

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/SwapFinalQuote.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/SwapFinalQuote.swift
@@ -47,6 +47,10 @@ public class SwapFinalQuote {
         transactionError == nil
     }
 
+    func executable(tokenIn _: Token, privateSend _: Bool) -> ISwapExecutable {
+        UnsupportedExecutable()
+    }
+
     func cautions(baseToken: Token) -> [CautionNew] {
         var cautions = [CautionNew]()
 

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/SwapFinalQuote.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/SwapFinalQuote.swift
@@ -11,7 +11,7 @@ public class SwapFinalQuote {
     let toAddress: String
     let depositAddress: String?
     let providerSwapId: String?
-    var refundAddress: String?
+    public var refundAddress: String?
 
     public init(
         expectedBuyAmount: Decimal,

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/SwapFinalQuote.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/SwapFinalQuote.swift
@@ -47,7 +47,7 @@ public class SwapFinalQuote {
         transactionError == nil
     }
 
-    func executable(tokenIn _: Token, privateSend _: Bool) -> ISwapExecutable {
+    func executable(tokenIn _: Token) -> ISwapExecutable {
         UnsupportedExecutable()
     }
 


### PR DESCRIPTION
- Added a registry-based `SwapProviderFactory` so each app can register its own provider resolver.
  - Kept the default provider resolver for Unstoppable and registered it explicitly during app startup.
  - Introduced structured swap executable payloads returned by final quotes.
  - Reworked `MultiSwapSendHandler` to prepare swaps through a resolved broadcaster instead of owning every chain/provider branch directly.
  - Added direct broadcasters for existing swap execution paths.
  - Added provider approval intent metadata for routes that need router allowance handling.
  - Added swap tracking support via `trackingHandle`, allowing a pending swap to be resolved to its final transaction hash later.
  - Opened the required WalletCore swap types/helpers as `public` for app-level composition.
  - Added focused tests for provider registry behavior, broadcaster selection, executable payloads, approval reset rules, and swap tracking gates.
  - Removed temporary diagnostic logging and neutralized provider comments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added broader swap support across multiple chains, including direct broadcasting for several networks.
  * Improved swap execution details so approvals, fees, and transaction data are handled more consistently.

* **Bug Fixes**
  * Swaps can now wait for a tracking hash before being processed, improving reliability for pending transactions.
  * Approval reset checks and allowance handling were refined for better token-specific behavior.
  * Updated app startup and storage so swap data is saved and restored with the latest fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->