### PR TITLE
Assemble EVM transaction converters per app

### DIFF
--- a/Unstoppable/Unstoppable/App/Transactions/UnstoppableEvmKitConfigProvider.swift
+++ b/Unstoppable/Unstoppable/App/Transactions/UnstoppableEvmKitConfigProvider.swift
@@ -1,4 +1,5 @@
 import EvmKit
+import MarketKit
 import WalletCore
 
 // App-side default EVM config for the Unstoppable app. Moved out of WalletCore (which now registers no provider
@@ -10,5 +11,11 @@ enum UnstoppableEvmKitConfigProvider: IEvmKitConfigProvider {
 
     static func decorators(account _: Account, evmKit: EvmKit.Kit) {
         EvmKitConfigFactory.defaultDecorators(evmKit: evmKit)
+    }
+}
+
+enum UnstoppableEvmTransactionConverterProvider: IEvmTransactionConverterProvider {
+    static func converters(baseToken: MarketKit.Token, userAddress: EvmKit.Address) -> [IEvmTransactionConverter]? {
+        EvmTransactionConverterFactory.defaultConverters(baseToken: baseToken, userAddress: userAddress)
     }
 }

--- a/Unstoppable/Unstoppable/App/UnstoppableApp.swift
+++ b/Unstoppable/Unstoppable/App/UnstoppableApp.swift
@@ -46,9 +46,12 @@ struct UnstoppableApp: App {
             .forEach { AppEventHandlerFactory.register($0) }
         DeepLinkPresenterFactory.register(sendPresenter: DeepLinkPresenterFactory.sendPresenter)
 
-        try Core.initApp(config: Core.Config(), widgetRefresher: WidgetRefresher())
-
+        // Registered BEFORE Core.initApp: adapters/kits are created asynchronously on wallet events, and their
+        // factories fatalError on a missing provider — registration must deterministically precede any creation.
         EvmKitConfigFactory.register(UnstoppableEvmKitConfigProvider.self)
+        EvmTransactionConverterFactory.register(UnstoppableEvmTransactionConverterProvider.self)
+
+        try Core.initApp(config: Core.Config(), widgetRefresher: WidgetRefresher())
 
         Core.shared.appManager.didFinishLaunching()
     }

--- a/packages/WalletCore/Sources/WalletCore/Core/Adapters/Evm/Eip20Adapter.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Adapters/Evm/Eip20Adapter.swift
@@ -10,19 +10,27 @@ public class Eip20Adapter: BaseEvmAdapter {
     private static let approveConfirmationsThreshold: Int? = nil
     public let eip20Kit: Eip20Kit.Kit
     private let contractAddress: EvmKit.Address
-    private let transactionConverter: EvmTransactionConverter
+    private let converters: [IEvmTransactionConverter]
 
-    init(evmKitWrapper: EvmKitWrapper, contractAddress: String, wallet: Wallet, baseToken: Token, coinManager: CoinManager, evmLabelManager: EvmLabelManager) throws {
+    init(evmKitWrapper: EvmKitWrapper, contractAddress: String, wallet: Wallet, baseToken: Token) throws {
         let address = try EvmKit.Address(hex: contractAddress)
         eip20Kit = try Eip20Kit.Kit.instance(evmKit: evmKitWrapper.evmKit, contractAddress: address)
         self.contractAddress = address
 
-        transactionConverter = EvmTransactionConverter(
-            source: wallet.transactionSource, baseToken: baseToken, coinManager: coinManager, blockchainType: evmKitWrapper.blockchainType,
-            userAddress: evmKitWrapper.evmKit.address, evmLabelManager: evmLabelManager
-        )
+        converters = EvmTransactionConverterFactory.converters(baseToken: baseToken, userAddress: evmKitWrapper.evmKit.address)
 
         super.init(evmKitWrapper: evmKitWrapper, decimals: wallet.decimals)
+    }
+
+    private func record(fromTransaction fullTransaction: FullTransaction) -> TransactionRecord? {
+        for converter in converters {
+            if let record = converter.convert(fullTransaction: fullTransaction) {
+                return record
+            }
+        }
+
+        print("Eip20Adapter: converter chain produced no record for \(fullTransaction.transaction.hash.hs.hexString)")
+        return nil
     }
 }
 
@@ -70,7 +78,7 @@ extension Eip20Adapter: ISendEthereumAdapter {
 
 extension Eip20Adapter: IAllowanceAdapter {
     var pendingTransactions: [TransactionRecord] {
-        eip20Kit.pendingTransactions().map { transactionConverter.transactionRecord(fromTransaction: $0) }
+        eip20Kit.pendingTransactions().compactMap { record(fromTransaction: $0) }
     }
 
     func allowance(spenderAddress: Address, defaultBlockParameter: BlockParameter) async throws -> Decimal {

--- a/packages/WalletCore/Sources/WalletCore/Core/Adapters/Evm/EvmTransactionConverter.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Adapters/Evm/EvmTransactionConverter.swift
@@ -7,24 +7,25 @@ import NftKit
 import OneInchKit
 import UniswapKit
 
-class EvmTransactionConverter {
-    private let coinManager: CoinManager
-    private let blockchainType: BlockchainType
-    private let userAddress: EvmKit.Address
-    private let evmLabelManager: EvmLabelManager
-    private let source: TransactionSource
-    private let baseToken: MarketKit.Token
+public class EvmTransactionConverter {
+    public let coinManager: CoinManager
+    public let userAddress: EvmKit.Address
+    public let evmLabelManager: EvmLabelManager
+    public let baseToken: MarketKit.Token
 
-    init(source: TransactionSource, baseToken: MarketKit.Token, coinManager: CoinManager, blockchainType: BlockchainType, userAddress: EvmKit.Address, evmLabelManager: EvmLabelManager) {
+    // EVM token types carry no source meta, so the record TransactionSource is fully defined by the base token.
+    public var source: TransactionSource {
+        TransactionSource(blockchainType: baseToken.blockchainType, meta: nil)
+    }
+
+    public init(baseToken: MarketKit.Token, coinManager: CoinManager, userAddress: EvmKit.Address, evmLabelManager: EvmLabelManager) {
         self.coinManager = coinManager
-        self.blockchainType = blockchainType
         self.userAddress = userAddress
         self.evmLabelManager = evmLabelManager
-        self.source = source
         self.baseToken = baseToken
     }
 
-    private func convertAmount(amount: BigUInt, decimals: Int, sign: FloatingPointSign) -> Decimal {
+    public static func convertAmount(amount: BigUInt, decimals: Int, sign: FloatingPointSign) -> Decimal {
         guard let significand = Decimal(string: amount.description), significand != 0 else {
             return 0
         }
@@ -32,23 +33,23 @@ class EvmTransactionConverter {
         return Decimal(sign: sign, exponent: -decimals, significand: significand)
     }
 
-    private func baseAppValue(value: BigUInt, sign: FloatingPointSign) -> AppValue {
-        let amount = convertAmount(amount: value, decimals: baseToken.decimals, sign: sign)
+    public static func baseAppValue(baseToken: MarketKit.Token, value: BigUInt, sign: FloatingPointSign) -> AppValue {
+        let amount = Self.convertAmount(amount: value, decimals: baseToken.decimals, sign: sign)
         return AppValue(token: baseToken, value: amount)
     }
 
-    private func eip20Value(tokenAddress: EvmKit.Address, value: BigUInt, sign: FloatingPointSign, tokenInfo: Eip20Kit.TokenInfo?) -> AppValue {
-        let query = TokenQuery(blockchainType: blockchainType, tokenType: .eip20(address: tokenAddress.hex))
+    public static func eip20Value(baseToken: MarketKit.Token, coinManager: CoinManager, tokenAddress: EvmKit.Address, value: BigUInt, sign: FloatingPointSign, tokenInfo: Eip20Kit.TokenInfo?) -> AppValue {
+        let query = TokenQuery(blockchainType: baseToken.blockchainType, tokenType: .eip20(address: tokenAddress.hex))
 
         if let token = try? coinManager.token(query: query) {
-            let value = convertAmount(amount: value, decimals: token.decimals, sign: sign)
+            let value = Self.convertAmount(amount: value, decimals: token.decimals, sign: sign)
             return AppValue(token: token, value: value)
         } else if let tokenInfo {
-            let value = convertAmount(amount: value, decimals: tokenInfo.tokenDecimal, sign: sign)
+            let value = Self.convertAmount(amount: value, decimals: tokenInfo.tokenDecimal, sign: sign)
             return AppValue(tokenName: tokenInfo.tokenName, tokenCode: tokenInfo.tokenSymbol, tokenDecimals: tokenInfo.tokenDecimal, value: value)
         }
 
-        return AppValue(value: convertAmount(amount: value, decimals: 0, sign: sign))
+        return AppValue(value: Self.convertAmount(amount: value, decimals: 0, sign: sign))
     }
 
     private func convertToAmount(token: SwapDecoration.Token, amount: SwapDecoration.Amount, sign: FloatingPointSign) -> SwapTransactionRecord.Amount {
@@ -60,8 +61,8 @@ class EvmTransactionConverter {
 
     private func convertToAppValue(token: SwapDecoration.Token, value: BigUInt, sign: FloatingPointSign) -> AppValue {
         switch token {
-        case .evmCoin: return baseAppValue(value: value, sign: sign)
-        case let .eip20Coin(tokenAddress, tokenInfo): return eip20Value(tokenAddress: tokenAddress, value: value, sign: sign, tokenInfo: tokenInfo)
+        case .evmCoin: return Self.baseAppValue(baseToken: baseToken, value: value, sign: sign)
+        case let .eip20Coin(tokenAddress, tokenInfo): return Self.eip20Value(baseToken: baseToken, coinManager: coinManager, tokenAddress: tokenAddress, value: value, sign: sign, tokenInfo: tokenInfo)
         }
     }
 
@@ -74,25 +75,25 @@ class EvmTransactionConverter {
 
     private func convertToAppValue(token: OneInchDecoration.Token, value: BigUInt, sign: FloatingPointSign) -> AppValue {
         switch token {
-        case .evmCoin: return baseAppValue(value: value, sign: sign)
-        case let .eip20Coin(tokenAddress, tokenInfo): return eip20Value(tokenAddress: tokenAddress, value: value, sign: sign, tokenInfo: tokenInfo)
+        case .evmCoin: return Self.baseAppValue(baseToken: baseToken, value: value, sign: sign)
+        case let .eip20Coin(tokenAddress, tokenInfo): return Self.eip20Value(baseToken: baseToken, coinManager: coinManager, tokenAddress: tokenAddress, value: value, sign: sign, tokenInfo: tokenInfo)
         }
     }
 
-    private func transferEvents(incomingEip20Transfers: [TransferEventInstance]) -> [TransferEvent] {
+    public static func transferEvents(baseToken: MarketKit.Token, coinManager: CoinManager, incomingEip20Transfers: [TransferEventInstance]) -> [TransferEvent] {
         incomingEip20Transfers.map { transfer in
             TransferEvent(
                 address: transfer.from.eip55,
-                value: eip20Value(tokenAddress: transfer.contractAddress, value: transfer.value, sign: .plus, tokenInfo: transfer.tokenInfo)
+                value: eip20Value(baseToken: baseToken, coinManager: coinManager, tokenAddress: transfer.contractAddress, value: transfer.value, sign: .plus, tokenInfo: transfer.tokenInfo)
             )
         }
     }
 
-    private func transferEvents(outgoingEip20Transfers: [TransferEventInstance]) -> [TransferEvent] {
+    public static func transferEvents(baseToken: MarketKit.Token, coinManager: CoinManager, outgoingEip20Transfers: [TransferEventInstance]) -> [TransferEvent] {
         outgoingEip20Transfers.map { transfer in
             TransferEvent(
                 address: transfer.to.eip55,
-                value: eip20Value(tokenAddress: transfer.contractAddress, value: transfer.value, sign: .minus, tokenInfo: transfer.tokenInfo)
+                value: eip20Value(baseToken: baseToken, coinManager: coinManager, tokenAddress: transfer.contractAddress, value: transfer.value, sign: .minus, tokenInfo: transfer.tokenInfo)
             )
         }
     }
@@ -133,7 +134,7 @@ class EvmTransactionConverter {
                     nftUid: .evm(blockchainType: source.blockchainType, contractAddress: transfer.contractAddress.hex, tokenId: transfer.tokenId.description),
                     tokenName: transfer.tokenInfo?.tokenName,
                     tokenSymbol: transfer.tokenInfo?.tokenSymbol,
-                    value: convertAmount(amount: transfer.value, decimals: 0, sign: .plus)
+                    value: Self.convertAmount(amount: transfer.value, decimals: 0, sign: .plus)
                 )
             )
         }
@@ -147,17 +148,17 @@ class EvmTransactionConverter {
                     nftUid: .evm(blockchainType: source.blockchainType, contractAddress: transfer.contractAddress.hex, tokenId: transfer.tokenId.description),
                     tokenName: transfer.tokenInfo?.tokenName,
                     tokenSymbol: transfer.tokenInfo?.tokenSymbol,
-                    value: convertAmount(amount: transfer.value, decimals: 0, sign: .minus)
+                    value: Self.convertAmount(amount: transfer.value, decimals: 0, sign: .minus)
                 )
             )
         }
     }
 
-    private func transferEvents(internalTransactions: [InternalTransaction]) -> [TransferEvent] {
+    public static func transferEvents(baseToken: MarketKit.Token, internalTransactions: [InternalTransaction]) -> [TransferEvent] {
         internalTransactions.map { internalTransaction in
             TransferEvent(
                 address: internalTransaction.from.eip55,
-                value: baseAppValue(value: internalTransaction.value, sign: .plus)
+                value: baseAppValue(baseToken: baseToken, value: internalTransaction.value, sign: .plus)
             )
         }
     }
@@ -169,14 +170,21 @@ class EvmTransactionConverter {
 
         let event = TransferEvent(
             address: contractAddress.eip55,
-            value: baseAppValue(value: value, sign: .minus)
+            value: Self.baseAppValue(baseToken: baseToken, value: value, sign: .minus)
         )
 
         return [event]
     }
 }
 
-extension EvmTransactionConverter {
+extension EvmTransactionConverter: IEvmTransactionConverter {
+    // Total: the default case returns a plain EvmTransactionRecord, so the chain always terminates here.
+    public func convert(fullTransaction: FullTransaction) -> TransactionRecord? {
+        transactionRecord(fromTransaction: fullTransaction)
+    }
+}
+
+public extension EvmTransactionConverter {
     func transactionRecord(fromTransaction fullTransaction: FullTransaction) -> TransactionRecord {
         let transaction = fullTransaction.transaction
         let protected = MerkleTransactionAdapter.isProtected(transaction: fullTransaction)
@@ -191,7 +199,7 @@ extension EvmTransactionConverter {
             )
 
         case let decoration as IncomingDecoration:
-            let appValue = baseAppValue(value: decoration.value, sign: .plus)
+            let appValue = Self.baseAppValue(baseToken: baseToken, value: decoration.value, sign: .plus)
 
             return EvmIncomingTransactionRecord(
                 source: source,
@@ -207,7 +215,7 @@ extension EvmTransactionConverter {
                 transaction: transaction,
                 baseToken: baseToken,
                 to: decoration.to.eip55,
-                value: baseAppValue(value: decoration.value, sign: .minus),
+                value: Self.baseAppValue(baseToken: baseToken, value: decoration.value, sign: .minus),
                 sentToSelf: decoration.sentToSelf,
                 protected: protected
             )
@@ -218,7 +226,7 @@ extension EvmTransactionConverter {
                 transaction: transaction,
                 baseToken: baseToken,
                 to: decoration.to.eip55,
-                value: eip20Value(tokenAddress: decoration.contractAddress, value: decoration.value, sign: .minus, tokenInfo: decoration.tokenInfo),
+                value: Self.eip20Value(baseToken: baseToken, coinManager: coinManager, tokenAddress: decoration.contractAddress, value: decoration.value, sign: .minus, tokenInfo: decoration.tokenInfo),
                 sentToSelf: decoration.sentToSelf,
                 protected: protected
             )
@@ -229,7 +237,7 @@ extension EvmTransactionConverter {
                 transaction: transaction,
                 baseToken: baseToken,
                 spender: decoration.spender.eip55,
-                value: eip20Value(tokenAddress: decoration.contractAddress, value: decoration.value, sign: .plus, tokenInfo: nil),
+                value: Self.eip20Value(baseToken: baseToken, coinManager: coinManager, tokenAddress: decoration.contractAddress, value: decoration.value, sign: .plus, tokenInfo: nil),
                 protected: protected
             )
 
@@ -290,7 +298,7 @@ extension EvmTransactionConverter {
                     nftUid: .evm(blockchainType: source.blockchainType, contractAddress: decoration.contractAddress.hex, tokenId: decoration.tokenId.description),
                     tokenName: decoration.tokenInfo?.tokenName,
                     tokenSymbol: decoration.tokenInfo?.tokenSymbol,
-                    value: convertAmount(amount: 1, decimals: 0, sign: .minus)
+                    value: Self.convertAmount(amount: 1, decimals: 0, sign: .minus)
                 ),
                 sentToSelf: decoration.sentToSelf,
                 protected: protected
@@ -306,7 +314,7 @@ extension EvmTransactionConverter {
                     nftUid: .evm(blockchainType: source.blockchainType, contractAddress: decoration.contractAddress.hex, tokenId: decoration.tokenId.description),
                     tokenName: decoration.tokenInfo?.tokenName,
                     tokenSymbol: decoration.tokenInfo?.tokenSymbol,
-                    value: convertAmount(amount: decoration.value, decimals: 0, sign: .minus)
+                    value: Self.convertAmount(amount: decoration.value, decimals: 0, sign: .minus)
                 ),
                 sentToSelf: decoration.sentToSelf,
                 protected: protected
@@ -327,8 +335,8 @@ extension EvmTransactionConverter {
             let incomingEip1155Transfers = eip1155Transfers.filter { $0.to == userAddress && $0.from != userAddress }
             let outgoingEip1155Transfers = eip1155Transfers.filter { $0.from == userAddress }
 
-            let incomingEvents = transferEvents(internalTransactions: internalTransactions) + transferEvents(incomingEip20Transfers: incomingEip20Transfers) + transferEvents(incomingEip721Transfers: incomingEip721Transfers) + transferEvents(incomingEip1155Transfers: incomingEip1155Transfers)
-            let outgoingEvents = transferEvents(outgoingEip20Transfers: outgoingEip20Transfers) + transferEvents(outgoingEip721Transfers: outgoingEip721Transfers) + transferEvents(outgoingEip1155Transfers: outgoingEip1155Transfers)
+            let incomingEvents = Self.transferEvents(baseToken: baseToken, internalTransactions: internalTransactions) + Self.transferEvents(baseToken: baseToken, coinManager: coinManager, incomingEip20Transfers: incomingEip20Transfers) + transferEvents(incomingEip721Transfers: incomingEip721Transfers) + transferEvents(incomingEip1155Transfers: incomingEip1155Transfers)
+            let outgoingEvents = Self.transferEvents(baseToken: baseToken, coinManager: coinManager, outgoingEip20Transfers: outgoingEip20Transfers) + transferEvents(outgoingEip721Transfers: outgoingEip721Transfers) + transferEvents(outgoingEip1155Transfers: outgoingEip1155Transfers)
 
             if transaction.from == userAddress, let contractAddress = transaction.to, let value = transaction.value {
                 return ContractCallTransactionRecord(

--- a/packages/WalletCore/Sources/WalletCore/Core/Adapters/Evm/EvmTransactionsAdapter.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Adapters/Evm/EvmTransactionsAdapter.swift
@@ -11,25 +11,28 @@ class EvmTransactionsAdapter: BaseEvmAdapter {
     static let decimal = 18
 
     private let evmTransactionSource: EvmKit.TransactionSource
-    private let transactionConverter: EvmTransactionConverter
+    private let converters: [IEvmTransactionConverter]
     private let spamManager: SpamManager?
 
-    init(evmKitWrapper: EvmKitWrapper, source: TransactionSource, baseToken: MarketKit.Token, evmTransactionSource: EvmKit.TransactionSource, coinManager: CoinManager, spamWrapper: SpamWrapper, evmLabelManager: EvmLabelManager) {
+    init(evmKitWrapper: EvmKitWrapper, source: TransactionSource, baseToken: MarketKit.Token, evmTransactionSource: EvmKit.TransactionSource, spamWrapper: SpamWrapper) {
         self.evmTransactionSource = evmTransactionSource
         spamManager = spamWrapper.spamManager(source: source)
 
-        transactionConverter = EvmTransactionConverter(
-            source: source,
-            baseToken: baseToken,
-            coinManager: coinManager,
-            blockchainType: evmKitWrapper.blockchainType,
-            userAddress: evmKitWrapper.evmKit.address,
-            evmLabelManager: evmLabelManager
-        )
-
+        converters = EvmTransactionConverterFactory.converters(baseToken: baseToken, userAddress: evmKitWrapper.evmKit.address)
         super.init(evmKitWrapper: evmKitWrapper, decimals: EvmAdapter.decimals)
 
         initializeSpamManager()
+    }
+
+    private func record(fromTransaction fullTransaction: FullTransaction) -> TransactionRecord? {
+        for converter in converters {
+            if let record = converter.convert(fullTransaction: fullTransaction) {
+                return record
+            }
+        }
+
+        print("EvmTransactionsAdapter: converter chain produced no record for \(fullTransaction.transaction.hash.hs.hexString)")
+        return nil
     }
 
     private func initializeSpamManager() {
@@ -106,7 +109,7 @@ extension EvmTransactionsAdapter: ITransactionsAdapter {
 
     private func handleTransactions(_ transactions: [FullTransaction]) -> [TransactionRecord] {
         // Preserve evmKit order (descending — newest first)
-        let records = transactions.map { transactionConverter.transactionRecord(fromTransaction: $0) }
+        let records = transactions.compactMap { record(fromTransaction: $0) }
 
         // Mutates .spam in-place via reference type.
         // Internally sorts ascending for correct detection,
@@ -140,7 +143,7 @@ extension EvmTransactionsAdapter: ITransactionsAdapter {
     func allTransactionsAfter(paginationData: String?) -> Single<[TransactionRecord]> {
         let hash = paginationData?.hs.hexData
         let transactions = evmKit.allTransactionsAfter(transactionHash: hash)
-        let records = transactions.compactMap { transactionConverter.transactionRecord(fromTransaction: $0) }
+        let records = transactions.compactMap { record(fromTransaction: $0) }
 
         return Single.just(records)
     }

--- a/packages/WalletCore/Sources/WalletCore/Core/Factories/AdapterFactory.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Factories/AdapterFactory.swift
@@ -53,7 +53,7 @@ public class AdapterFactory {
         return EvmAdapter(evmKitWrapper: evmKitWrapper)
     }
 
-    private func eip20Adapter(address: String, wallet: Wallet, coinManager: CoinManager) -> IAdapter? {
+    private func eip20Adapter(address: String, wallet: Wallet) -> IAdapter? {
         guard let blockchainType = evmBlockchainManager.blockchain(token: wallet.token)?.type else {
             return nil
         }
@@ -68,9 +68,7 @@ public class AdapterFactory {
             evmKitWrapper: evmKitWrapper,
             contractAddress: address,
             wallet: wallet,
-            baseToken: baseToken,
-            coinManager: coinManager,
-            evmLabelManager: evmLabelManager
+            baseToken: baseToken
         )
     }
 
@@ -113,9 +111,7 @@ extension AdapterFactory {
                 source: transactionSource,
                 baseToken: baseToken,
                 evmTransactionSource: syncSource.transactionSource,
-                coinManager: coinManager,
-                spamWrapper: spamWrapper,
-                evmLabelManager: evmLabelManager
+                spamWrapper: spamWrapper
             )
             return TransactionsAdapterDecoratorFactory.decorate(adapter: adapter, source: transactionSource)
         }
@@ -226,7 +222,7 @@ extension AdapterFactory {
             return evmAdapter(wallet: wallet)
 
         case let (.eip20(address), .ethereum), let (.eip20(address), .binanceSmartChain), let (.eip20(address), .polygon), let (.eip20(address), .avalanche), let (.eip20(address), .optimism), let (.eip20(address), .arbitrumOne), let (.eip20(address), .gnosis), let (.eip20(address), .fantom), let (.eip20(address), .base), let (.eip20(address), .zkSync):
-            return eip20Adapter(address: address, wallet: wallet, coinManager: coinManager)
+            return eip20Adapter(address: address, wallet: wallet)
 
         case (.native, .tron):
             return tronAdapter(wallet: wallet)

--- a/packages/WalletCore/Sources/WalletCore/Core/Factories/EvmTransactionConverterFactory.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Factories/EvmTransactionConverterFactory.swift
@@ -1,0 +1,55 @@
+import EvmKit
+import MarketKit
+
+// One FullTransaction → TransactionRecord converter in an app-assembled chain. nil → the next converter.
+public protocol IEvmTransactionConverter {
+    func convert(fullTransaction: FullTransaction) -> TransactionRecord?
+}
+
+// Supplies the converter chain for one adapter instance. Only the truly per-wallet context is passed:
+// singletons (coinManager, evmLabelManager) are resolved inside WalletCore; the record TransactionSource is
+// reconstructed from `baseToken` (EVM token types carry no source meta). nil → try the next provider.
+public protocol IEvmTransactionConverterProvider {
+    static func converters(baseToken: MarketKit.Token, userAddress: EvmKit.Address) -> [IEvmTransactionConverter]?
+}
+
+// Empty by default — every app registers a provider that supplies a converter chain for every EVM wallet,
+// ending with a TOTAL converter (`defaultConverters`); mirrors EvmKitConfigFactory.
+public enum EvmTransactionConverterFactory {
+    private static var providers: [IEvmTransactionConverterProvider.Type] = []
+
+    public static func register(_ provider: IEvmTransactionConverterProvider.Type) {
+        providers.append(provider)
+    }
+
+    public static func prepend(_ provider: IEvmTransactionConverterProvider.Type) {
+        providers.insert(provider, at: 0)
+    }
+
+    static func converters(baseToken: MarketKit.Token, userAddress: EvmKit.Address) -> [IEvmTransactionConverter] {
+        for provider in providers {
+            if let converters = provider.converters(baseToken: baseToken, userAddress: userAddress) {
+                return converters
+            }
+        }
+
+        // An empty chain silently breaks transaction history — a misconfiguration, never valid. Every app must
+        // register a provider (EvmTransactionConverterFactory.register) that returns a chain for every EVM wallet.
+        fatalError("EvmTransactionConverterFactory: no registered provider supplied converters for \(baseToken.blockchainType.uid)")
+    }
+
+    // The stock converter wired with the shared managers — public so an app chain composes or reuses it.
+    public static func defaultConverter(baseToken: MarketKit.Token, userAddress: EvmKit.Address) -> EvmTransactionConverter {
+        EvmTransactionConverter(
+            baseToken: baseToken,
+            coinManager: Core.shared.coinManager,
+            userAddress: userAddress,
+            evmLabelManager: Core.shared.evmLabelManager
+        )
+    }
+
+    // The default chain — total: converts every FullTransaction.
+    public static func defaultConverters(baseToken: MarketKit.Token, userAddress: EvmKit.Address) -> [IEvmTransactionConverter] {
+        [defaultConverter(baseToken: baseToken, userAddress: userAddress)]
+    }
+}

--- a/packages/WalletCore/Sources/WalletCore/Models/TransactionRecords/Evm/ContractCallTransactionRecord.swift
+++ b/packages/WalletCore/Sources/WalletCore/Models/TransactionRecords/Evm/ContractCallTransactionRecord.swift
@@ -2,7 +2,7 @@ import EvmKit
 import Foundation
 import MarketKit
 
-class ContractCallTransactionRecord: EvmTransactionRecord {
+public class ContractCallTransactionRecord: EvmTransactionRecord {
     let contractAddress: String
     let method: String?
     let incomingEvents: [TransferEvent]
@@ -23,7 +23,7 @@ class ContractCallTransactionRecord: EvmTransactionRecord {
         combined(incomingEvents: incomingEvents, outgoingEvents: outgoingEvents)
     }
 
-    override var mainValue: AppValue? {
+    override public var mainValue: AppValue? {
         let (incomingValues, outgoingValues) = combinedValues
 
         if incomingValues.count == 1, outgoingValues.isEmpty {


### PR DESCRIPTION
- `EvmTransactionConverterFactory`: apps register the converter chain used by `EvmTransactionsAdapter` and `Eip20Adapter`; the stock `EvmTransactionConverter` stays the composable default (registered in `UnstoppableApp.initCore`, behavior unchanged)
- `EvmTransactionConverter` opened up: public context (`baseToken`/`coinManager`/`userAddress`/`evmLabelManager`), reusable static helpers (`convertAmount`/`baseAppValue`/`eip20Value`/`transferEvents`), `TransactionSource` derived from the base token
- Factory registrations moved before `Core.initApp` so registration deterministically precedes any kit/adapter creation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added extensible EVM transaction conversion, allowing app-specific converters to be registered and applied in sequence.
  - Improved transaction recognition for standard, token, NFT, and contract transactions.
  - Exposed additional transaction conversion capabilities for integrations.

- **Bug Fixes**
  - Transactions now fall back through available converters, reducing cases where transaction records cannot be created.
  - Ensured converter configuration is registered before application initialization for reliable transaction history processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->