### PR TITLE
Add TRON chain swaps for LIFI provider

### DIFF
--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Broadcaster/Direct/TronSwapBroadcaster.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Broadcaster/Direct/TronSwapBroadcaster.swift
@@ -22,7 +22,11 @@ class TronSwapBroadcaster: ISwapBroadcaster {
 
         _ = try await tronKitWrapper.send(createdTranaction: created)
 
-        return BroadcastResult(txHash: nil, trackingHandle: nil)
+        // The Tron tx hash IS the created transaction's `txID` (sha256 of raw_data — the value we
+        // sign, which becomes the on-chain hash). Surface it as the broadcast hash so USwap swaps
+        // (e.g. LI.FI Tron-source) can track by `inboundTxHash`; without it the track call would
+        // omit the hash and the server can't poll the provider's status.
+        return BroadcastResult(txHash: created.txID.hs.hex, trackingHandle: nil)
     }
 }
 

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/USwap/USwapMultiSwapProvider.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/USwap/USwapMultiSwapProvider.swift
@@ -468,7 +468,8 @@ class USwapMultiSwapProvider: IMultiSwapProvider {
             // No token list (BARTER-style), but LI.FI is CROSS-CHAIN, so each side must be
             // self-describing — the chain travels with the asset so the server resolves a
             // cross-chain pair without a shared `chainId` hint. EVM token → `<CHAIN>.<contract>`,
-            // EVM native → `<CHAIN>.<0xeee…>` sentinel, Solana → `SOL.<mint>` (wSOL = native SOL).
+            // EVM native → `<CHAIN>.<0xeee…>` sentinel, Solana → `SOL.<mint>` (wSOL = native SOL),
+            // Tron → `TRON.TRX` (native) / `TRON.<contract>` (TRC20).
             if token.blockchainType == .solana {
                 let wsolMint = "So11111111111111111111111111111111111111112"
                 switch token.type {
@@ -476,6 +477,16 @@ class USwapMultiSwapProvider: IMultiSwapProvider {
                 case let .spl(address):
                     guard address != wsolMint else { return nil }
                     return "SOL.\(address)"
+                default: return nil
+                }
+            }
+            if token.blockchainType == .tron {
+                // Tron is TVM (base58 addresses, not `0x`): the server resolves `TRON.TRX` as native
+                // and `TRON.<contract>` as a TRC20 — the EVM `0xeee…` native sentinel does not apply.
+                // TRC20 contracts ride the `.eip20` case with a base58 address (see buildTronConfirmationQuote).
+                switch token.type {
+                case .native: return "TRON.TRX"
+                case let .eip20(address): return "TRON.\(address)"
                 default: return nil
                 }
             }
@@ -1306,7 +1317,8 @@ extension USwapMultiSwapProvider {
 
     // LI.FI has no token list, so assets are encoded self-describingly as `<CHAIN>.<address>`
     // (see `asset(token:)`). This maps each supported EVM chain to the server's chain code — the
-    // prefix the server's LI.FI resolver expects. Solana is handled inline via the `SOL.` prefix.
+    // prefix the server's LI.FI resolver expects. Solana and Tron are handled inline (`SOL.` /
+    // `TRON.` prefixes) since their address formats aren't the EVM `0xeee…`/contract shape.
     static let lifiChainCode: [BlockchainType: String] = [
         .ethereum: "ETH",
         .polygon: "POL",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Tron swap tracking by returning the on-chain transaction hash after broadcast.
  * Added support for encoding native Tron and TRC20 assets for swap processing.

* **Bug Fixes**
  * Unsupported Tron token types are now handled safely during asset resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->