### PR TITLE
Add autoEnableStats flag to Core.Config

### DIFF
--- a/packages/WalletCore/Sources/WalletCore/Core/Core.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Core.swift
@@ -428,7 +428,7 @@ public class Core {
         recentAddressStorage = try RecentAddressStorage(dbPool: dbPool)
 
         let statStorage = StatStorage(dbPool: dbPool)
-        statManager = StatManager(marketKit: marketKit, storage: statStorage, userDefaultsStorage: userDefaultsStorage)
+        statManager = StatManager(marketKit: marketKit, storage: statStorage, userDefaultsStorage: userDefaultsStorage, autoEnableStats: config.autoEnableStats)
 
         let tonConnectStorage = try TonConnectStorage(dbPool: dbPool)
         tonConnectManager = TonConnectManager(storage: tonConnectStorage, accountManager: accountManager)
@@ -521,9 +521,11 @@ public class Core {
 public extension Core {
     struct Config {
         let autoEnableTokensOnReceive: Bool
+        let autoEnableStats: Bool
 
-        public init(autoEnableTokensOnReceive: Bool = true) {
+        public init(autoEnableTokensOnReceive: Bool = true, autoEnableStats: Bool = true) {
             self.autoEnableTokensOnReceive = autoEnableTokensOnReceive
+            self.autoEnableStats = autoEnableStats
         }
     }
 }

--- a/packages/WalletCore/Sources/WalletCore/Core/Managers/StatManager.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Managers/StatManager.swift
@@ -37,14 +37,14 @@ class StatManager {
         allowedSubject.eraseToAnyPublisher()
     }
 
-    init(marketKit: MarketKit.Kit, storage: StatStorage, userDefaultsStorage: UserDefaultsStorage) {
+    init(marketKit: MarketKit.Kit, storage: StatStorage, userDefaultsStorage: UserDefaultsStorage, autoEnableStats: Bool) {
         self.marketKit = marketKit
         self.storage = storage
         self.userDefaultsStorage = userDefaultsStorage
 
         appVersion = AppConfig.appVersion
         appId = AppConfig.appId
-        allowed = userDefaultsStorage.value(for: StatManager.keySendingAllowed) ?? true
+        allowed = userDefaultsStorage.value(for: StatManager.keySendingAllowed) ?? autoEnableStats
     }
 
     func logStat(eventPage: StatPage, eventSection: StatSection? = nil, event: StatEvent) {


### PR DESCRIPTION
Default stats-sending consent is now app-configurable: StatManager falls back to autoEnableStats instead of hardcoded true.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a configuration option to control whether statistics are enabled automatically.
  - Automatic statistics remain enabled by default for existing setups.
  - When no previous preference is saved, the configured default now determines the initial statistics setting.
  - Existing saved statistics preferences continue to take precedence over the configured default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->