### PR TITLE
Pass the caller's token scope through the EVM converter chain

### DIFF
--- a/packages/WalletCore/Sources/WalletCore/Core/Adapters/Evm/Eip20Adapter.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Adapters/Evm/Eip20Adapter.swift
@@ -10,21 +10,23 @@ public class Eip20Adapter: BaseEvmAdapter {
     private static let approveConfirmationsThreshold: Int? = nil
     public let eip20Kit: Eip20Kit.Kit
     private let contractAddress: EvmKit.Address
+    private let token: Token
     private let converters: [IEvmTransactionConverter]
 
     init(evmKitWrapper: EvmKitWrapper, contractAddress: String, wallet: Wallet, baseToken: Token) throws {
         let address = try EvmKit.Address(hex: contractAddress)
         eip20Kit = try Eip20Kit.Kit.instance(evmKit: evmKitWrapper.evmKit, contractAddress: address)
         self.contractAddress = address
+        token = wallet.token
 
         converters = EvmTransactionConverterFactory.converters(baseToken: baseToken, userAddress: evmKitWrapper.evmKit.address)
 
         super.init(evmKitWrapper: evmKitWrapper, decimals: wallet.decimals)
     }
 
-    private func record(fromTransaction fullTransaction: FullTransaction) -> TransactionRecord? {
+    private func record(fromTransaction fullTransaction: FullTransaction, token: Token?) -> TransactionRecord? {
         for converter in converters {
-            if let record = converter.convert(fullTransaction: fullTransaction) {
+            if let record = converter.convert(fullTransaction: fullTransaction, token: token) {
                 return record
             }
         }
@@ -78,7 +80,7 @@ extension Eip20Adapter: ISendEthereumAdapter {
 
 extension Eip20Adapter: IAllowanceAdapter {
     var pendingTransactions: [TransactionRecord] {
-        eip20Kit.pendingTransactions().compactMap { record(fromTransaction: $0) }
+        eip20Kit.pendingTransactions().compactMap { record(fromTransaction: $0, token: token) }
     }
 
     func allowance(spenderAddress: Address, defaultBlockParameter: BlockParameter) async throws -> Decimal {

--- a/packages/WalletCore/Sources/WalletCore/Core/Adapters/Evm/EvmTransactionConverter.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Adapters/Evm/EvmTransactionConverter.swift
@@ -179,7 +179,8 @@ public class EvmTransactionConverter {
 
 extension EvmTransactionConverter: IEvmTransactionConverter {
     // Total: the default case returns a plain EvmTransactionRecord, so the chain always terminates here.
-    public func convert(fullTransaction: FullTransaction) -> TransactionRecord? {
+    // Scope-agnostic: the stock records carry all events; scoping is a custom-converter concern.
+    public func convert(fullTransaction: FullTransaction, token _: MarketKit.Token?) -> TransactionRecord? {
         transactionRecord(fromTransaction: fullTransaction)
     }
 }

--- a/packages/WalletCore/Sources/WalletCore/Core/Adapters/Evm/EvmTransactionsAdapter.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Adapters/Evm/EvmTransactionsAdapter.swift
@@ -24,9 +24,9 @@ class EvmTransactionsAdapter: BaseEvmAdapter {
         initializeSpamManager()
     }
 
-    private func record(fromTransaction fullTransaction: FullTransaction) -> TransactionRecord? {
+    private func record(fromTransaction fullTransaction: FullTransaction, token: MarketKit.Token?) -> TransactionRecord? {
         for converter in converters {
-            if let record = converter.convert(fullTransaction: fullTransaction) {
+            if let record = converter.convert(fullTransaction: fullTransaction, token: token) {
                 return record
             }
         }
@@ -107,9 +107,9 @@ extension EvmTransactionsAdapter: ITransactionsAdapter {
         evmTransactionSource.transactionUrl(hash: transactionHash)
     }
 
-    private func handleTransactions(_ transactions: [FullTransaction]) -> [TransactionRecord] {
+    private func handleTransactions(_ transactions: [FullTransaction], token: MarketKit.Token?) -> [TransactionRecord] {
         // Preserve evmKit order (descending — newest first)
-        let records = transactions.compactMap { record(fromTransaction: $0) }
+        let records = transactions.compactMap { record(fromTransaction: $0, token: token) }
 
         // Mutates .spam in-place via reference type.
         // Internally sorts ascending for correct detection,
@@ -122,7 +122,7 @@ extension EvmTransactionsAdapter: ITransactionsAdapter {
     func transactionsObservable(token: MarketKit.Token?, filter: TransactionTypeFilter, address: String?) -> Observable<[TransactionRecord]> {
         evmKit.transactionsObservable(tagQueries: [tagQuery(token: token, filter: filter, address: address?.lowercased())]).map { [weak self] in
 
-            self?.handleTransactions($0) ?? []
+            self?.handleTransactions($0, token: token) ?? []
         }
     }
 
@@ -136,14 +136,14 @@ extension EvmTransactionsAdapter: ITransactionsAdapter {
                     return []
                 }
 
-                return self?.handleTransactions(transactions) ?? []
+                return self?.handleTransactions(transactions, token: token) ?? []
             }
     }
 
     func allTransactionsAfter(paginationData: String?) -> Single<[TransactionRecord]> {
         let hash = paginationData?.hs.hexData
         let transactions = evmKit.allTransactionsAfter(transactionHash: hash)
-        let records = transactions.compactMap { record(fromTransaction: $0) }
+        let records = transactions.compactMap { record(fromTransaction: $0, token: nil) }
 
         return Single.just(records)
     }

--- a/packages/WalletCore/Sources/WalletCore/Core/Factories/EvmTransactionConverterFactory.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Factories/EvmTransactionConverterFactory.swift
@@ -2,8 +2,10 @@ import EvmKit
 import MarketKit
 
 // One FullTransaction → TransactionRecord converter in an app-assembled chain. nil → the next converter.
+// `token` is the caller's scope — the pool token for list queries, nil for unscoped consumers
+// (TransactionInfo live updates, SpamManager); a converter may shape the record per scope.
 public protocol IEvmTransactionConverter {
-    func convert(fullTransaction: FullTransaction) -> TransactionRecord?
+    func convert(fullTransaction: FullTransaction, token: MarketKit.Token?) -> TransactionRecord?
 }
 
 // Supplies the converter chain for one adapter instance. Only the truly per-wallet context is passed:


### PR DESCRIPTION
- `IEvmTransactionConverter.convert` now receives the caller's `token` — the pool token for list queries, nil for unscoped consumers (TransactionInfo live updates, SpamManager); a custom converter may shape the record per scope
- `EvmTransactionsAdapter` threads the query token into conversion; `Eip20Adapter` passes its wallet token for pending records
- The default converter ignores the scope — behavior unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved EVM transaction processing by preserving token context when creating transaction records.
  * Enhanced transaction conversion for token-specific transaction histories.
  * Maintained existing transaction ordering and behavior for unscoped transaction views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->