### PR TITLE
Expose blockchain(chainId:) and blockTime

### DIFF
--- a/packages/WalletCore/Sources/WalletCore/Core/Managers/EvmBlockchainManager.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Managers/EvmBlockchainManager.swift
@@ -60,7 +60,7 @@ public class EvmBlockchainManager {
 }
 
 extension EvmBlockchainManager {
-    func blockchain(chainId: Int) -> Blockchain? {
+    public func blockchain(chainId: Int) -> Blockchain? {
         allBlockchains.first(where: { (try? chain(blockchainType: $0.type).id) == chainId })
     }
 

--- a/packages/WalletCore/Sources/WalletCore/Extensions/BlockchainType.swift
+++ b/packages/WalletCore/Sources/WalletCore/Extensions/BlockchainType.swift
@@ -268,10 +268,10 @@ extension BlockchainType {
         }
     }
 
-    var blockTime: TimeInterval? {
+    public var blockTime: TimeInterval? {
         switch self {
         case .ethereum: return 12
-        case .binanceSmartChain, .tron: return 3
+        case .tron: return 3
         case .polygon, .avalanche, .optimism, .fantom, .base, .zkSync: return 2
         case .gnosis, .stellar, .ton: return 5
         case .bitcoin, .bitcoinCash, .ecash: return 600
@@ -279,7 +279,7 @@ extension BlockchainType {
         case .zcash: return 75
         case .monero: return 120
         case .zano: return 60
-        case .arbitrumOne: return 1
+        case .binanceSmartChain, .arbitrumOne: return 1
         case .solana, .unsupported: return nil
         }
     }


### PR DESCRIPTION
- update BSC blockTime to 1 sec (0.45) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exposed blockchain lookup and block-time information through the public API.
  * Updated supported network block-time values, including faster timings for Binance Smart Chain and Arbitrum One.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->