### PR TITLE
Open Tron transaction layer for external decoration

### DIFF
--- a/packages/WalletCore/Package.swift
+++ b/packages/WalletCore/Package.swift
@@ -47,7 +47,7 @@ let package = Package(
         .package(url: "https://github.com/horizontalsystems/StellarKit.Swift", exact: "1.2.0"),
         .package(url: "https://github.com/horizontalsystems/TonConnectAPI", exact: "1.0.0"),
         .package(url: "https://github.com/horizontalsystems/TonKit.Swift", exact: "1.2.1"),
-        .package(url: "https://github.com/horizontalsystems/TronKit.Swift.git", exact: "1.5.1"),
+        .package(url: "https://github.com/horizontalsystems/TronKit.Swift.git", exact: "1.5.2"),
         .package(url: "https://github.com/horizontalsystems/UIExtensions.Swift", exact: "1.0.2"),
         .package(url: "https://github.com/horizontalsystems/UniswapKit.Swift", exact: "3.2.0"),
         .package(url: "https://github.com/horizontalsystems/ZcashLightClientKit", exact: "2.6.0-alpha.4-hs.1"),

--- a/packages/WalletCore/Sources/WalletCore/Core/Factories/AdapterFactory.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Factories/AdapterFactory.swift
@@ -127,7 +127,7 @@ extension AdapterFactory {
         let query = TokenQuery(blockchainType: .tron, tokenType: .native)
 
         if let tronKitWrapper = tronKitManager.tronKitWrapper, let baseToken = try? coinManager.token(query: query) {
-            return TronTransactionsAdapter(
+            let adapter = TronTransactionsAdapter(
                 tronKitWrapper: tronKitWrapper,
                 source: transactionSource,
                 baseToken: baseToken,
@@ -135,6 +135,7 @@ extension AdapterFactory {
                 spamWrapper: spamWrapper,
                 evmLabelManager: evmLabelManager
             )
+            return TransactionsAdapterDecoratorFactory.decorate(adapter: adapter, source: transactionSource)
         }
 
         return nil

--- a/packages/WalletCore/Sources/WalletCore/Core/Managers/TronKitManager.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Managers/TronKitManager.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 import HdWalletKit
 import MarketKit
@@ -15,6 +16,7 @@ public class TronKitManager {
     private weak var _tronKitWrapper: TronKitWrapper?
 
     private let tronKitCreatedRelay = PublishRelay<Void>()
+    private let tronKitCreatedSubject = PassthroughSubject<Void, Never>()
     private let tronKitUpdatedRelay = PublishRelay<Void>()
     private var currentAccount: Account?
 
@@ -103,12 +105,17 @@ public class TronKitManager {
         currentAccount = account
 
         tronKitCreatedRelay.accept(())
+        tronKitCreatedSubject.send()
 
         return wrapper
     }
 }
 
 extension TronKitManager {
+    public var tronKitCreatedPublisher: AnyPublisher<Void, Never> {
+        tronKitCreatedSubject.eraseToAnyPublisher()
+    }
+
     var tronKitCreatedObservable: Observable<Void> {
         tronKitCreatedRelay.asObservable()
     }
@@ -117,7 +124,7 @@ extension TronKitManager {
         tronKitUpdatedRelay.asObservable()
     }
 
-    var tronKitWrapper: TronKitWrapper? {
+    public var tronKitWrapper: TronKitWrapper? {
         queue.sync {
             _tronKitWrapper
         }
@@ -131,11 +138,11 @@ extension TronKitManager {
 }
 
 public class TronKitWrapper {
-    let tronKit: TronKit.Kit
+    public let tronKit: TronKit.Kit
     let signer: Signer?
-    /// True when this wrapper serves a gas-token-payment account (currently passkey / GasFree).
-    /// UI uses it to bypass on-chain `accountActive == false` cosmetic ("not activated") for accounts
-    /// whose wallet is a CREATE2 BeaconProxy not yet deployed on chain.
+    // True when this wrapper serves an account that pays network fees in tokens. UI uses it to bypass
+    // the on-chain `accountActive == false` cosmetic ("not activated") for accounts whose wallet
+    // contract is not yet deployed on chain.
     let gasTokenPayment: Bool
 
     init(tronKit: TronKit.Kit, signer: Signer?, gasTokenPayment: Bool) {

--- a/packages/WalletCore/Sources/WalletCore/Models/TransactionRecords/TransactionRecord.swift
+++ b/packages/WalletCore/Sources/WalletCore/Models/TransactionRecords/TransactionRecord.swift
@@ -11,7 +11,7 @@ open class TransactionRecord: Identifiable {
     public let date: Date
     let failed: Bool
 
-    var spam: Bool
+    public internal(set) var spam: Bool
     var paginationRaw: String
 
     init(source: TransactionSource, uid: String, transactionHash: String, transactionIndex: Int, blockHeight: Int?, confirmationsThreshold: Int?, date: Date, failed: Bool, paginationRaw: String? = nil, spam: Bool = false) {

--- a/packages/WalletCore/Sources/WalletCore/Models/TransactionRecords/Tron/TronOutgoingTransactionRecord.swift
+++ b/packages/WalletCore/Sources/WalletCore/Models/TransactionRecords/Tron/TronOutgoingTransactionRecord.swift
@@ -2,10 +2,10 @@ import Foundation
 import MarketKit
 import TronKit
 
-class TronOutgoingTransactionRecord: TronTransactionRecord {
-    let to: String
-    let value: AppValue
-    let sentToSelf: Bool
+public class TronOutgoingTransactionRecord: TronTransactionRecord {
+    public let to: String
+    public let value: AppValue
+    public let sentToSelf: Bool
 
     init(source: TransactionSource, transaction: Transaction, baseToken: Token, to: String, value: AppValue, sentToSelf: Bool) {
         self.to = to
@@ -15,7 +15,7 @@ class TronOutgoingTransactionRecord: TronTransactionRecord {
         super.init(source: source, transaction: transaction, baseToken: baseToken, ownTransaction: true)
     }
 
-    override var mainValue: AppValue? {
+    override public var mainValue: AppValue? {
         value
     }
 }

--- a/packages/WalletCore/Sources/WalletCore/Models/TransactionRecords/Tron/TronTransactionRecord.swift
+++ b/packages/WalletCore/Sources/WalletCore/Models/TransactionRecords/Tron/TronTransactionRecord.swift
@@ -2,13 +2,13 @@ import Foundation
 import MarketKit
 import TronKit
 
-public class TronTransactionRecord: TransactionRecord {
-    let transaction: Transaction
+open class TronTransactionRecord: TransactionRecord {
+    public let transaction: Transaction
     let confirmed: Bool
     let ownTransaction: Bool
     let fee: AppValue?
 
-    init(source: TransactionSource, transaction: Transaction, baseToken: Token, ownTransaction: Bool, spam: Bool = false) {
+    public init(source: TransactionSource, transaction: Transaction, baseToken: Token, ownTransaction: Bool, spam: Bool = false) {
         self.transaction = transaction
         confirmed = transaction.confirmed
         let txHash = transaction.hash.hs.hex

--- a/packages/WalletCore/Sources/WalletCore/Modules/Transactions/TransactionSource.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/Transactions/TransactionSource.swift
@@ -1,7 +1,7 @@
 import MarketKit
 
 public struct TransactionSource: Hashable {
-    let blockchainType: BlockchainType
+    public let blockchainType: BlockchainType
     let meta: String?
 
     public func hash(into hasher: inout Hasher) {


### PR DESCRIPTION
Route TronTransactionsAdapter through TransactionsAdapterDecoratorFactory; make TronTransactionRecord open and TronKitWrapper.tronKit public; add Combine tronKitCreatedPublisher to TronKitManager. Bump TronKit to 1.5.2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Combine publisher support for detecting TronKit creation.
  - Exposed TronKit wrappers and transaction details for broader integration.
  - Made Tron transaction records and their key properties publicly accessible.
  - Added transaction source blockchain type visibility.

- **Bug Fixes**
  - Improved Tron transaction adapter behavior by applying transaction decoration.
  - Updated TronKit.Swift to version 1.5.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->