### PR TITLE
Add Tron GasFree swap support

### DIFF
--- a/packages/WalletCore/Package.swift
+++ b/packages/WalletCore/Package.swift
@@ -37,7 +37,7 @@ let package = Package(
         .package(url: "https://github.com/horizontalsystems/MoneroKit.Swift", exact: "0.2.9"),
         .package(url: "https://github.com/horizontalsystems/NftKit.Swift", exact: "2.0.2"),
         .package(url: "https://github.com/tristanhimmelman/ObjectMapper", exact: "4.2.0"),
-        .package(url: "https://github.com/horizontalsystems/OneInchKit.Swift", exact: "3.0.4"),
+        .package(url: "https://github.com/horizontalsystems/OneInchKit.Swift", exact: "3.1.0"),
         .package(url: "https://github.com/reown-com/reown-swift", exact: "2.0.0"),
         .package(url: "https://github.com/ReactiveX/RxSwift.git", from: "5.1.3"),
         .package(url: "https://github.com/horizontalsystems/SectionsTableView.Swift", exact: "1.0.0"),

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Broadcaster/Direct/TronSwapBroadcaster.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Broadcaster/Direct/TronSwapBroadcaster.swift
@@ -16,8 +16,11 @@ class TronSwapBroadcaster: ISwapBroadcaster {
         guard let prepared = prepared as? DirectPrepared, let executable = prepared.executable as? TronExecutable else {
             throw SwapBroadcasterError.dataMismatch
         }
+        guard let created = executable.created else {
+            throw MultiSwapSendHandler.SendError.invalidTransactionData
+        }
 
-        _ = try await tronKitWrapper.send(createdTranaction: executable.created)
+        _ = try await tronKitWrapper.send(createdTranaction: created)
 
         return BroadcastResult(txHash: nil, trackingHandle: nil)
     }

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Broadcaster/SwapExecutables.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Broadcaster/SwapExecutables.swift
@@ -46,8 +46,9 @@ public extension SwapApproval {
 }
 
 public struct TronExecutable: ISwapExecutable {
-    public let created: CreatedTransactionResponse
+    public let created: CreatedTransactionResponse?
     public let transferIntent: TronTransferIntent?
+    public let token: Token
 }
 
 // plain p2p transfer description for routes that are a single token transfer;
@@ -56,6 +57,12 @@ public struct TronTransferIntent {
     public let token: TronKit.Address
     public let receiver: TronKit.Address
     public let value: BigUInt
+
+    public init(token: TronKit.Address, receiver: TronKit.Address, value: BigUInt) {
+        self.token = token
+        self.receiver = receiver
+        self.value = value
+    }
 }
 
 public struct UtxoExecutable: ISwapExecutable {

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/OneInchMultiSwapProvider.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/OneInchMultiSwapProvider.swift
@@ -19,15 +19,19 @@ public class OneInchMultiSwapProvider: BaseEvmMultiSwapProvider {
     private let evmFeeEstimator = EvmFeeEstimator()
     private let commission: Decimal? = AppConfig.oneInchCommission
     private let commissionAddress: String? = AppConfig.oneInchCommissionAddress
+    // when true, 1inch skips its own on-chain allowance/balance simulation and returns the swap tx
+    // regardless — the caller validates itself; nil omits the query param entirely (1inch default)
+    private let disableEstimate: Bool?
 
-    public init(kit: OneInchKit.Kit) {
+    public init(kit: OneInchKit.Kit, disableEstimate: Bool? = nil) {
         self.kit = kit
+        self.disableEstimate = disableEstimate
 
         super.init()
     }
 
-    public convenience init(apiKey: String) {
-        self.init(kit: OneInchKit.Kit.instance(apiKey: apiKey))
+    public convenience init(apiKey: String, disableEstimate: Bool? = nil) {
+        self.init(kit: OneInchKit.Kit.instance(apiKey: apiKey), disableEstimate: disableEstimate)
     }
 
     override public var id: String { Self.id }
@@ -103,7 +107,8 @@ public class OneInchMultiSwapProvider: BaseEvmMultiSwapProvider {
             referrer: commissionAddress,
             fee: commission,
             recipient: recipientAddress,
-            gasPrice: gasPriceData.userDefined
+            gasPrice: gasPriceData.userDefined,
+            disableEstimate: disableEstimate
         )
 
         let evmBalance = evmKit.accountState?.balance ?? 0

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/TronSwapFinalQuote.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/TronSwapFinalQuote.swift
@@ -4,19 +4,19 @@ import Foundation
 import MarketKit
 import TronKit
 
-class TronSwapFinalQuote: SwapFinalQuote {
+public class TronSwapFinalQuote: SwapFinalQuote {
     private let amountIn: Decimal
-    let createdTransaction: CreatedTransactionResponse
+    let createdTransaction: CreatedTransactionResponse?
     let transferIntent: TronTransferIntent?
     private let fees: [Fee]
 
-    init(
+    public init(
         amountIn: Decimal,
         expectedAmountOut: Decimal,
         recipient: String?,
         slippage: Decimal?,
         estimatedTime: TimeInterval? = nil,
-        createdTransaction: CreatedTransactionResponse,
+        createdTransaction: CreatedTransactionResponse?,
         transferIntent: TronTransferIntent? = nil,
         fees: [Fee],
         transactionError: Error?,
@@ -45,8 +45,12 @@ class TronSwapFinalQuote: SwapFinalQuote {
         .tron(fees: fees)
     }
 
-    override func executable(tokenIn _: Token) -> ISwapExecutable {
-        TronExecutable(created: createdTransaction, transferIntent: transferIntent)
+    override public var canSwap: Bool {
+        super.canSwap && createdTransaction != nil
+    }
+
+    override public func executable(tokenIn: Token) -> ISwapExecutable {
+        TronExecutable(created: createdTransaction, transferIntent: transferIntent, token: tokenIn)
     }
 
     override func caution(transactionError: Error, baseToken: Token) -> CautionNew? {


### PR DESCRIPTION
- TronExecutable/TronSwapFinalQuote.createdTransaction made Optional (GasFree routes need no server-signable tx, only transferIntent)
- TronSwapFinalQuote.canSwap now requires createdTransaction for the EOA path
- TronSwapBroadcaster guards on the new Optional before submit
- OneInchMultiSwapProvider gains disableEstimate passthrough
- Bump OneInchKit.Swift to 3.1.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an optional swap estimation setting, giving swap requests more flexible behavior.
  * Expanded Tron swap handling with clearer transaction context support.

* **Bug Fixes**
  * Improved validation before submitting Tron swaps to prevent attempts with missing transaction data.
  * Made Tron swap eligibility checks stricter so incomplete transactions are no longer treated as swappable.
  * Updated a wallet dependency to a newer version for compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->