### PR TITLE
Deeplink registry assembly

### DIFF
--- a/Unstoppable/Unstoppable/App/UnstoppableApp.swift
+++ b/Unstoppable/Unstoppable/App/UnstoppableApp.swift
@@ -42,6 +42,7 @@ struct UnstoppableApp: App {
             .forEach { DeepLinkRouteFactory.register($0) }
         [AppEventHandlerKind.walletConnect, .widgetCoin, .address, .telegramUser, .openCryptoPay]
             .forEach { AppEventHandlerFactory.register($0) }
+        DeepLinkPresenterFactory.register(sendPresenter: DeepLinkPresenterFactory.sendPresenter)
 
         try Core.initApp(config: Core.Config(), widgetRefresher: WidgetRefresher())
 

--- a/Unstoppable/Unstoppable/App/UnstoppableApp.swift
+++ b/Unstoppable/Unstoppable/App/UnstoppableApp.swift
@@ -38,6 +38,11 @@ struct UnstoppableApp: App {
     private static func initCore() throws {
         SwapProviderFactory.register([DefaultSwapProviderResolver.self])
 
+        [DeepLinkRoute.walletConnect, .tonConnect, .tonTransfer, .coin, .referral, .openCryptoPay, .transfer]
+            .forEach { DeepLinkRouteFactory.register($0) }
+        [AppEventHandlerKind.walletConnect, .widgetCoin, .address, .telegramUser, .openCryptoPay]
+            .forEach { AppEventHandlerFactory.register($0) }
+
         try Core.initApp(config: Core.Config(), widgetRefresher: WidgetRefresher())
 
         EvmKitConfigFactory.register(UnstoppableEvmKitConfigProvider.self)

--- a/Unstoppable/Unstoppable/App/UnstoppableApp.swift
+++ b/Unstoppable/Unstoppable/App/UnstoppableApp.swift
@@ -38,7 +38,9 @@ struct UnstoppableApp: App {
     private static func initCore() throws {
         SwapProviderFactory.register([DefaultSwapProviderResolver.self])
 
-        [DeepLinkRoute.walletConnect, .tonConnect, .tonTransfer, .coin, .referral, .openCryptoPay, .transfer]
+        // .tonConnect is not registered: TonConnectEventHandler is disabled, a parsed link would
+        // only die in the handler chain. Register it together with re-enabling the handler.
+        [DeepLinkRoute.walletConnect, .tonTransfer, .coin, .referral, .openCryptoPay, .transfer]
             .forEach { DeepLinkRouteFactory.register($0) }
         [AppEventHandlerKind.walletConnect, .widgetCoin, .address, .telegramUser, .openCryptoPay]
             .forEach { AppEventHandlerFactory.register($0) }

--- a/packages/WalletCore/Sources/WalletCore/Core/Core.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Core.swift
@@ -16,6 +16,23 @@ public class Core {
         SwapBroadcasterFactory.register(SwapBroadcasterFactory.unstoppableBroadcasters)
         // EvmKit syncers/decorators are registered by each app (no shared fallback): stable in StableCore, the
         // unstoppable app in its own initCore (registers a provider over defaultSyncers/defaultDecorators).
+
+        // Event handlers attach post-init deliberately: the first event cannot arrive before the UI exists,
+        // and this keeps one attach point for both built-in and future app-registered handlers.
+        let appEventHandlerFactory = AppEventHandlerFactory(
+            marketKit: core.marketKit,
+            walletConnectSessionManager: core.walletConnectSessionManager,
+            walletConnectRequestHandler: core.walletConnectRequestHandler,
+            cloudBackupManager: core.cloudBackupManager,
+            accountManager: core.accountManager,
+            lockManager: core.lockManager
+        )
+
+        for handler in appEventHandlerFactory.handlers() {
+            core.appEventHandler.append(handler: handler)
+        }
+
+        DeepLinkRouteFactory.assertCoherence(handlerKinds: AppEventHandlerFactory.resolved())
     }
 
     public static var shared: Core {
@@ -102,9 +119,12 @@ public class Core {
     let nftAdapterManager: NftAdapterManager
     let nftMetadataSyncer: NftMetadataSyncer
 
-    let walletConnectRequestHandler: WalletConnectRequestChain
-    let walletConnectManager: WalletConnectManager
-    let walletConnectSessionManager: WalletConnectSessionManager
+    // The WC stack is assembled only when AppEventHandlerKind.walletConnect is registered:
+    // WalletConnectService.init configures the relay networking and opens a socket, which
+    // an app without WalletConnect must not do.
+    let walletConnectRequestHandler: WalletConnectRequestChain?
+    let walletConnectManager: WalletConnectManager?
+    let walletConnectSessionManager: WalletConnectSessionManager?
 
     public let adapterManager: AdapterManager
     public let transactionAdapterManager: TransactionAdapterManager
@@ -186,7 +206,7 @@ public class Core {
         themeManager = ThemeManager.shared
         systemInfoManager = SystemInfoManager()
         testNetManager = TestNetManager(userDefaultsStorage: userDefaultsStorage)
-        deepLinkManager = DeepLinkManager()
+        deepLinkManager = DeepLinkManager(matchers: DeepLinkRouteFactory.matchers())
         deeplinkStorage = DeeplinkStorage()
         launchScreenManager = LaunchScreenManager(userDefaultsStorage: userDefaultsStorage)
         appSettingManager = AppSettingManager(userDefaultsStorage: userDefaultsStorage)
@@ -290,31 +310,39 @@ public class Core {
         )
         nftMetadataSyncer = NftMetadataSyncer(nftAdapterManager: nftAdapterManager, nftMetadataManager: nftMetadataManager, nftStorage: nftStorage)
 
-        walletConnectRequestHandler = WalletConnectRequestChain.instance(evmBlockchainManager: evmBlockchainManager, stellarKitManager: stellarKitManager, accountManager: accountManager)
+        if AppEventHandlerFactory.resolved().contains(.walletConnect) {
+            let requestHandler = WalletConnectRequestChain.instance(evmBlockchainManager: evmBlockchainManager, stellarKitManager: stellarKitManager, accountManager: accountManager)
 
-        let walletClientInfo = WalletConnectClientInfo(
-            projectId: AppConfig.walletConnectV2ProjectKey ?? "c4f79cc821944d9680842e34466bfb",
-            relayHost: "relay.walletconnect.com",
-            name: AppConfig.appName,
-            description: "",
-            url: AppConfig.appWebPageLink,
-            icons: ["https://raw.githubusercontent.com/horizontalsystems/HS-Design/master/PressKit/UW-AppIcon-on-light.png"]
-        )
+            let walletClientInfo = WalletConnectClientInfo(
+                projectId: AppConfig.walletConnectV2ProjectKey ?? "c4f79cc821944d9680842e34466bfb",
+                relayHost: "relay.walletconnect.com",
+                name: AppConfig.appName,
+                description: "",
+                url: AppConfig.appWebPageLink,
+                icons: ["https://raw.githubusercontent.com/horizontalsystems/HS-Design/master/PressKit/UW-AppIcon-on-light.png"]
+            )
 
-        let walletConnectService = WalletConnectService(
-            info: walletClientInfo,
-            logger: logger
-        )
-        let walletConnectSessionStorage = WalletConnectSessionStorage(dbPool: dbPool)
-        walletConnectSessionManager = WalletConnectSessionManager(
-            service: walletConnectService,
-            storage: walletConnectSessionStorage,
-            accountManager: accountManager,
-            requestHandler: walletConnectRequestHandler,
-            currentDateProvider: CurrentDateProvider()
-        )
+            let walletConnectService = WalletConnectService(
+                info: walletClientInfo,
+                logger: logger
+            )
+            let walletConnectSessionStorage = WalletConnectSessionStorage(dbPool: dbPool)
+            let sessionManager = WalletConnectSessionManager(
+                service: walletConnectService,
+                storage: walletConnectSessionStorage,
+                accountManager: accountManager,
+                requestHandler: requestHandler,
+                currentDateProvider: CurrentDateProvider()
+            )
 
-        walletConnectManager = WalletConnectManager(walletConnectSessionManager: walletConnectSessionManager)
+            walletConnectRequestHandler = requestHandler
+            walletConnectSessionManager = sessionManager
+            walletConnectManager = WalletConnectManager(walletConnectSessionManager: sessionManager)
+        } else {
+            walletConnectRequestHandler = nil
+            walletConnectSessionManager = nil
+            walletConnectManager = nil
+        }
 
         let scannedTransactionStorage = try ScannedTransactionStorage(dbPool: dbPool)
         spamWrapper = SpamWrapper(
@@ -437,18 +465,6 @@ public class Core {
 
         valueFormatter = CurrencyValueFormatter(amountRoundingManager: amountRoundingManager)
 
-        let walletConnectHandler = WalletConnectHandlerModule.handler(
-            walletConnectManager: walletConnectSessionManager,
-            walletConnectRequestHandler: walletConnectRequestHandler,
-            cloudAccountBackupManager: cloudBackupManager,
-            accountManager: accountManager,
-            lockManager: lockManager
-        )
-        let widgetCoinHandler = WidgetCoinEventHandler(marketKit: marketKit)
-        let sendAddressHandler = AddressEventHandler(marketKit: marketKit)
-        let telegramUserHandler = TelegramUserHandler(marketKit: marketKit)
-        // let tonConnectHandler = TonConnectEventHandler(tonConnectManager: tonConnectManager)
-
         openCryptoPay = OpenCryptoPayModule(
             dbPool: dbPool,
             networkManager: networkManager,
@@ -459,15 +475,6 @@ public class Core {
 
         transactionInfoExtraFactory = TransactionInfoExtraFactory()
         transactionInfoExtraFactory.register(OpenCryptoPayTransactionInfoProvider(manager: openCryptoPay.paymentManager, accountManager: accountManager))
-
-        let openCryptoPayHandler = OpenCryptoPayEventHandler()
-
-        appEventHandler.append(handler: walletConnectHandler)
-        // eventHandler.append(handler: tonConnectHandler)
-        appEventHandler.append(handler: widgetCoinHandler)
-        appEventHandler.append(handler: sendAddressHandler)
-        appEventHandler.append(handler: telegramUserHandler)
-        appEventHandler.append(handler: openCryptoPayHandler)
 
         appManager = AppManager(
             widgetRefresher: widgetRefresher,

--- a/packages/WalletCore/Sources/WalletCore/Core/Core.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Core.swift
@@ -4,7 +4,7 @@ import HsToolKit
 import MarketKit
 
 public class Core {
-    static var instance: Core?
+    public static var instance: Core?
 
     public static func initApp(config: Config, widgetRefresher: IWidgetRefresher? = nil) throws {
         let core = try Core(config: config, widgetRefresher: widgetRefresher)
@@ -33,6 +33,7 @@ public class Core {
         }
 
         DeepLinkRouteFactory.assertCoherence(handlerKinds: AppEventHandlerFactory.resolved())
+        DeepLinkPresenterFactory.assertCoherence(handlerKinds: AppEventHandlerFactory.resolved())
     }
 
     public static var shared: Core {

--- a/packages/WalletCore/Sources/WalletCore/Core/Factories/AppEventHandlerFactory.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Factories/AppEventHandlerFactory.swift
@@ -1,0 +1,71 @@
+import MarketKit
+
+public class AppEventHandlerFactory {
+    // Empty by default: every app registers its own set before Core.initApp.
+    // Registration after Core.initApp has no effect.
+    private static var kinds = Set<AppEventHandlerKind>()
+
+    public static func register(_ kind: AppEventHandlerKind) {
+        kinds.insert(kind)
+    }
+
+    static func resolved() -> Set<AppEventHandlerKind> {
+        kinds
+    }
+
+    private let marketKit: MarketKit.Kit
+    private let walletConnectSessionManager: WalletConnectSessionManager?
+    private let walletConnectRequestHandler: WalletConnectRequestChain?
+    private let cloudBackupManager: CloudBackupManager
+    private let accountManager: AccountManager
+    private let lockManager: LockManager
+
+    init(
+        marketKit: MarketKit.Kit,
+        walletConnectSessionManager: WalletConnectSessionManager?,
+        walletConnectRequestHandler: WalletConnectRequestChain?,
+        cloudBackupManager: CloudBackupManager,
+        accountManager: AccountManager,
+        lockManager: LockManager
+    ) {
+        self.marketKit = marketKit
+        self.walletConnectSessionManager = walletConnectSessionManager
+        self.walletConnectRequestHandler = walletConnectRequestHandler
+        self.cloudBackupManager = cloudBackupManager
+        self.accountManager = accountManager
+        self.lockManager = lockManager
+    }
+
+    // Builds handlers for the registered kinds. Chain order is fixed here and does not depend
+    // on registration order: it is the fallback-resolution order of EventHandler.
+    func handlers() -> [IEventHandler] {
+        let kinds = Self.kinds
+        var handlers = [IEventHandler]()
+
+        if kinds.contains(.walletConnect), let walletConnectSessionManager, let walletConnectRequestHandler {
+            handlers.append(WalletConnectHandlerModule.handler(
+                walletConnectManager: walletConnectSessionManager,
+                walletConnectRequestHandler: walletConnectRequestHandler,
+                cloudAccountBackupManager: cloudBackupManager,
+                accountManager: accountManager,
+                lockManager: lockManager
+            ))
+        }
+        // TonConnectEventHandler is disabled — DeepLinkRoute.tonConnect stays a known dangling route:
+        // handlers.append(TonConnectEventHandler(tonConnectManager: tonConnectManager))
+        if kinds.contains(.widgetCoin) {
+            handlers.append(WidgetCoinEventHandler(marketKit: marketKit))
+        }
+        if kinds.contains(.address) {
+            handlers.append(AddressEventHandler(marketKit: marketKit))
+        }
+        if kinds.contains(.telegramUser) {
+            handlers.append(TelegramUserHandler(marketKit: marketKit))
+        }
+        if kinds.contains(.openCryptoPay) {
+            handlers.append(OpenCryptoPayEventHandler())
+        }
+
+        return handlers
+    }
+}

--- a/packages/WalletCore/Sources/WalletCore/Core/Factories/DeepLinkPresenterFactory.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Factories/DeepLinkPresenterFactory.swift
@@ -1,0 +1,42 @@
+import MarketKit
+
+// Resolved payload of a transfer deep link / scanned transfer uri, handed to the app-registered presenter.
+public struct SendDeepLink {
+    public let blockchainTypes: [BlockchainType]?
+    public let tokenTypes: [TokenType]?
+    public let address: String?
+    public let amount: AddressUri.Amount?
+    public let memo: String?
+}
+
+// Presentation seam for the view layer each app owns (its Coordinator / send flow):
+// DeepLinkViewManager hands resolved transfer links to the registered presenter.
+// Empty by default — every app that registers the .address handler kind must also register
+// its presenter (checked by assertCoherence at assembly time).
+public enum DeepLinkPresenterFactory {
+    private static var registeredSendPresenter: ((SendDeepLink) -> Void)?
+
+    // Default presentation: token list of the shared send flow.
+    public static let sendPresenter: (SendDeepLink) -> Void = { link in
+        Coordinator.shared.present { isPresented in
+            SendTokenListView(
+                options: .init(blockchainTypes: link.blockchainTypes, tokenTypes: link.tokenTypes, address: link.address, amount: link.amount, memo: link.memo),
+                isPresented: isPresented
+            )
+        }
+    }
+
+    public static func register(sendPresenter: @escaping (SendDeepLink) -> Void) {
+        registeredSendPresenter = sendPresenter
+    }
+
+    @MainActor static func presentSend(link: SendDeepLink) {
+        registeredSendPresenter?(link)
+    }
+
+    static func assertCoherence(handlerKinds: Set<AppEventHandlerKind>) {
+        if handlerKinds.contains(.address), registeredSendPresenter == nil {
+            assertionFailure("Handler kind 'address' is registered but no send deep link presenter is")
+        }
+    }
+}

--- a/packages/WalletCore/Sources/WalletCore/Core/Factories/DeepLinkRouteFactory.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Factories/DeepLinkRouteFactory.swift
@@ -2,29 +2,42 @@ public enum DeepLinkRouteFactory {
     // Empty by default: every app registers its own set before Core.initApp.
     // Registration after Core.initApp has no effect.
     private static var routes = Set<DeepLinkRoute>()
-
-    // Built-in matchers in fixed priority order — it does not depend on route registration order;
-    // the generic transfer matcher is the catch-all and always goes last.
-    private static let builtInMatchers: [IDeepLinkMatcher] = [
-        WalletConnectDeepLinkMatcher(),
-        TonConnectDeepLinkMatcher(),
-        TonTransferDeepLinkMatcher(),
-        CoinDeepLinkMatcher(),
-        ReferralDeepLinkMatcher(),
-        OpenCryptoPayDeepLinkMatcher(),
-        TransferDeepLinkMatcher(),
-    ]
+    private static var appTransferScheme: String?
 
     public static func register(_ route: DeepLinkRoute) {
         routes.insert(route)
+    }
+
+    // App-scheme transfer links (<scheme>://send?uri=...): the app provides its own url scheme,
+    // which must also be declared in its Info.plist CFBundleURLTypes.
+    public static func register(appTransferScheme: String) {
+        routes.insert(.appTransfer)
+        self.appTransferScheme = appTransferScheme
     }
 
     static func resolved() -> Set<DeepLinkRoute> {
         routes
     }
 
+    // Built-in matchers in fixed priority order — it does not depend on route registration order;
+    // the generic transfer matcher is the catch-all and always goes last.
     static func matchers() -> [IDeepLinkMatcher] {
-        builtInMatchers.filter { routes.contains($0.route) }
+        var builtIn: [IDeepLinkMatcher] = [
+            WalletConnectDeepLinkMatcher(),
+            TonConnectDeepLinkMatcher(),
+            TonTransferDeepLinkMatcher(),
+            CoinDeepLinkMatcher(),
+            ReferralDeepLinkMatcher(),
+            OpenCryptoPayDeepLinkMatcher(),
+        ]
+
+        if let appTransferScheme {
+            builtIn.append(AppSchemeTransferDeepLinkMatcher(scheme: appTransferScheme))
+        }
+
+        builtIn.append(TransferDeepLinkMatcher())
+
+        return builtIn.filter { routes.contains($0.route) }
     }
 
     // Routes and handler kinds are registered independently, but a route without its consuming
@@ -38,6 +51,7 @@ public enum DeepLinkRouteFactory {
             .referral: .telegramUser,
             .openCryptoPay: .openCryptoPay,
             .transfer: .address,
+            .appTransfer: .address,
         ]
 
         for route in routes {

--- a/packages/WalletCore/Sources/WalletCore/Core/Factories/DeepLinkRouteFactory.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Factories/DeepLinkRouteFactory.swift
@@ -41,8 +41,9 @@ public enum DeepLinkRouteFactory {
     }
 
     // Routes and handler kinds are registered independently, but a route without its consuming
-    // handler is a silent no-op (EventHandler reports .handled without any UI). Catch the mismatch in debug.
-    // DeepLinkRoute.tonConnect is intentionally dangling: TonConnectEventHandler is disabled in Core.
+    // handler is a dead parse (the link only dies in the handler chain). Catch the mismatch in debug.
+    // DeepLinkRoute.tonConnect has no entry: TonConnectEventHandler is disabled in Core, so the route
+    // must not be registered until the handler is re-enabled (and mapped here).
     static func assertCoherence(handlerKinds: Set<AppEventHandlerKind>) {
         let consumers: [DeepLinkRoute: AppEventHandlerKind] = [
             .walletConnect: .walletConnect,

--- a/packages/WalletCore/Sources/WalletCore/Core/Factories/DeepLinkRouteFactory.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Factories/DeepLinkRouteFactory.swift
@@ -1,0 +1,51 @@
+public enum DeepLinkRouteFactory {
+    // Empty by default: every app registers its own set before Core.initApp.
+    // Registration after Core.initApp has no effect.
+    private static var routes = Set<DeepLinkRoute>()
+
+    // Built-in matchers in fixed priority order — it does not depend on route registration order;
+    // the generic transfer matcher is the catch-all and always goes last.
+    private static let builtInMatchers: [IDeepLinkMatcher] = [
+        WalletConnectDeepLinkMatcher(),
+        TonConnectDeepLinkMatcher(),
+        TonTransferDeepLinkMatcher(),
+        CoinDeepLinkMatcher(),
+        ReferralDeepLinkMatcher(),
+        OpenCryptoPayDeepLinkMatcher(),
+        TransferDeepLinkMatcher(),
+    ]
+
+    public static func register(_ route: DeepLinkRoute) {
+        routes.insert(route)
+    }
+
+    static func resolved() -> Set<DeepLinkRoute> {
+        routes
+    }
+
+    static func matchers() -> [IDeepLinkMatcher] {
+        builtInMatchers.filter { routes.contains($0.route) }
+    }
+
+    // Routes and handler kinds are registered independently, but a route without its consuming
+    // handler is a silent no-op (EventHandler reports .handled without any UI). Catch the mismatch in debug.
+    // DeepLinkRoute.tonConnect is intentionally dangling: TonConnectEventHandler is disabled in Core.
+    static func assertCoherence(handlerKinds: Set<AppEventHandlerKind>) {
+        let consumers: [DeepLinkRoute: AppEventHandlerKind] = [
+            .walletConnect: .walletConnect,
+            .tonTransfer: .address,
+            .coin: .widgetCoin,
+            .referral: .telegramUser,
+            .openCryptoPay: .openCryptoPay,
+            .transfer: .address,
+        ]
+
+        for route in routes {
+            guard let kind = consumers[route], !handlerKinds.contains(kind) else {
+                continue
+            }
+
+            assertionFailure("DeepLink route '\(route.id)' is registered but its consuming handler '\(kind.id)' is not")
+        }
+    }
+}

--- a/packages/WalletCore/Sources/WalletCore/Core/Managers/AppManager.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Managers/AppManager.swift
@@ -137,7 +137,7 @@ public extension AppManager {
         widgetRefresher?.refreshAll()
     }
 
-    internal func didReceive(url: URL) {
+    func didReceive(url: URL) {
         deeplinkStorage.deepLinkUrl = url
     }
 }

--- a/packages/WalletCore/Sources/WalletCore/Core/Managers/DeepLinkManager.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Managers/DeepLinkManager.swift
@@ -1,4 +1,3 @@
-import BigInt
 import Combine
 import Foundation
 
@@ -8,8 +7,12 @@ class DeepLinkManager {
     static let tonUniversalHost = "ton-connect"
     static let tonDeepLinkHost = "tc"
 
-    private let addressUriParser = AddressUriParser(blockchainType: nil, tokenType: nil)
     private let newSchemeSubject = CurrentValueSubject<DeepLink?, Never>(nil)
+    private let matchers: [IDeepLinkMatcher]
+
+    init(matchers: [IDeepLinkMatcher]) {
+        self.matchers = matchers
+    }
 }
 
 extension DeepLinkManager {
@@ -22,65 +25,18 @@ extension DeepLinkManager {
             return
         }
 
-        let scheme = urlComponents.scheme
-        let host = urlComponents.host
-        let path = urlComponents.path
-        let queryItems = urlComponents.queryItems
-
-        if (scheme == DeepLinkManager.deepLinkScheme && host == "wc") || (scheme == "https" && host == DeepLinkManager.deepLinkScheme && path == "/wc"),
-           let uri = queryItems?.first(where: { $0.name == "uri" })?.value
-        {
-            newSchemeSubject.send(.walletConnect(url: uri))
-            return
-        }
-
-        if (scheme == DeepLinkManager.deepLinkScheme && (host == Self.tonDeepLinkHost || host == Self.tonUniversalHost)) ||
-            (scheme == "https" && host == Self.deepLinkScheme && path == "/\(Self.tonUniversalHost)"),
-            let parameters = try? TonConnectManager.parseParameters(queryItems: queryItems)
-        {
-            newSchemeSubject.send(.tonConnect(parameters: parameters))
-            return
-        }
-
-        if scheme == Self.tonDeepLinkScheme {
-            let parser = AddressParserFactory.parser(blockchainType: .ton, tokenType: nil)
-            do {
-                let address = try parser.parse(url: url.absoluteString)
-                newSchemeSubject.send(.transfer(addressUri: address))
-                return
-            } catch {
-                HudHelper.instance.show(banner: .error(string: error.localizedDescription))
-            }
-        }
-
-        if scheme == DeepLinkManager.deepLinkScheme, host == "coin" {
-            let uid = path.replacingOccurrences(of: "/", with: "")
-
-            newSchemeSubject.send(.coin(uid: uid))
-            return
-        }
-
-        if (scheme == DeepLinkManager.deepLinkScheme && host == "referral") || (scheme == "https" && host == DeepLinkManager.deepLinkScheme && path == "/referral") {
-            guard let queryItems, queryItems.count == 2,
-                  let userId = queryItems[0].value,
-                  let referralCode = queryItems[1].value
-            else {
-                return
+        for matcher in matchers {
+            guard let result = matcher.match(urlComponents: urlComponents, url: url) else {
+                continue
             }
 
-            newSchemeSubject.send(.referral(telegramUserId: userId, referralCode: referralCode))
-            return
-        }
-
-        if let ocp = OpenCryptoPayUrl.detect(text: url.absoluteString) {
-            newSchemeSubject.send(.openCryptoPay(url: ocp))
-            return
-        }
-
-        let encoded = url.absoluteString.removingPercentEncoding ?? url.absoluteString
-        if let uri = try? addressUriParser.parse(url: encoded) {
-            newSchemeSubject.send(.transfer(addressUri: uri))
-            return
+            switch result {
+            case .handled:
+                return
+            case let .deepLink(deepLink):
+                newSchemeSubject.send(deepLink)
+                return
+            }
         }
 
         HudHelper.instance.show(banner: .error(string: "alert.cant_recognize".localized))

--- a/packages/WalletCore/Sources/WalletCore/Core/Managers/DeepLinkMatchers.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Managers/DeepLinkMatchers.swift
@@ -119,6 +119,31 @@ class OpenCryptoPayDeepLinkMatcher: IDeepLinkMatcher {
     }
 }
 
+// App-scheme transfer link: <scheme>://send?uri=<percent-encoded transfer uri>, e.g. myapp://send?uri=tron:TXyz?amount=5.
+// The scheme is app-provided at registration (DeepLinkRouteFactory.register(appTransferScheme:)), mirroring
+// the wc-host pattern of WalletConnectDeepLinkMatcher.
+class AppSchemeTransferDeepLinkMatcher: IDeepLinkMatcher {
+    let route: DeepLinkRoute = .appTransfer
+
+    private let scheme: String
+    private let addressUriParser = AddressUriParser(blockchainType: nil, tokenType: nil)
+
+    init(scheme: String) {
+        self.scheme = scheme
+    }
+
+    func match(urlComponents: URLComponents, url _: URL) -> DeepLinkMatchResult? {
+        guard urlComponents.scheme == scheme, urlComponents.host == "send",
+              let transferUri = urlComponents.queryItems?.first(where: { $0.name == "uri" })?.value,
+              let uri = try? addressUriParser.parse(url: transferUri)
+        else {
+            return nil
+        }
+
+        return .deepLink(.transfer(addressUri: uri))
+    }
+}
+
 class TransferDeepLinkMatcher: IDeepLinkMatcher {
     let route: DeepLinkRoute = .transfer
 

--- a/packages/WalletCore/Sources/WalletCore/Core/Managers/DeepLinkMatchers.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Managers/DeepLinkMatchers.swift
@@ -1,0 +1,135 @@
+import Foundation
+
+// A matcher either passes the url on (nil), consumes it silently (.handled — e.g. a malformed
+// referral link), or resolves it into a DeepLink.
+enum DeepLinkMatchResult {
+    case handled
+    case deepLink(DeepLinkManager.DeepLink)
+}
+
+protocol IDeepLinkMatcher {
+    var route: DeepLinkRoute { get }
+    func match(urlComponents: URLComponents, url: URL) -> DeepLinkMatchResult?
+}
+
+class WalletConnectDeepLinkMatcher: IDeepLinkMatcher {
+    let route: DeepLinkRoute = .walletConnect
+
+    func match(urlComponents: URLComponents, url _: URL) -> DeepLinkMatchResult? {
+        let scheme = urlComponents.scheme
+        let host = urlComponents.host
+        let path = urlComponents.path
+
+        guard (scheme == DeepLinkManager.deepLinkScheme && host == "wc") || (scheme == "https" && host == DeepLinkManager.deepLinkScheme && path == "/wc"),
+              let uri = urlComponents.queryItems?.first(where: { $0.name == "uri" })?.value
+        else {
+            return nil
+        }
+
+        return .deepLink(.walletConnect(url: uri))
+    }
+}
+
+class TonConnectDeepLinkMatcher: IDeepLinkMatcher {
+    let route: DeepLinkRoute = .tonConnect
+
+    func match(urlComponents: URLComponents, url _: URL) -> DeepLinkMatchResult? {
+        let scheme = urlComponents.scheme
+        let host = urlComponents.host
+        let path = urlComponents.path
+
+        guard (scheme == DeepLinkManager.deepLinkScheme && (host == DeepLinkManager.tonDeepLinkHost || host == DeepLinkManager.tonUniversalHost)) ||
+            (scheme == "https" && host == DeepLinkManager.deepLinkScheme && path == "/\(DeepLinkManager.tonUniversalHost)"),
+            let parameters = try? TonConnectManager.parseParameters(queryItems: urlComponents.queryItems)
+        else {
+            return nil
+        }
+
+        return .deepLink(.tonConnect(parameters: parameters))
+    }
+}
+
+class TonTransferDeepLinkMatcher: IDeepLinkMatcher {
+    let route: DeepLinkRoute = .tonTransfer
+
+    func match(urlComponents: URLComponents, url: URL) -> DeepLinkMatchResult? {
+        guard urlComponents.scheme == DeepLinkManager.tonDeepLinkScheme else {
+            return nil
+        }
+
+        let parser = AddressParserFactory.parser(blockchainType: .ton, tokenType: nil)
+        do {
+            let address = try parser.parse(url: url.absoluteString)
+            return .deepLink(.transfer(addressUri: address))
+        } catch {
+            // Parse error shows the banner but keeps the url falling through to the next matchers.
+            HudHelper.instance.show(banner: .error(string: error.localizedDescription))
+            return nil
+        }
+    }
+}
+
+class CoinDeepLinkMatcher: IDeepLinkMatcher {
+    let route: DeepLinkRoute = .coin
+
+    func match(urlComponents: URLComponents, url _: URL) -> DeepLinkMatchResult? {
+        guard urlComponents.scheme == DeepLinkManager.deepLinkScheme, urlComponents.host == "coin" else {
+            return nil
+        }
+
+        let uid = urlComponents.path.replacingOccurrences(of: "/", with: "")
+
+        return .deepLink(.coin(uid: uid))
+    }
+}
+
+class ReferralDeepLinkMatcher: IDeepLinkMatcher {
+    let route: DeepLinkRoute = .referral
+
+    func match(urlComponents: URLComponents, url _: URL) -> DeepLinkMatchResult? {
+        let scheme = urlComponents.scheme
+        let host = urlComponents.host
+        let path = urlComponents.path
+
+        guard (scheme == DeepLinkManager.deepLinkScheme && host == "referral") || (scheme == "https" && host == DeepLinkManager.deepLinkScheme && path == "/referral") else {
+            return nil
+        }
+
+        guard let queryItems = urlComponents.queryItems, queryItems.count == 2,
+              let userId = queryItems[0].value,
+              let referralCode = queryItems[1].value
+        else {
+            // A referral-shaped url with malformed query is consumed silently, without the banner.
+            return .handled
+        }
+
+        return .deepLink(.referral(telegramUserId: userId, referralCode: referralCode))
+    }
+}
+
+class OpenCryptoPayDeepLinkMatcher: IDeepLinkMatcher {
+    let route: DeepLinkRoute = .openCryptoPay
+
+    func match(urlComponents _: URLComponents, url: URL) -> DeepLinkMatchResult? {
+        guard let ocp = OpenCryptoPayUrl.detect(text: url.absoluteString) else {
+            return nil
+        }
+
+        return .deepLink(.openCryptoPay(url: ocp))
+    }
+}
+
+class TransferDeepLinkMatcher: IDeepLinkMatcher {
+    let route: DeepLinkRoute = .transfer
+
+    private let addressUriParser = AddressUriParser(blockchainType: nil, tokenType: nil)
+
+    func match(urlComponents _: URLComponents, url: URL) -> DeepLinkMatchResult? {
+        let encoded = url.absoluteString.removingPercentEncoding ?? url.absoluteString
+        guard let uri = try? addressUriParser.parse(url: encoded) else {
+            return nil
+        }
+
+        return .deepLink(.transfer(addressUri: uri))
+    }
+}

--- a/packages/WalletCore/Sources/WalletCore/Core/Managers/DeepLinkRoute.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Managers/DeepLinkRoute.swift
@@ -1,0 +1,17 @@
+public struct DeepLinkRoute: Hashable {
+    public let id: String
+
+    public init(id: String) {
+        self.id = id
+    }
+}
+
+public extension DeepLinkRoute {
+    static let walletConnect = DeepLinkRoute(id: "wallet_connect")
+    static let tonConnect = DeepLinkRoute(id: "ton_connect")
+    static let tonTransfer = DeepLinkRoute(id: "ton_transfer")
+    static let coin = DeepLinkRoute(id: "coin")
+    static let referral = DeepLinkRoute(id: "referral")
+    static let openCryptoPay = DeepLinkRoute(id: "open_crypto_pay")
+    static let transfer = DeepLinkRoute(id: "transfer")
+}

--- a/packages/WalletCore/Sources/WalletCore/Core/Managers/DeepLinkRoute.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Managers/DeepLinkRoute.swift
@@ -14,4 +14,5 @@ public extension DeepLinkRoute {
     static let referral = DeepLinkRoute(id: "referral")
     static let openCryptoPay = DeepLinkRoute(id: "open_crypto_pay")
     static let transfer = DeepLinkRoute(id: "transfer")
+    static let appTransfer = DeepLinkRoute(id: "app_transfer")
 }

--- a/packages/WalletCore/Sources/WalletCore/Models/AddressUri.swift
+++ b/packages/WalletCore/Sources/WalletCore/Models/AddressUri.swift
@@ -71,7 +71,7 @@ extension AddressUri {
         }
     }
 
-    enum Amount: Hashable {
+    public enum Amount: Hashable {
         case points(Decimal) // lamports, satoshi, wei
         case decimals(Decimal) // human readable
 

--- a/packages/WalletCore/Sources/WalletCore/Modules/Main/Deeplink/DeepLinkViewManager.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/Main/Deeplink/DeepLinkViewManager.swift
@@ -55,9 +55,15 @@ class DeepLinkViewManager {
         switch signal {
         case let .coinPage(coin): Coordinator.shared.presentCoinPage(coin: coin, page: .deepLink)
         case let .sendPage(options):
-            Coordinator.shared.present { isPresented in
-                SendTokenListView(options: options, isPresented: isPresented)
+            var blockchainTypes: [BlockchainType]?
+            var tokenTypes: [TokenType]?
+            if case let .blockchain(filterBlockchainTypes, filterTokenTypes) = options.filter {
+                blockchainTypes = filterBlockchainTypes
+                tokenTypes = filterTokenTypes
             }
+
+            let link = SendDeepLink(blockchainTypes: blockchainTypes, tokenTypes: tokenTypes, address: options.address, amount: options.amount, memo: options.memo)
+            DeepLinkPresenterFactory.presentSend(link: link)
         case let .cryptoPaySendPage(url):
             Coordinator.shared.present { isPresented in
                 CryptoPaySendTokenListView(url: url, isPresented: isPresented)

--- a/packages/WalletCore/Sources/WalletCore/Modules/Main/Deeplink/DeepLinkViewManager.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/Main/Deeplink/DeepLinkViewManager.swift
@@ -10,9 +10,9 @@ class DeepLinkViewManager {
     let walletConnectVerificationModel: WalletConnectVerificationModel
 
     private let eventHandler: EventHandler
-    private let walletConnectManager: WalletConnectManager
+    private let walletConnectManager: WalletConnectManager?
 
-    init(eventHandler: EventHandler, walletConnectManager: WalletConnectManager, accountManager: AccountManager, cloudBackupManager: CloudBackupManager) {
+    init(eventHandler: EventHandler, walletConnectManager: WalletConnectManager?, accountManager: AccountManager, cloudBackupManager: CloudBackupManager) {
         self.eventHandler = eventHandler
         self.walletConnectManager = walletConnectManager
 
@@ -26,21 +26,23 @@ class DeepLinkViewManager {
             }
             .store(in: &cancellables)
 
-        walletConnectManager.$isWaitingForSession
-            .subscribe(on: DispatchQueue.global(qos: .userInitiated))
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] waitingForSession in
-                self?.showWaitingForSession(waitingForSession)
-            }
-            .store(in: &cancellables)
+        if let walletConnectManager {
+            walletConnectManager.$isWaitingForSession
+                .subscribe(on: DispatchQueue.global(qos: .userInitiated))
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] waitingForSession in
+                    self?.showWaitingForSession(waitingForSession)
+                }
+                .store(in: &cancellables)
 
-        walletConnectManager.errorPublisher
-            .subscribe(on: DispatchQueue.global(qos: .userInitiated))
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] error in
-                self?.show(error: error)
-            }
-            .store(in: &cancellables)
+            walletConnectManager.errorPublisher
+                .subscribe(on: DispatchQueue.global(qos: .userInitiated))
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] error in
+                    self?.show(error: error)
+                }
+                .store(in: &cancellables)
+        }
     }
 
     private func handleAsync(_ signal: EventHandlerSignal) {
@@ -120,6 +122,6 @@ class DeepLinkViewManager {
     }
 
     private func handleWalletConnect(url: String) {
-        walletConnectManager.pair(url: url)
+        walletConnectManager?.pair(url: url)
     }
 }

--- a/packages/WalletCore/Sources/WalletCore/Modules/Main/MainBadgeViewModel.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/Main/MainBadgeViewModel.swift
@@ -36,7 +36,7 @@ class MainBadgeViewModel: ObservableObject {
             .sink { [weak self] _ in self?.syncSettingsBadge() }
             .store(in: &cancellables)
 
-        walletConnectSessionManager.activePendingRequestsObservable
+        walletConnectSessionManager?.activePendingRequestsObservable
             .subscribeOn(ConcurrentDispatchQueueScheduler(qos: .background))
             .observeOn(ConcurrentDispatchQueueScheduler(qos: .background))
             .subscribe(onNext: { [weak self] _ in
@@ -56,7 +56,7 @@ class MainBadgeViewModel: ObservableObject {
     }
 
     private var resolvedBadge: String? {
-        let count = walletConnectSessionManager.activePendingRequests.count
+        let count = walletConnectSessionManager?.activePendingRequests.count ?? 0
 
         if count > 0 {
             return count.description

--- a/packages/WalletCore/Sources/WalletCore/Modules/Main/Workers/AppEventHandlerKind.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/Main/Workers/AppEventHandlerKind.swift
@@ -1,0 +1,15 @@
+public struct AppEventHandlerKind: Hashable {
+    public let id: String
+
+    public init(id: String) {
+        self.id = id
+    }
+}
+
+public extension AppEventHandlerKind {
+    static let walletConnect = AppEventHandlerKind(id: "wallet_connect")
+    static let widgetCoin = AppEventHandlerKind(id: "widget_coin")
+    static let address = AppEventHandlerKind(id: "address")
+    static let telegramUser = AppEventHandlerKind(id: "telegram_user")
+    static let openCryptoPay = AppEventHandlerKind(id: "open_crypto_pay")
+}

--- a/packages/WalletCore/Sources/WalletCore/Modules/SendNew/WalletConnect/WalletConnectEvmSendHandler.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/SendNew/WalletConnect/WalletConnectEvmSendHandler.swift
@@ -5,7 +5,7 @@ import MarketKit
 class WalletConnectEvmSendHandler {
     private let request: WalletConnectRequest
     private let payload: WCEthereumTransactionPayload
-    private let signService: IWalletConnectSignService = Core.shared.walletConnectSessionManager.service
+    private let signService: IWalletConnectSignService
 
     let baseToken: Token
     private let transactionData: TransactionData
@@ -13,12 +13,13 @@ class WalletConnectEvmSendHandler {
     private let decorator = EvmDecorator()
     private let evmFeeEstimator = EvmFeeEstimator()
 
-    init(request: WalletConnectRequest, payload: WCEthereumTransactionPayload, baseToken: Token, transactionData: TransactionData, evmKitWrapper: EvmKitWrapper) {
+    init(request: WalletConnectRequest, payload: WCEthereumTransactionPayload, baseToken: Token, transactionData: TransactionData, evmKitWrapper: EvmKitWrapper, signService: IWalletConnectSignService) {
         self.request = request
         self.payload = payload
         self.baseToken = baseToken
         self.transactionData = transactionData
         self.evmKitWrapper = evmKitWrapper
+        self.signService = signService
     }
 }
 
@@ -128,6 +129,10 @@ extension WalletConnectEvmSendHandler {
             return nil
         }
 
+        guard let signService = Core.shared.walletConnectSessionManager?.service else {
+            return nil
+        }
+
         let transactionData = TransactionData(
             to: payload.transaction.to,
             value: payload.transaction.value,
@@ -139,7 +144,8 @@ extension WalletConnectEvmSendHandler {
             payload: payload,
             baseToken: baseToken,
             transactionData: transactionData,
-            evmKitWrapper: evmKitWrapper
+            evmKitWrapper: evmKitWrapper,
+            signService: signService
         )
     }
 }

--- a/packages/WalletCore/Sources/WalletCore/Modules/SendNew/WalletConnect/WalletConnectSendViewModel.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/SendNew/WalletConnect/WalletConnectSendViewModel.swift
@@ -2,7 +2,9 @@ import Combine
 
 class WalletConnectSendViewModel: ObservableObject {
     private let request: WalletConnectRequest
-    private let signService: IWalletConnectSignService = Core.shared.walletConnectSessionManager.service
+    private var signService: IWalletConnectSignService? {
+        Core.shared.walletConnectSessionManager?.service
+    }
 
     init(request: WalletConnectRequest) {
         self.request = request
@@ -29,6 +31,6 @@ class WalletConnectSendViewModel: ObservableObject {
     }
 
     func reject() {
-        signService.rejectRequest(id: request.id)
+        signService?.rejectRequest(id: request.id)
     }
 }

--- a/packages/WalletCore/Sources/WalletCore/Modules/SendNew/WalletConnect/WalletConnectStellarTransactionHandler.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/SendNew/WalletConnect/WalletConnectStellarTransactionHandler.swift
@@ -7,18 +7,19 @@ import stellarsdk
 class WalletConnectStellarTransactionHandler {
     private let request: WalletConnectRequest
     private let payload: WCStellarTransactionPayload
-    private let signService: IWalletConnectSignService = Core.shared.walletConnectSessionManager.service
+    private let signService: IWalletConnectSignService
 
     let baseToken: Token
     private let stellarKit: StellarKit.Kit
     private let keyPair: KeyPair
 
-    init(request: WalletConnectRequest, payload: WCStellarTransactionPayload, baseToken: Token, keyPair: KeyPair, stellarKit: StellarKit.Kit) {
+    init(request: WalletConnectRequest, payload: WCStellarTransactionPayload, baseToken: Token, keyPair: KeyPair, stellarKit: StellarKit.Kit, signService: IWalletConnectSignService) {
         self.request = request
         self.payload = payload
         self.baseToken = baseToken
         self.keyPair = keyPair
         self.stellarKit = stellarKit
+        self.signService = signService
     }
 }
 
@@ -262,12 +263,17 @@ extension WalletConnectStellarTransactionHandler {
             return nil
         }
 
+        guard let signService = Core.shared.walletConnectSessionManager?.service else {
+            return nil
+        }
+
         return WalletConnectStellarTransactionHandler(
             request: request,
             payload: payload,
             baseToken: baseToken,
             keyPair: keyPair,
             stellarKit: stellarKit,
+            signService: signService
         )
     }
 }

--- a/packages/WalletCore/Sources/WalletCore/Modules/Settings/Main/MainSettingsViewModel.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/Settings/Main/MainSettingsViewModel.swift
@@ -84,8 +84,10 @@ class MainSettingsViewModel: ObservableObject {
         debuggingAmlResult = localStorage.debuggingAmlCheckResult
 
         subscribe(MainScheduler.instance, disposeBag, backupManager.allBackedUpObservable) { [weak self] _ in self?.syncManageWalletsAlert() }
-        subscribe(MainScheduler.instance, disposeBag, walletConnectSessionManager.sessionsObservable) { [weak self] _ in self?.syncWalletConnectSessionCount() }
-        subscribe(MainScheduler.instance, disposeBag, walletConnectSessionManager.activePendingRequestsObservable) { [weak self] _ in self?.syncWalletConnectPendingRequestCount() }
+        if let walletConnectSessionManager {
+            subscribe(MainScheduler.instance, disposeBag, walletConnectSessionManager.sessionsObservable) { [weak self] _ in self?.syncWalletConnectSessionCount() }
+            subscribe(MainScheduler.instance, disposeBag, walletConnectSessionManager.activePendingRequestsObservable) { [weak self] _ in self?.syncWalletConnectPendingRequestCount() }
+        }
         subscribe(MainScheduler.instance, disposeBag, contactManager.iCloudErrorObservable) { [weak self] error in
             if error != nil, self?.contactManager.remoteSync ?? false {
                 self?.iCloudUnavailable = true
@@ -138,11 +140,11 @@ class MainSettingsViewModel: ObservableObject {
     }
 
     private func syncWalletConnectSessionCount() {
-        walletConnectSessionCount = walletConnectSessionManager.sessions.count
+        walletConnectSessionCount = walletConnectSessionManager?.sessions.count ?? 0
     }
 
     private func syncWalletConnectPendingRequestCount() {
-        walletConnectPendingRequestCount = walletConnectSessionManager.activePendingRequests.count
+        walletConnectPendingRequestCount = walletConnectSessionManager?.activePendingRequests.count ?? 0
     }
 
     private func syncSecurityAlert() {

--- a/packages/WalletCore/Sources/WalletCore/Modules/Wallet/WalletViewModel.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/Wallet/WalletViewModel.swift
@@ -146,7 +146,7 @@ extension WalletViewModel {
         coinPriceService.refresh()
     }
 
-    func process(scanned: String) {
+    public func process(scanned: String) {
         Task { [eventHandler] in
             try await eventHandler.handle(source: StatPage.balance, event: scanned.trimmingCharacters(in: .whitespacesAndNewlines), eventType: [.walletConnectUri, .address])
         }

--- a/packages/WalletCore/Sources/WalletCore/Modules/WalletConnect/List/WalletConnectListModule.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/WalletConnect/List/WalletConnectListModule.swift
@@ -2,9 +2,13 @@ import SwiftUI
 import UIKit
 
 enum WalletConnectListModule {
-    static func viewController() -> UIViewController {
+    static func viewController() -> UIViewController? {
+        guard let sessionManager = Core.shared.walletConnectSessionManager else {
+            return nil
+        }
+
         let service = WalletConnectListService(
-            sessionManager: Core.shared.walletConnectSessionManager,
+            sessionManager: sessionManager,
             evmBlockchainManager: Core.shared.evmBlockchainManager
         )
 
@@ -19,7 +23,7 @@ struct WalletConnectListView: UIViewControllerRepresentable {
     typealias UIViewControllerType = UIViewController
 
     func makeUIViewController(context _: Context) -> UIViewController {
-        WalletConnectListModule.viewController()
+        WalletConnectListModule.viewController() ?? ErrorViewController(text: AppError.unknownError.localizedDescription)
     }
 
     func updateUIViewController(_: UIViewController, context _: Context) {}

--- a/packages/WalletCore/Sources/WalletCore/Modules/WalletConnect/List/WalletConnectListViewController.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/WalletConnect/List/WalletConnectListViewController.swift
@@ -102,7 +102,9 @@ class WalletConnectListViewController: ThemeViewController {
         guard let account = Core.shared.accountManager.activeAccount else {
             return
         }
-        let viewController = WalletConnectMainModule.viewController(account: account, session: session, sourceViewController: self, viaPushing: true)
+        guard let viewController = WalletConnectMainModule.viewController(account: account, session: session, sourceViewController: self, viaPushing: true) else {
+            return
+        }
 
         stat(page: .walletConnect, event: .open(page: .walletConnectSession))
         navigationController?.pushViewController(viewController, animated: true)

--- a/packages/WalletCore/Sources/WalletCore/Modules/WalletConnect/Main/WalletConnectMainModule.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/WalletConnect/Main/WalletConnectMainModule.swift
@@ -7,11 +7,16 @@ import WalletConnectSign
 import WalletConnectUtils
 
 enum WalletConnectMainModule {
-    static func viewController(account: Account, session: WalletConnectSign.Session? = nil, proposal: WalletConnectSign.Session.Proposal? = nil, sourceViewController: UIViewController?, viaPushing: Bool = false) -> UIViewController {
-        let service = Core.shared.walletConnectSessionManager.service
+    static func viewController(account: Account, session: WalletConnectSign.Session? = nil, proposal: WalletConnectSign.Session.Proposal? = nil, sourceViewController: UIViewController?, viaPushing: Bool = false) -> UIViewController? {
+        guard let sessionManager = Core.shared.walletConnectSessionManager,
+              let walletConnectRequestHandler = Core.shared.walletConnectRequestHandler
+        else {
+            return nil
+        }
+
+        let service = sessionManager.service
 
         let chain = ProposalChain()
-        let walletConnectRequestHandler = Core.shared.walletConnectRequestHandler
         chain.append(handler: Eip155ProposalHandler(evmBlockchainManager: Core.shared.evmBlockchainManager, account: account, supportedMethods: walletConnectRequestHandler.supportedMethodsBy(namespace: Eip155ProposalHandler.namespace)))
 
         chain.append(handler: StellarProposalHandler(stellarKitManager: Core.shared.stellarKitManager, account: account, supportedMethods: walletConnectRequestHandler.supportedMethodsBy(namespace: StellarProposalHandler.namespace)))
@@ -29,11 +34,17 @@ enum WalletConnectMainModule {
         return viewController(service: mainService, sourceViewController: sourceViewController, viaPushing: viaPushing)
     }
 
-    static func viewController(service: WalletConnectMainService, sourceViewController: UIViewController?, viaPushing: Bool = false) -> UIViewController {
+    static func viewController(service: WalletConnectMainService, sourceViewController: UIViewController?, viaPushing: Bool = false) -> UIViewController? {
+        guard let sessionManager = Core.shared.walletConnectSessionManager,
+              let requestHandler = Core.shared.walletConnectRequestHandler
+        else {
+            return nil
+        }
+
         let viewModel = WalletConnectMainViewModel(service: service)
         let viewController = WalletConnectMainViewController(
             viewModel: viewModel,
-            requestViewFactory: Core.shared.walletConnectRequestHandler,
+            requestViewFactory: requestHandler,
             sourceViewController: sourceViewController,
             viaPushing: viaPushing
         )
@@ -41,10 +52,10 @@ enum WalletConnectMainModule {
         let pendingRequestService = WalletConnectMainPendingRequestService(
             service: service,
             accountManager: Core.shared.accountManager,
-            sessionManager: Core.shared.walletConnectSessionManager,
-            requestHandler: Core.shared.walletConnectRequestHandler,
+            sessionManager: sessionManager,
+            requestHandler: requestHandler,
             evmBlockchainManager: Core.shared.evmBlockchainManager,
-            signService: Core.shared.walletConnectSessionManager.service
+            signService: sessionManager.service
         )
         let pendingRequestViewModel = WalletConnectMainPendingRequestViewModel(service: pendingRequestService)
         viewController.pendingRequestViewModel = pendingRequestViewModel
@@ -65,6 +76,7 @@ struct WalletConnectMainView: UIViewControllerRepresentable {
 
     func makeUIViewController(context _: Context) -> UIViewController {
         WalletConnectMainModule.viewController(account: account, session: session, proposal: proposal, sourceViewController: nil)
+            ?? ErrorViewController(text: AppError.unknownError.localizedDescription)
     }
 
     func updateUIViewController(_: UIViewController, context _: Context) {}

--- a/packages/WalletCore/Sources/WalletCore/Modules/WalletConnect/Request/Confirmations/SendEthereumTransaction/WCSendEthereumTransactionRequestModule.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/WalletConnect/Request/Confirmations/SendEthereumTransaction/WCSendEthereumTransactionRequestModule.swift
@@ -22,7 +22,9 @@ enum WCSendEthereumTransactionRequestModule {
             return nil
         }
 
-        let signService = Core.shared.walletConnectSessionManager.service
+        guard let signService = Core.shared.walletConnectSessionManager?.service else {
+            return nil
+        }
         guard let service = WCSendEthereumTransactionRequestService(request: request, baseService: signService) else {
             return nil
         }

--- a/packages/WalletCore/Sources/WalletCore/Modules/WalletConnect/Request/Confirmations/Sign/WCSignMessageRequestModule.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/WalletConnect/Request/Confirmations/Sign/WCSignMessageRequestModule.swift
@@ -7,16 +7,16 @@ enum WCSignMessageRequestModule {
         guard let account = Core.shared.accountManager.activeAccount,
               let chainId = Int(request.chain.id),
               let evmWrapper = Core.shared.evmBlockchainManager.kitWrapper(chainId: chainId, account: account),
-              let signer = evmWrapper.signer
+              let signer = evmWrapper.signer,
+              let signService = Core.shared.walletConnectSessionManager?.service
         else {
             return nil
         }
 
-        return viewController(account: account, evmWrapper: evmWrapper, signer: signer, request: request)
+        return viewController(account: account, evmWrapper: evmWrapper, signer: signer, request: request, signService: signService)
     }
 
-    static func viewController(account _: Account, evmWrapper _: EvmKitWrapper, signer: Signer, request: WalletConnectRequest) -> UIViewController {
-        let signService = Core.shared.walletConnectSessionManager.service
+    static func viewController(account _: Account, evmWrapper _: EvmKitWrapper, signer: Signer, request: WalletConnectRequest, signService: IWalletConnectSignService) -> UIViewController {
         let service = WCSignMessageRequestService(request: request, signService: signService, signer: signer)
         let viewModel = WCSignMessageRequestViewModel(service: service)
 

--- a/packages/WalletCore/Sources/WalletCore/Modules/WalletConnect/Request/Confirmations/SignEthereumTransaction/WCSignEthereumTransactionRequestModule.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/WalletConnect/Request/Confirmations/SignEthereumTransaction/WCSignEthereumTransactionRequestModule.swift
@@ -22,7 +22,9 @@ enum WCSignEthereumTransactionRequestModule {
             return nil
         }
 
-        let wcService = Core.shared.walletConnectSessionManager.service
+        guard let wcService = Core.shared.walletConnectSessionManager?.service else {
+            return nil
+        }
         let viewModel = WCSignEthereumTransactionRequestViewModel(requestId: request.id, payload: payload, evmKitWrapper: evmKitWrapper, wcService: wcService)
 
         let info = SendEvmData.DAppInfo(name: request.payload.dAppName, chainName: request.chain.chainName, address: request.chain.address)


### PR DESCRIPTION
- Deep link routes and app event handlers are now assembled per app: empty-by-default registries (`DeepLinkRouteFactory`, `AppEventHandlerFactory`), each app registers its set before `Core.initApp`; `DeepLinkManager` if-chain split into `IDeepLinkMatcher` classes filtered by registered routes. Unstoppable registers the full set — behavior is unchanged.
- The WalletConnect stack is built only when the `walletConnect` handler kind is registered, so an app without WC never configures the relay networking or opens its socket.
- Added `appTransfer` route (`<scheme>://send?uri=<transfer-uri>`, scheme provided at registration) and `DeepLinkPresenterFactory`: each app explicitly registers its send presenter (no built-in fallback); exposed `AppManager.didReceive(url:)` and `WalletViewModel.process(scanned:)` for apps with their own view layer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded deep-link coverage for wallet connections, transfers, referrals, crypto payments, and coin links.
  * Enabled app-level customization of transfer deep-link presentation.
* **Bug Fixes**
  * Improved stability when WalletConnect support is not available (no unnecessary setup).
  * Added graceful fallbacks when WalletConnect screens or confirmation services can’t load.
  * Deep-link recognition is now more reliable, with safe handling of malformed/unsupported links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->