### PR TITLE
Zcash Orchard→Ironwood migration (SDK 2.7.0-rc.2) + Solana swap SOL-fee fix

### DIFF
--- a/Unstoppable/Tests/ZcashMigrationTests.swift
+++ b/Unstoppable/Tests/ZcashMigrationTests.swift
@@ -33,13 +33,11 @@ struct ZcashMigrationTests {
 
     @Test func predicateTable() {
         func needed(migrationEnabled: Bool = true, ironwoodActive: Bool = true, syncStatus: SyncStatus = .upToDate,
-                    orchardSpendable: Decimal = 1, threshold: Decimal = 0.0004, alertShown: Bool = false,
-                    migrationTimestamp: Date? = nil, now: Date = Date()) -> Bool
+                    orchardSpendable: Decimal = 1, threshold: Decimal = 0.0004, alertShown: Bool = false) -> Bool
         {
             ZcashMigrator.isMigrationSuggestionNeeded(
                 migrationEnabled: migrationEnabled, ironwoodActive: ironwoodActive, syncStatus: syncStatus,
-                orchardSpendable: orchardSpendable, threshold: threshold, alertShown: alertShown,
-                migrationTimestamp: migrationTimestamp, now: now
+                orchardSpendable: orchardSpendable, threshold: threshold, alertShown: alertShown
             )
         }
 
@@ -48,116 +46,63 @@ struct ZcashMigrationTests {
         #expect(!needed(ironwoodActive: false))
         #expect(!needed(syncStatus: .syncing(0.5, false)))
         #expect(!needed(syncStatus: .unprepared))
+        // send-max leaves no privacy buffer: once the swept notes go pending-spent the balance drops
+        // to/below the threshold and the predicate is false on its own — no timestamp suppression needed.
         #expect(!needed(orchardSpendable: 0.0004))
         #expect(!needed(alertShown: true))
     }
 
-    @Test func predicateTimestampWindow() {
-        let now = Date()
-        let inWindow = ZcashMigrator.isMigrationSuggestionNeeded(
-            migrationEnabled: true, ironwoodActive: true, syncStatus: .upToDate,
-            orchardSpendable: 1, threshold: 0.0004, alertShown: false,
-            migrationTimestamp: now.addingTimeInterval(-ZcashMigrator.bufferInterval + 10), now: now
-        )
-        let afterWindow = ZcashMigrator.isMigrationSuggestionNeeded(
-            migrationEnabled: true, ironwoodActive: true, syncStatus: .upToDate,
-            orchardSpendable: 1, threshold: 0.0004, alertShown: false,
-            migrationTimestamp: now.addingTimeInterval(-ZcashMigrator.bufferInterval - 10), now: now
-        )
-        #expect(!inWindow)
-        #expect(afterWindow)
-    }
-
-    // MARK: - Session
+    // MARK: - Migration (send-max)
 
     @Test func successfulMigrationSavesRecord() async throws {
         let (migrator, storage) = try makeMigrator(uniqueId: "acc-1")
-        let engine = FakeZcashMigrationEngine()
+        let engine = MockMigrationEngine()
         migrator.engine = engine
 
-        let txId = try await migrator.performMigration(currentEndpointHost: "zec.rocks")
+        let txId = try await migrator.performMigration()
 
         let unwrappedTxId = try #require(txId)
         #expect(engine.executedTxIds == [unwrappedTxId])
 
         let storedIds = try storage.migrationTxIds(accountId: "acc-1")
         #expect(storedIds == [unwrappedTxId])
-        let timestamp = try #require(migrator.timestamp)
-        #expect(abs(timestamp.timeIntervalSinceNow) < 5)
-    }
-
-    @Test func retryableNetworkErrorIsRetried() async throws {
-        let (migrator, _) = try makeMigrator()
-        let engine = FakeZcashMigrationEngine(executeResults: [.networkError(retryable: true)])
-        migrator.engine = engine
-
-        let txId = try await migrator.performMigration(currentEndpointHost: "zec.rocks")
-
-        #expect(txId != nil)
-        #expect(engine.executedTxIds.count == 1)
-    }
-
-    @Test func retriesExhaustAfterTwoAttempts() async throws {
-        let (migrator, storage) = try makeMigrator(uniqueId: "acc-exhaust")
-        let engine = FakeZcashMigrationEngine(executeResults: [
-            .networkError(retryable: true), .networkError(retryable: true), .networkError(retryable: true),
-        ])
-        migrator.engine = engine
-
-        var thrown = false
-        do {
-            _ = try await migrator.performMigration(currentEndpointHost: "zec.rocks")
-        } catch {
-            thrown = true
-        }
-
-        #expect(thrown)
-        #expect(engine.executeResults.isEmpty) // initial attempt + 2 retries consumed the queue
-        let storedIds = try storage.migrationTxIds(accountId: "acc-exhaust")
-        #expect(storedIds.isEmpty)
-        #expect(migrator.timestamp == nil)
-    }
-
-    @Test func nonRetryableNetworkErrorFailsImmediately() async throws {
-        let (migrator, _) = try makeMigrator()
-        let engine = FakeZcashMigrationEngine(executeResults: [.networkError(retryable: false), .networkError(retryable: false)])
-        migrator.engine = engine
-
-        var thrown = false
-        do {
-            _ = try await migrator.performMigration(currentEndpointHost: "zec.rocks")
-        } catch {
-            thrown = true
-        }
-
-        #expect(thrown)
-        #expect(engine.executeResults.count == 1) // only the first result consumed, no retry
-    }
-
-    @Test func invalidNoteRestartsSchedule() async throws {
-        let (migrator, _) = try makeMigrator()
-        let engine = FakeZcashMigrationEngine(executeResults: [.invalidNote])
-        migrator.engine = engine
-
-        var thrown = false
-        do {
-            _ = try await migrator.performMigration(currentEndpointHost: "zec.rocks")
-        } catch {
-            thrown = true
-        }
-
-        #expect(thrown)
-        #expect(engine.signedSchedule == nil) // restart cleared the schedule
-        #expect(engine.executeResults.isEmpty) // the queued .invalidNote was actually consumed
     }
 
     @Test func dustBalanceThrowsNotEnough() async throws {
-        let (migrator, _) = try makeMigrator()
-        migrator.engine = FakeZcashMigrationEngine(orchardSpendable: Zatoshi(10000)) // below fake fee
+        let (migrator, storage) = try makeMigrator(uniqueId: "acc-dust")
+        migrator.engine = MockMigrationEngine(orchardSpendable: Zatoshi(10000)) // below fake fee
 
         var notEnough = false
         do {
-            _ = try await migrator.performMigration(currentEndpointHost: "zec.rocks")
+            _ = try await migrator.performMigration()
+        } catch AppError.ZcashError.notEnough {
+            notEnough = true
+        }
+
+        #expect(notEnough)
+        #expect(try storage.migrationTxIds(accountId: "acc-dust").isEmpty) // nothing broadcast, nothing recorded
+    }
+
+    @Test func proposalAmountAndFee() async throws {
+        let (migrator, _) = try makeMigrator()
+        migrator.engine = MockMigrationEngine() // spendable well above fee
+
+        let orchardBalance: Decimal = 1
+        let proposal = try await migrator.migrationProposal(orchardBalance: orchardBalance)
+
+        let fee = Self.fee.decimalValue.decimalValue
+        #expect(proposal.fee == fee) // fee is authoritative from the proposal, asserted independently
+        #expect(proposal.amount == orchardBalance - fee) // amount is the swept shielded balance minus fee
+    }
+
+    @Test func proposalThrowsNotEnoughWhenFeeConsumesBalance() async throws {
+        let (migrator, _) = try makeMigrator()
+        migrator.engine = MockMigrationEngine()
+
+        // balance exactly equal to the fee → amount == 0 → notEnough (boundary, not just `< fee`)
+        var notEnough = false
+        do {
+            _ = try await migrator.migrationProposal(orchardBalance: Self.fee.decimalValue.decimalValue)
         } catch AppError.ZcashError.notEnough {
             notEnough = true
         }
@@ -165,165 +110,18 @@ struct ZcashMigrationTests {
         #expect(notEnough)
     }
 
-    @Test func proposalAmountAndFee() async throws {
-        let (migrator, _) = try makeMigrator()
-        migrator.engine = FakeZcashMigrationEngine(orchardSpendable: Zatoshi(100_000_000))
-
-        let proposal = try await migrator.migrationProposal(orchardBalance: 1)
-
-        #expect(proposal.amount == (Zatoshi(100_000_000) - Self.fee).decimalValue.decimalValue)
-        #expect(proposal.fee == 1 - proposal.amount)
-    }
-
-    // MARK: - Reconciliation
-
-    @Test func reconcileDeliversSignedPendingTransfer() async throws {
-        let (migrator, storage) = try makeMigrator(uniqueId: "acc-rec")
-        let engine = FakeZcashMigrationEngine()
-        migrator.engine = engine
-
-        // interrupted session: signed but never executed
-        let schedule = try await engine.proposeImmediate()
-        try await engine.signAndStore(schedule: schedule)
-
-        await migrator.reconcileIfNeeded(currentEndpointHost: "zec.rocks", enabled: true)
-
-        #expect(engine.executedTxIds.count == 1)
-        let storedIds = try storage.migrationTxIds(accountId: "acc-rec")
-        #expect(storedIds == engine.executedTxIds)
-    }
-
-    @Test func reconcileIsNoOpWhenNothingPending() async throws {
-        let (migrator, storage) = try makeMigrator(uniqueId: "acc-idle")
-        let engine = FakeZcashMigrationEngine()
-        migrator.engine = engine
-
-        await migrator.reconcileIfNeeded(currentEndpointHost: "zec.rocks", enabled: true)
-
-        #expect(engine.executedTxIds.isEmpty)
-        let storedIds = try storage.migrationTxIds(accountId: "acc-idle")
-        #expect(storedIds.isEmpty)
-    }
-
-    @Test func recordFailedAfterBroadcastCountsAsSent() async throws {
-        let (migrator, storage) = try makeMigrator(uniqueId: "acc-recordfail")
-        let engine = FakeZcashMigrationEngine()
-        engine.executeThrowsRecordFailed = true
-        migrator.engine = engine
-
-        let txId = try await migrator.performMigration(currentEndpointHost: "zec.rocks")
-
-        #expect(txId == nil)
-        let timestamp = try #require(migrator.timestamp) // buffer marker row written without txId
-        #expect(abs(timestamp.timeIntervalSinceNow) < 5)
-        let storedIds = try storage.migrationTxIds(accountId: "acc-recordfail")
-        #expect(storedIds.isEmpty)
-    }
-
-    @Test func duplicateBufferMarkerDoesNotExtendWindow() async throws {
-        let (migrator, storage) = try makeMigrator(uniqueId: "acc-dup")
-        let engine = FakeZcashMigrationEngine()
-        engine.executeThrowsRecordFailed = true
-        migrator.engine = engine
-
-        let markerDate = Date().addingTimeInterval(-100)
-        try storage.save(migrationTx: ZcashMigrationTx(txId: nil, accountId: "acc-dup", createdAt: markerDate))
-
-        _ = try await migrator.performMigration(currentEndpointHost: "zec.rocks")
-
-        let timestamp = try #require(migrator.timestamp)
-        #expect(abs(timestamp.timeIntervalSince(markerDate)) < 1) // second nil-marker skipped, window not extended
-    }
-
     @Test func isMigrationTxMatchesOnlyStoredRecords() async throws {
         let (migrator, _) = try makeMigrator(uniqueId: "acc-match")
-        migrator.engine = FakeZcashMigrationEngine()
+        migrator.engine = MockMigrationEngine()
 
-        let txId = try await migrator.performMigration(currentEndpointHost: "zec.rocks")
+        let txId = try await migrator.performMigration()
 
         let unwrappedTxId = try #require(txId)
         #expect(migrator.isMigrationTx(hash: unwrappedTxId))
         #expect(!migrator.isMigrationTx(hash: String(repeating: "0", count: 64)))
     }
 
-    @Test func reconcileNetworkErrorKeepsTransferPending() async throws {
-        let (migrator, storage) = try makeMigrator(uniqueId: "acc-neterr")
-        let engine = FakeZcashMigrationEngine(executeResults: [.networkError(retryable: false)])
-        migrator.engine = engine
-
-        let schedule = try await engine.proposeImmediate()
-        try await engine.signAndStore(schedule: schedule)
-
-        await migrator.reconcileIfNeeded(currentEndpointHost: "zec.rocks", enabled: true)
-
-        #expect(engine.signedSchedule != nil) // stays pending for the next start
-        let storedIds = try storage.migrationTxIds(accountId: "acc-neterr")
-        #expect(storedIds.isEmpty)
-    }
-
-    @Test func reconcileExpiredTransferRestarts() async throws {
-        let (migrator, storage) = try makeMigrator(uniqueId: "acc-expired")
-        let engine = FakeZcashMigrationEngine(executeResults: [.expired])
-        migrator.engine = engine
-
-        let schedule = try await engine.proposeImmediate()
-        try await engine.signAndStore(schedule: schedule)
-
-        await migrator.reconcileIfNeeded(currentEndpointHost: "zec.rocks", enabled: true)
-
-        #expect(engine.signedSchedule == nil) // restart cleared the schedule
-        #expect(engine.executeResults.isEmpty)
-        let storedIds = try storage.migrationTxIds(accountId: "acc-expired")
-        #expect(storedIds.isEmpty)
-    }
-
-    @Test func reconcileRequiresAttentionRestarts() async throws {
-        let (migrator, _) = try makeMigrator(uniqueId: "acc-attention")
-        let engine = FakeZcashMigrationEngine()
-        migrator.engine = engine
-
-        let schedule = try await engine.proposeImmediate()
-        try await engine.signAndStore(schedule: schedule)
-        engine.stateOverride = .requiresAttention(.transferExpired)
-
-        await migrator.reconcileIfNeeded(currentEndpointHost: "zec.rocks", enabled: true)
-
-        #expect(engine.signedSchedule == nil) // silent restart
-        #expect(engine.executedTxIds.isEmpty)
-    }
-
-    @Test func reconcileRestoresMissingBufferMarker() async throws {
-        let (migrator, storage) = try makeMigrator(uniqueId: "acc-marker")
-        let engine = FakeZcashMigrationEngine()
-        migrator.engine = engine
-
-        // broadcast happened (gate armed) but the local row was never written: killed between execute and save
-        _ = try await engine.signAndStore(schedule: engine.proposeImmediate())
-        _ = try await engine.executeNext(options: MigrationNetworkPrivacyOptions(useTor: false, submissionEndpoint: ZcashAdapter.defaultEndpoint))
-        try storage.deleteMigrationTxs(accountId: "acc-marker")
-
-        await migrator.reconcileIfNeeded(currentEndpointHost: "zec.rocks", enabled: true)
-
-        let timestamp = try #require(migrator.timestamp)
-        #expect(abs(timestamp.timeIntervalSinceNow) < 5)
-    }
-
-    @Test func remainingBufferMinutesEdges() throws {
-        let (migrator, storage) = try makeMigrator(uniqueId: "acc-minutes")
-
-        #expect(migrator.remainingBufferMinutes == nil) // no rows
-
-        try storage.save(migrationTx: ZcashMigrationTx(txId: nil, accountId: "acc-minutes", createdAt: Date().addingTimeInterval(-30)))
-        #expect(migrator.remainingBufferMinutes == 10) // 570s left rounds up
-
-        try storage.deleteMigrationTxs(accountId: "acc-minutes")
-        try storage.save(migrationTx: ZcashMigrationTx(txId: nil, accountId: "acc-minutes", createdAt: Date().addingTimeInterval(-ZcashMigrator.bufferInterval + 30)))
-        #expect(migrator.remainingBufferMinutes == 1)
-
-        try storage.deleteMigrationTxs(accountId: "acc-minutes")
-        try storage.save(migrationTx: ZcashMigrationTx(txId: nil, accountId: "acc-minutes", createdAt: Date().addingTimeInterval(-ZcashMigrator.bufferInterval - 1)))
-        #expect(migrator.remainingBufferMinutes == nil) // window over
-    }
+    // MARK: - Activation boundary
 
     @Test func ironwoodActivationBoundary() throws {
         let (migrator, _) = try makeMigrator(networkType: .mainnet)
@@ -334,56 +132,52 @@ struct ZcashMigrationTests {
         #expect(migrator.ironwoodActive(latestHeight: activation))
     }
 
-    @Test func submissionEndpointForCustomSyncNodeStaysInDefaultPool() throws {
-        let (migrator, _) = try makeMigrator(networkType: .mainnet)
-
-        let endpoint = migrator.submissionEndpoint(excludingHost: "my.custom.node")
-
-        let isDefault = ZcashNode.defaultNodes.contains { $0.url.host == endpoint.host }
-        #expect(isDefault)
-        #expect(endpoint.host != "my.custom.node")
-    }
-
-    // MARK: - Broadcast endpoint
-
-    @Test func submissionEndpointAvoidsSyncNode() throws {
-        let (migrator, _) = try makeMigrator(networkType: .mainnet)
-
-        let endpoint = migrator.submissionEndpoint(excludingHost: ZcashNode.defaultNodes[0].url.host!)
-
-        #expect(endpoint.host != ZcashNode.defaultNodes[0].url.host)
-        let isDefault = ZcashNode.defaultNodes.contains { $0.url.host == endpoint.host }
-        #expect(isDefault)
-    }
-
-    @Test func submissionEndpointTestnetDegeneratesToSameNode() throws {
-        let (migrator, _) = try makeMigrator(networkType: .testnet)
-
-        let endpoint = migrator.submissionEndpoint(excludingHost: ZcashNode.defaultTestnetNodes[0].url.host!)
-
-        #expect(endpoint.host == ZcashNode.defaultTestnetNodes[0].url.host)
-    }
-
     // MARK: - Wallet isolation
 
     @Test func recordsAreIsolatedPerAccount() async throws {
         let storage = try makeStorage()
         let (migratorA, _) = try makeMigrator(uniqueId: "acc-a", storage: storage)
         let (migratorB, _) = try makeMigrator(uniqueId: "acc-b", storage: storage)
-        migratorA.engine = FakeZcashMigrationEngine()
+        migratorA.engine = MockMigrationEngine()
 
-        _ = try await migratorA.performMigration(currentEndpointHost: "zec.rocks")
+        _ = try await migratorA.performMigration()
 
-        #expect(migratorA.timestamp != nil)
-        #expect(migratorB.timestamp == nil)
-        let idsB = try storage.migrationTxIds(accountId: "acc-b")
-        #expect(idsB.isEmpty)
+        #expect(try storage.migrationTxIds(accountId: "acc-a").count == 1)
+        #expect(try storage.migrationTxIds(accountId: "acc-b").isEmpty)
 
         migratorB.clearOnWipe()
-        let idsA = try storage.migrationTxIds(accountId: "acc-a")
-        #expect(idsA.count == 1) // wiping B must not touch A
+        #expect(try storage.migrationTxIds(accountId: "acc-a").count == 1) // wiping B must not touch A
 
         migratorA.clearOnWipe()
-        #expect(migratorA.timestamp == nil)
+        #expect(try storage.migrationTxIds(accountId: "acc-a").isEmpty)
+    }
+}
+
+// Test double for the send-max migration engine: fixed fee, sweeps its emulated balance to a fake txid.
+private final class MockMigrationEngine: IZcashMigrationEngine {
+    private static let fee = Zatoshi(15000)
+
+    private(set) var orchardSpendable: Zatoshi
+    private(set) var executedTxIds = [String]()
+
+    init(orchardSpendable: Zatoshi = Zatoshi(100_000_000)) {
+        self.orchardSpendable = orchardSpendable
+    }
+
+    func estimatedFee() async throws -> Zatoshi {
+        guard orchardSpendable > Self.fee else {
+            throw AppError.ZcashError.notEnough
+        }
+        return Self.fee
+    }
+
+    func migrate() async throws -> String? {
+        guard orchardSpendable > Self.fee else {
+            throw AppError.ZcashError.notEnough
+        }
+        let txId = (UUID().uuidString + UUID().uuidString).replacingOccurrences(of: "-", with: "").lowercased()
+        executedTxIds.append(txId)
+        orchardSpendable = Zatoshi(0)
+        return txId
     }
 }

--- a/Unstoppable/Unstoppable.xcodeproj/project.pbxproj
+++ b/Unstoppable/Unstoppable.xcodeproj/project.pbxproj
@@ -581,7 +581,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.49.2;
+				MARKETING_VERSION = 0.49.3;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -704,7 +704,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.49.2;
+				MARKETING_VERSION = 0.49.3;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEV;
@@ -832,7 +832,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.49.2;
+				MARKETING_VERSION = 0.49.3;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -955,7 +955,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.49.2;
+				MARKETING_VERSION = 0.49.3;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = PROD;

--- a/packages/WalletCore/Package.swift
+++ b/packages/WalletCore/Package.swift
@@ -52,7 +52,7 @@ let package = Package(
         .package(url: "https://github.com/horizontalsystems/UniswapKit.Swift", exact: "3.2.0"),
         // Ironwood sync/send hotfix: frozen upstream e58e14e + HS librustzcash pin (81152f63),
         // binary FFI via the 2.6.0-ironwood-hs.1 release on the fork
-        .package(url: "https://github.com/horizontalsystems/ZcashLightClientKit", exact: "2.6.0-ironwood-hs.2"),
+        .package(url: "https://github.com/horizontalsystems/ZcashLightClientKit", exact: "2.7.0-rc.2-hs.1"),
     ],
     targets: [
         .target(

--- a/packages/WalletCore/Sources/WalletCore/Core/Adapters/Zcash/ZcashAdapter.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Adapters/Zcash/ZcashAdapter.swift
@@ -720,13 +720,13 @@ class ZcashAdapter {
     private func rewind(unmined: ZcashTransaction.Overview, completion: (() -> Void)? = nil) {
         synchronizer
             .rewind(.transaction(unmined))
-            .sink(receiveCompletion: { result in
+            .sink(receiveCompletion: { [weak self] result in
                       switch result {
                       case .finished:
                           Core.shared.localStorage.zcashAlwaysPendingRewind = true
                           completion?()
                       case .failure:
-                          self.rewindQuick()
+                          self?.rewindQuick()
                       }
                   },
                   receiveValue: { _ in })

--- a/packages/WalletCore/Sources/WalletCore/Core/Adapters/Zcash/ZcashAdapter.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Adapters/Zcash/ZcashAdapter.swift
@@ -36,8 +36,6 @@ class ZcashAdapter {
     private var cancellables: [AnyCancellable] = []
     private var deferredStopCancellable: AnyCancellable?
     private var resubmitTask: Task<Void, Never>? // main-confined; dedupes concurrent startSynchronizer kicks
-    private var migrationGateCancellable: AnyCancellable? // main-confined; releases the migrating state when the SDK gate opens
-    private var migrationTickCancellable: AnyCancellable? // main-confined; countdown refresh + stuck-transfer healing
 
     private let token: Token
     private let transactionSource: TransactionSource
@@ -98,13 +96,6 @@ class ZcashAdapter {
 
     var balanceState: AdapterState {
         state.adapterState
-    }
-
-    var isMigrating: Bool {
-        if case .migrating = state {
-            return true
-        }
-        return false
     }
 
     var isIronwoodActive: Bool {
@@ -257,10 +248,10 @@ class ZcashAdapter {
             return
         }
 
-        // defense for non-UI callers (backup restore, node deletion): never reconfigure
-        // the synchronizer while background-finishing work or the migration window is active — "try again later"
+        // defense for non-UI callers (backup restore, node deletion): never reconfigure the
+        // synchronizer while background-finishing work (a send/migration broadcast) is active — "try again later"
         let busy = await MainActor.run { Core.shared.backgroundTaskManager.isCriticalActive }
-        guard !busy, !isMigrating else {
+        guard !busy else {
             throw AppError.zcash(reason: .sendInProgress)
         }
 
@@ -316,16 +307,7 @@ class ZcashAdapter {
                 self?.accountId = account.id
                 self?.uAddress = uAddress
                 self?.tAddress = tAddress
-                // the single engine selection point; the fake branch does not exist in release binaries
-                #if DEBUG
-                    if Core.shared.localStorage.emulateZcashMigration {
-                        self?.migrator.engine = FakeZcashMigrationEngine(migratedAt: self?.migrator.timestamp)
-                    } else {
-                        self?.migrator.engine = ZcashMigrationEngine(synchronizer: synchronizer, accountUUID: account.id, spendingKey: unifiedSpendingKey)
-                    }
-                #else
-                    self?.migrator.engine = ZcashMigrationEngine(synchronizer: synchronizer, accountUUID: account.id, spendingKey: unifiedSpendingKey)
-                #endif
+                self?.migrator.engine = ZcashMigrationEngine(synchronizer: synchronizer, accountUUID: account.id, spendingKey: unifiedSpendingKey)
 
                 self?.depositAddressSubject.send(.completed(DepositAddress(uAddress.stringEncoded)))
 
@@ -365,19 +347,7 @@ class ZcashAdapter {
 
         logger?.log(level: .debug, message: "Start kit after finish preparing!")
 
-        // one-shot per adapter activation: the sync is not running yet, so a pending
-        // migration transfer can be executed without stopping anything
-        Task { [weak self] in
-            guard let self else { return }
-            await migrator.reconcileIfNeeded(currentEndpointHost: currentEndpoint.host)
-
-            // relaunch inside the privacy window: show migrating and let the watcher restart sync
-            if let engine = migrator.engine, await engine.isSyncBlocked() {
-                enterMigratingState()
-            } else {
-                startSynchronizer()
-            }
-        }
+        startSynchronizer()
     }
 
     private func startSynchronizer() {
@@ -862,19 +832,13 @@ class ZcashAdapter {
             return
         }
 
-        let full = balances.shieldedTotal()
-        let available = balances.shieldedSpendableValue
+        let full = balances.saplingBalance.total() + balances.orchardBalance.total() + balances.ironwoodBalance.total()
+        let available = balances.saplingBalance.spendableValue + balances.orchardBalance.spendableValue + balances.ironwoodBalance.spendableValue
         logger?.log(level: .debug, message: "Full balance from syncer: \(full.decimalValue.decimalValue.description)")
         logger?.log(level: .debug, message: "Available balance from syncer: \(available.decimalValue.decimalValue.description)")
 
 //        print("BALANCE: t = \(balances.unshielded.decimalValue.decimalValue)")
-        var orchard = balances.orchardBalance.spendableValue.decimalValue.decimalValue
-        #if DEBUG
-            // emulation: the whole migration cycle (cell, alert, screen, zeroing) runs off the fake engine state
-            if let fakeEngine = migrator.engine as? FakeZcashMigrationEngine {
-                orchard = fakeEngine.orchardSpendable.decimalValue.decimalValue
-            }
-        #endif
+        let orchard = balances.orchardBalance.spendableValue.decimalValue.decimalValue
 
         let zCashBalanceData = ZcashBalanceData(
             id: uniqueId,
@@ -1101,12 +1065,6 @@ extension ZcashAdapter: IAdapter {
     func stop() {
         synchronizer.stop()
         logger?.log(level: .debug, message: "Synchronizer will stop")
-
-        // a live gate subscription would otherwise revive sync after deactivation
-        DispatchQueue.main.async { [weak self] in
-            self?.migrationGateCancellable = nil
-            self?.migrationTickCancellable = nil
-        }
     }
 
     func refresh() {
@@ -1136,9 +1094,6 @@ extension ZcashAdapter: IAdapter {
             Task { [weak self] in
                 do {
                     try await self?.synchronizer.start(retry: true)
-                } catch ZcashError.migrationSyncBlocked {
-                    // not an error: the migration privacy gate is holding sync, wait it out
-                    self?.enterMigratingState()
                 } catch {
                     self?.state = .notSynced(error: error)
                 }
@@ -1469,84 +1424,15 @@ extension ZcashAdapter {
         migrator.clearOnWipe()
     }
 
+    // send-max sweep to the wallet's own UA. It is an ordinary send: no stop-sync, no privacy buffer.
+    // Runs under the same "zcash-send" critical section as every send, so background survivability and
+    // same-bytes resubmit apply for free.
     func performMigration() async throws -> String? {
-        do {
-            let txId = try await Core.shared.backgroundTaskManager.performCritical(name: "zcash-migration") {
-                // sign/execute throw migrationBroadcastDuringSync while the synchronizer is live
-                stop()
-                await waitUntilSyncStopped()
-                return try await migrator.performMigration(currentEndpointHost: currentEndpoint.host)
-            }
-
-            enterMigratingState()
-            return txId
-        } catch {
-            // a failed broadcast can leave the signed transfer holding the sync gate;
-            // surface migrating and let the watcher reconcile it instead of a dead stopped sync
-            if let engine = migrator.engine, await engine.isSyncBlocked() {
-                enterMigratingState()
-            }
-            throw error
+        let txId = try await Core.shared.backgroundTaskManager.performCritical(name: "zcash-send") {
+            try await migrator.performMigration()
         }
-    }
-
-    // SDK stop() only schedules the teardown; the migration guard throws while status is still .syncing
-    private func waitUntilSyncStopped() async {
-        for _ in 0 ..< 50 {
-            guard case .syncing = synchronizer.latestState.syncStatus else {
-                return
-            }
-            try? await Task.sleep(seconds: 0.1)
-        }
-    }
-
-    private func enterMigratingState() {
-        DispatchQueue.main.async { [weak self] in
-            guard let self, let engine = migrator.engine else { return }
-
-            areFundsSpendable = false // no spending against a stopped sync; restored by the sync stream after restart
-            state = .migrating(remainingMinutes: migrator.remainingBufferMinutes)
-
-            guard migrationGateCancellable == nil else { return }
-
-            // the gate is a CurrentValueSubject with its own expiry ticker: false arrives pushed.
-            // the subject's initial value can be stale (the SDK recomputes lazily on subscription),
-            // so every release is confirmed by an authoritative poll before leaving the window
-            migrationGateCancellable = engine.syncBlockedStream
-                .filter { !$0 }
-                .sink { [weak self] _ in
-                    Task { [weak self] in
-                        guard let self, let engine = migrator.engine else { return }
-                        guard await !engine.isSyncBlocked() else {
-                            return
-                        }
-                        DispatchQueue.main.async { [weak self] in self?.exitMigratingState() }
-                    }
-                }
-
-            // once a minute: refresh the countdown and re-deliver a stuck signed transfer (reconcile is idempotent)
-            migrationTickCancellable = Timer.publish(every: 60, on: .main, in: .common)
-                .autoconnect()
-                .sink { [weak self] _ in
-                    guard let self else { return }
-
-                    state = .migrating(remainingMinutes: migrator.remainingBufferMinutes)
-                    Task { [weak self] in
-                        guard let self else { return }
-                        await migrator.reconcileIfNeeded(currentEndpointHost: currentEndpoint.host)
-                    }
-                }
-        }
-    }
-
-    private func exitMigratingState() {
-        guard migrationGateCancellable != nil else { return } // already exited or stopped
-
-        migrationGateCancellable = nil
-        migrationTickCancellable = nil
-
-        logger?.log(level: .debug, message: "Migration gate released, restarting synchronizer")
-        startSynchronizer()
+        reSyncPending()
+        return txId
     }
 
     private func send(proposal: Proposal, spendingKey: UnifiedSpendingKey) async throws -> String? {
@@ -1627,24 +1513,17 @@ extension ZcashAdapter {
         }
 
         for overview in candidates {
-            let transaction: CreatedTransaction
-            do {
-                transaction = try CreatedTransaction(overview: overview)
-            } catch {
-                logger?.log(level: .error, message: "Resubmit skip \(overview.rawID.toHexStringTxId()): \(error)")
+            guard let raw = overview.raw else {
+                logger?.log(level: .error, message: "Resubmit skip \(overview.rawID.toHexStringTxId()): missing raw bytes")
                 continue
             }
 
-            let outcome = await synchronizer.broadcaster.submit(transaction: transaction, to: [currentEndpoint])
-
-            switch outcome {
-            case .accepted:
-                logger?.log(level: .debug, message: "Resubmit accepted: \(transaction.txId.toHexStringTxId())")
-            case let .rejected(code, message):
-                // duplicate ("already in block chain") or permanent rejection — retried on next foreground anyway
-                logger?.log(level: .error, message: "Resubmit rejected: \(transaction.txId.toHexStringTxId()) | code: \(code) | \(message)")
-            case .unreachable, .timedOut, .notAttempted, .cancelled:
-                logger?.log(level: .error, message: "Resubmit not delivered: \(transaction.txId.toHexStringTxId()) | \(outcome)")
+            do {
+                try await synchronizer.broadcaster.submit(raw, to: currentEndpoint)
+                logger?.log(level: .debug, message: "Resubmit accepted: \(overview.rawID.toHexStringTxId())")
+            } catch {
+                // duplicate ("already in block chain") or transient failure — retried on next foreground anyway
+                logger?.log(level: .error, message: "Resubmit not delivered: \(overview.rawID.toHexStringTxId()) | \(error)")
             }
         }
     }
@@ -1707,7 +1586,6 @@ enum ZCashAdapterState: Equatable {
     case preparing
     case synced
     case syncing(progress: Int?, remaining: Int?, lastBlockDate: Date?)
-    case migrating(remainingMinutes: Int?)
     case notSynced(error: Error)
 
     public static func == (lhs: ZCashAdapterState, rhs: ZCashAdapterState) -> Bool {
@@ -1716,7 +1594,6 @@ enum ZCashAdapterState: Equatable {
         case (.preparing, .preparing): return true
         case (.synced, .synced): return true
         case let (.syncing(lProgress, lRemaining, lLastBlockDate), .syncing(rProgress, rRemaining, rLastBlockDate)): return lProgress == rProgress && lRemaining == rRemaining && lLastBlockDate == rLastBlockDate
-        case let (.migrating(lRemaining), .migrating(rRemaining)): return lRemaining == rRemaining
         case (.notSynced, .notSynced): return true
         default: return false
         }
@@ -1728,7 +1605,6 @@ enum ZCashAdapterState: Equatable {
         case .preparing: return .customSyncing(main: "Preparing...", secondary: nil, progress: nil)
         case .synced: return .synced
         case let .syncing(progress, remaining, lastDate): return .syncing(progress: progress, remaining: remaining, lastBlockDate: lastDate)
-        case let .migrating(remainingMinutes): return .customSyncing(main: "Migrating...", secondary: remainingMinutes.map { "~\($0) min" }, progress: nil)
         case let .notSynced(error): return .notSynced(error: error.localizedDescription)
         }
     }
@@ -1739,7 +1615,6 @@ enum ZCashAdapterState: Equatable {
         case .preparing: return "Preparing..."
         case .synced: return "Synced"
         case let .syncing(progress, _, lastDate): return "Syncing: progress = \(progress?.description ?? "N/A"), lastBlockDate: \(lastDate?.description ?? "N/A")"
-        case let .migrating(remainingMinutes): return "Migrating: remaining = \(remainingMinutes?.description ?? "N/A") min"
         case let .notSynced(error): return "Not synced \(error.localizedDescription)"
         }
     }

--- a/packages/WalletCore/Sources/WalletCore/Core/Adapters/Zcash/ZcashMigrationEngine.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Adapters/Zcash/ZcashMigrationEngine.swift
@@ -1,18 +1,16 @@
-import Combine
 import Foundation
 import ZcashLightClientKit
 
 protocol IZcashMigrationEngine: AnyObject {
-    func state() async throws -> MigrationState
-    func proposeImmediate() async throws -> MigrationSchedule
-    func signAndStore(schedule: MigrationSchedule) async throws
-    func executeNext(options: MigrationNetworkPrivacyOptions) async throws -> MigrationTransferResult?
-    func isSyncBlocked() async -> Bool
-    var syncBlockedStream: AnyPublisher<Bool, Never> { get }
-    func restart() async throws
+    // Propose a send-max sweep of the account's spendable shielded funds to its own Unified Address
+    // and return the fee the proposal requires. Used by the confirmation screen (amount = balance − fee).
+    func estimatedFee() async throws -> Zatoshi
+    // Re-propose fresh and execute the send-max sweep, returning the first broadcast txid (display hex),
+    // or nil if no transaction landed.
+    func migrate() async throws -> String?
 }
 
-class ZcashMigrationEngine: IZcashMigrationEngine {
+final class ZcashMigrationEngine: IZcashMigrationEngine {
     private let synchronizer: Synchronizer
     private let accountUUID: AccountUUID
     private let spendingKey: UnifiedSpendingKey
@@ -23,145 +21,38 @@ class ZcashMigrationEngine: IZcashMigrationEngine {
         self.spendingKey = spendingKey
     }
 
-    func state() async throws -> MigrationState {
-        try await synchronizer.migrationState(accountUUID: accountUUID)
+    func estimatedFee() async throws -> Zatoshi {
+        try await proposal().totalFeeRequired()
     }
 
-    func proposeImmediate() async throws -> MigrationSchedule {
-        try await synchronizer.proposeImmediateMigration(accountUUID: accountUUID)
+    func migrate() async throws -> String? {
+        // re-propose: the balance may have moved since the confirmation screen was shown
+        let proposal = try await proposal()
+
+        let stream = try await synchronizer.createProposedTransactions(proposal: proposal, spendingKey: spendingKey)
+
+        // A send-max over [Sapling, Orchard] under ZIP-317 can be multi-step. Drive the whole stream to
+        // completion exactly like ZcashAdapter.send — never break early, otherwise the remaining steps are
+        // never pulled → never signed → never broadcast. The SDK persists every created tx, so the normal
+        // resubmit/reSync path keeps them alive across backgrounding.
+        var txIds: [String] = []
+        var iterator = stream.makeAsyncIterator()
+        for _ in 0 ..< proposal.transactionCount() {
+            guard let result = try await iterator.next() else { continue }
+            switch result {
+            case let .success(txId: id),
+                 let .grpcFailure(txId: id, error: _),
+                 let .submitFailure(txId: id, code: _, description: _),
+                 let .notAttempted(txId: id):
+                txIds.append(id.toHexStringTxId())
+            }
+        }
+        return txIds.first
     }
 
-    func signAndStore(schedule: MigrationSchedule) async throws {
-        try await synchronizer.signAndStoreMigrationSchedule(accountUUID: accountUUID, schedule, usk: spendingKey)
-    }
-
-    func executeNext(options: MigrationNetworkPrivacyOptions) async throws -> MigrationTransferResult? {
-        try await synchronizer.executeNextPendingMigrationTransfer(accountUUID: accountUUID, options: options)
-    }
-
-    func isSyncBlocked() async -> Bool {
-        await synchronizer.isMigrationSyncBlocked()
-    }
-
-    // CurrentValueSubject-backed with an internal SDK ticker: pushes false when the privacy buffer expires
-    var syncBlockedStream: AnyPublisher<Bool, Never> {
-        synchronizer.migrationSyncBlockedStream
-    }
-
-    func restart() async throws {
-        _ = try await synchronizer.restartCurrentMigrationStep(accountUUID: accountUUID, includeResidual: false)
+    // official Orchard→Ironwood migration (2.7.0-rc.1): migrates the account's entire Orchard balance
+    // into the Ironwood pool.
+    private func proposal() async throws -> Proposal {
+        try await synchronizer.proposeOrchardToIronwoodMigration(accountUUID: accountUUID)
     }
 }
-
-#if DEBUG
-    class FakeZcashMigrationEngine: IZcashMigrationEngine {
-        private static let fee = Zatoshi(15000)
-
-        var orchardSpendable: Zatoshi
-        var executeResults: [MigrationTransferResult]
-        var stateOverride: MigrationState?
-        var executeThrowsRecordFailed = false
-        private(set) var signedSchedule: MigrationSchedule?
-        private(set) var executedTxIds = [String]()
-        private var lastExecuteAt: Date?
-        private let blockedSubject: CurrentValueSubject<Bool, Never>
-
-        // migratedAt (the latest stored migration row) makes the fake honest across relaunches:
-        // migrated → zero balance, gate blocked while inside the privacy window
-        init(orchardSpendable: Zatoshi = Zatoshi(100_000_000), executeResults: [MigrationTransferResult] = [], migratedAt: Date? = nil) {
-            self.orchardSpendable = migratedAt == nil ? orchardSpendable : Zatoshi(0)
-            self.executeResults = executeResults
-            lastExecuteAt = migratedAt
-
-            let remaining = migratedAt.map { ZcashMigrator.bufferInterval - Date().timeIntervalSince($0) } ?? 0
-            blockedSubject = CurrentValueSubject(remaining > 0)
-            if remaining > 0 {
-                scheduleGateRelease(after: remaining)
-            }
-        }
-
-        // mirrors the SDK gate ticker: pushes false when the emulated buffer expires
-        private func scheduleGateRelease(after seconds: TimeInterval) {
-            Task { [weak self] in
-                try? await Task.sleep(seconds: seconds)
-                self?.blockedSubject.send(false)
-            }
-        }
-
-        func state() async throws -> MigrationState {
-            if let stateOverride {
-                return stateOverride
-            }
-            if lastExecuteAt != nil {
-                return .complete
-            }
-            return signedSchedule == nil ? .readyToPropose : .inProgress(MigrationProgress(
-                completedTransfers: 0, totalTransfers: 1, remainingOrchard: orchardSpendable, nextTransferReadyAtHeight: nil
-            ))
-        }
-
-        func proposeImmediate() async throws -> MigrationSchedule {
-            guard orchardSpendable > Self.fee else {
-                return MigrationSchedule(transfers: [], estimatedDurationHours: 0)
-            }
-
-            let transfer = MigrationTransferProposal(
-                id: UUID().uuidString,
-                amount: orchardSpendable - Self.fee,
-                anchorHeight: 3_428_143,
-                nextExecutableAfterHeight: 3_428_143,
-                expiryHeight: 3_428_143 + 288
-            )
-            return MigrationSchedule(transfers: [transfer], estimatedDurationHours: 0)
-        }
-
-        func signAndStore(schedule: MigrationSchedule) async throws {
-            signedSchedule = schedule
-        }
-
-        func executeNext(options _: MigrationNetworkPrivacyOptions) async throws -> MigrationTransferResult? {
-            if executeThrowsRecordFailed {
-                lastExecuteAt = Date()
-                signedSchedule = nil
-                throw ZcashError.migrationRecordFailedAfterBroadcast(NSError(domain: "fake", code: 0))
-            }
-            guard signedSchedule != nil else {
-                return nil
-            }
-
-            let result = executeResults.isEmpty ? .success(txId: Self.fakeTxId()) : executeResults.removeFirst()
-            if case let .success(txId) = result {
-                executedTxIds.append(txId)
-                signedSchedule = nil
-                orchardSpendable = Zatoshi(0)
-                lastExecuteAt = Date()
-                blockedSubject.send(true)
-                scheduleGateRelease(after: ZcashMigrator.bufferInterval)
-            }
-            return result
-        }
-
-        // mirrors the SDK gate: blocked while a signed transfer is pending or within the privacy buffer after broadcast
-        func isSyncBlocked() async -> Bool {
-            if signedSchedule != nil {
-                return true
-            }
-            if let lastExecuteAt {
-                return Date().timeIntervalSince(lastExecuteAt) < ZcashMigrator.bufferInterval
-            }
-            return false
-        }
-
-        var syncBlockedStream: AnyPublisher<Bool, Never> {
-            blockedSubject.eraseToAnyPublisher()
-        }
-
-        func restart() async throws {
-            signedSchedule = nil
-        }
-
-        private static func fakeTxId() -> String {
-            (UUID().uuidString + UUID().uuidString).replacingOccurrences(of: "-", with: "").lowercased()
-        }
-    }
-#endif

--- a/packages/WalletCore/Sources/WalletCore/Core/Adapters/Zcash/ZcashMigrator.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Adapters/Zcash/ZcashMigrator.swift
@@ -3,11 +3,10 @@ import HsToolKit
 import ZcashLightClientKit
 
 class ZcashMigrator {
-    // kill-switch for the Orchard → Ironwood migration flow. OFF for the Ironwood sync/send hotfix:
-    // the UI/session/reconcile infrastructure stays in place but has no entry points; re-enabled
-    // together with the move to the upstream send-max engine (docs/specs/2026-07-23-…-transition)
-    static let migrationEnabled = false
-    static let bufferInterval: TimeInterval = 600 // mirrors the SDK-enforced post-broadcast privacy window
+    // kill-switch for the Orchard → Ironwood migration flow. Flip to true together with the testnet
+    // E2E once the send-max migration is validated end to end.
+    // TEMPORARILY true for testnet debugging — revert to false before release.
+    static let migrationEnabled = true
 
     private let uniqueId: String
     private let threshold: Decimal
@@ -18,24 +17,6 @@ class ZcashMigrator {
     var engine: IZcashMigrationEngine?
 
     private var alertShown = false
-
-    // a migration row exists ⟺ a broadcast happened; createdAt of the latest row is the privacy-buffer start
-    var timestamp: Date? {
-        (try? storage.latestMigrationDate(accountId: uniqueId)) ?? nil
-    }
-
-    // UI countdown only; the authority on whether sync is actually blocked is the SDK gate
-    var remainingBufferMinutes: Int? {
-        guard let timestamp else {
-            return nil
-        }
-
-        let remaining = timestamp.addingTimeInterval(Self.bufferInterval).timeIntervalSinceNow
-        guard remaining > 0 else {
-            return nil
-        }
-        return Int((remaining / 60).rounded(.up))
-    }
 
     init(uniqueId: String, threshold: Decimal, network: ZcashNetwork, storage: ZcashAdapterStorage, logger: HsToolKit.Logger?) {
         self.uniqueId = uniqueId
@@ -55,20 +36,35 @@ class ZcashMigrator {
         ((try? storage.migrationTxIds(accountId: uniqueId)) ?? []).contains(hash)
     }
 
+    // history marker only: a row lets `isMigrationTx` label the self-send in transaction history.
+    // send-max is a normal transaction, so there is no privacy buffer to track here.
     private func save(txId: String?) {
-        if let txId {
-            guard !isMigrationTx(hash: txId) else {
-                return
-            }
-        } else if let timestamp, Date() < timestamp.addingTimeInterval(Self.bufferInterval) {
-            return // an active buffer marker already exists; a duplicate row would extend the window
+        guard let txId, !isMigrationTx(hash: txId) else {
+            return
         }
-
         try? storage.save(migrationTx: ZcashMigrationTx(txId: txId, accountId: uniqueId, createdAt: Date()))
     }
 
+    // The NU6.3 (Ironwood) activation height for the wallet's network. In DEBUG, when the
+    // "Emulate ZEC Migration" toggle is on, mainnet is forced to a low height so the migration flow
+    // can be exercised on mainnet; otherwise the real SDK/FFI activation height is used.
+    var activationHeight: BlockHeight? {
+        #if DEBUG
+            if Core.shared.localStorage.emulateZcashMigration, network.networkType == .mainnet {
+                return 3_420_000
+            }
+        #endif
+        // NU6.3 (Ironwood) activation heights, from zcash_protocol consensus (the SDK reads the same
+        // values via the rust FFI, which the official prebuilt binary doesn't surface to Swift).
+        switch network.networkType {
+        case .mainnet: return 3_428_143
+        case .testnet: return 4_134_000
+        default: return nil
+        }
+    }
+
     func ironwoodActive(latestHeight: Int) -> Bool {
-        guard let activationHeight = network.ironwoodActivationHeight else {
+        guard let activationHeight else {
             return false
         }
         return latestHeight >= activationHeight
@@ -85,9 +81,7 @@ class ZcashMigrator {
             syncStatus: syncStatus,
             orchardSpendable: orchardBalance,
             threshold: threshold,
-            alertShown: alertShown,
-            migrationTimestamp: timestamp,
-            now: Date()
+            alertShown: alertShown
         ) else {
             return false
         }
@@ -98,153 +92,43 @@ class ZcashMigrator {
         return true
     }
 
-    static func isMigrationSuggestionNeeded(migrationEnabled: Bool, ironwoodActive: Bool, syncStatus: SyncStatus, orchardSpendable: Decimal,
-                                            threshold: Decimal, alertShown: Bool, migrationTimestamp: Date?, now: Date) -> Bool
+    // After a broadcast the swept notes become pending-spent, so orchardSpendable drops below the
+    // threshold and the predicate is false on its own — no timestamp-based suppression needed.
+    static func isMigrationSuggestionNeeded(migrationEnabled: Bool, ironwoodActive: Bool, syncStatus: SyncStatus,
+                                            orchardSpendable: Decimal, threshold: Decimal, alertShown: Bool) -> Bool
     {
         guard migrationEnabled, ironwoodActive, !alertShown, syncStatus == .upToDate else {
             return false
         }
-        guard orchardSpendable > threshold else {
-            return false
-        }
-        if let migrationTimestamp, now < migrationTimestamp.addingTimeInterval(bufferInterval) {
-            return false
-        }
-        return true
+        return orchardSpendable > threshold
     }
 
-    // pure read for the confirmation screen; the session re-proposes before signing
+    // read for the confirmation screen: fee is authoritative from the proposal, amount is the swept
+    // shielded balance minus that fee. `performMigration` re-proposes before broadcasting.
     func migrationProposal(orchardBalance: Decimal) async throws -> (amount: Decimal, fee: Decimal) {
         guard let engine else {
             throw AppError.ZcashError.noAccountId
         }
 
-        let schedule = try await engine.proposeImmediate()
-        guard let transfer = schedule.transfers.first else {
+        let fee = try await engine.estimatedFee().decimalValue.decimalValue
+        let amount = orchardBalance - fee
+        guard amount > 0 else {
             throw AppError.ZcashError.notEnough
         }
-
-        let amount = transfer.amount.decimalValue.decimalValue
-        return (amount: amount, fee: max(0, orchardBalance - amount))
+        return (amount: amount, fee: fee)
     }
 
-    // must be called with the synchronizer stopped: sign/execute throw migrationBroadcastDuringSync while sync is live.
-    // Returns nil when the broadcast landed but the SDK failed to record it (reconciled by the engine later).
-    func performMigration(currentEndpointHost: String) async throws -> String? {
+    // send-max sweep to the wallet's own UA. Runs as an ordinary send (the adapter wraps it in its
+    // send critical section); no stop-sync, no privacy buffer. Returns the broadcast txid.
+    func performMigration() async throws -> String? {
         guard let engine else {
             throw AppError.ZcashError.noAccountId
         }
 
-        // re-propose: the balance may have changed since the confirmation screen
-        let schedule = try await engine.proposeImmediate()
-        guard let transfer = schedule.transfers.first else {
-            throw AppError.ZcashError.notEnough
-        }
-
-        try await engine.signAndStore(schedule: schedule)
-
-        let options = MigrationNetworkPrivacyOptions(useTor: false, submissionEndpoint: submissionEndpoint(excludingHost: currentEndpointHost))
-        let txId = try await executeWithRetries(engine: engine, options: options)
-
+        let txId = try await engine.migrate()
         save(txId: txId)
         logger?.log(level: .debug, message: "Migration broadcast done, txId: \(txId ?? "unrecorded")")
         return txId
-    }
-
-    // called once per adapter activation, before the synchronizer starts
-    func reconcileIfNeeded(currentEndpointHost: String, enabled: Bool = ZcashMigrator.migrationEnabled) async {
-        guard enabled, let engine else {
-            return
-        }
-
-        do {
-            let state = try await engine.state()
-
-            switch state {
-            case .inProgress:
-                _ = try await resumePendingMigration(currentEndpointHost: currentEndpointHost)
-            case .requiresAttention:
-                try await engine.restart() // silent: the alert will offer migration again
-            case .notStarted, .readyToPropose:
-                if await engine.isSyncBlocked() {
-                    try await engine.restart() // un-wedge: gate armed but nothing scheduled
-                }
-            case .splitPendingConfirmation, .complete:
-                // killed between execute and save: restore the buffer marker so the countdown survives
-                if timestamp == nil, await engine.isSyncBlocked() {
-                    save(txId: nil)
-                }
-            }
-        } catch {
-            logger?.log(level: .error, message: "Migration reconcile failed: \(error)")
-        }
-    }
-
-    // reconcile path for an interrupted session: a signed-but-unexecuted transfer is delivered,
-    // "nothing pending" is a normal outcome (the broadcast already happened before the interruption)
-    private func resumePendingMigration(currentEndpointHost: String) async throws -> String? {
-        guard let engine else {
-            return nil
-        }
-
-        let options = MigrationNetworkPrivacyOptions(useTor: false, submissionEndpoint: submissionEndpoint(excludingHost: currentEndpointHost))
-
-        let result: MigrationTransferResult?
-        do {
-            result = try await engine.executeNext(options: options)
-        } catch ZcashError.migrationRecordFailedAfterBroadcast {
-            save(txId: nil)
-            return nil
-        }
-
-        switch result {
-        case let .success(txId):
-            save(txId: txId)
-            logger?.log(level: .debug, message: "Reconcile delivered pending migration transfer, txId: \(txId)")
-            return txId
-        case nil, .networkError:
-            // networkError: signed transfer stays pending, retried on next adapter start
-            return nil
-        case .invalidNote, .expired:
-            try await engine.restart()
-            return nil
-        }
-    }
-
-    private func executeWithRetries(engine: IZcashMigrationEngine, options: MigrationNetworkPrivacyOptions) async throws -> String? {
-        var attemptsLeft = 2
-
-        while true {
-            let result: MigrationTransferResult?
-            do {
-                result = try await engine.executeNext(options: options)
-            } catch ZcashError.migrationRecordFailedAfterBroadcast {
-                return nil
-            }
-
-            switch result {
-            case let .success(txId):
-                return txId
-            case .networkError(retryable: true) where attemptsLeft > 0:
-                attemptsLeft -= 1
-                logger?.log(level: .debug, message: "Migration broadcast retry, attempts left: \(attemptsLeft)")
-            case .networkError:
-                // signed transfer stays pending; reconciliation re-executes it on next adapter start
-                throw AppError.zcash(reason: .migrationFailed)
-            case .invalidNote, .expired, nil:
-                try await engine.restart()
-                throw AppError.zcash(reason: .migrationFailed)
-            }
-        }
-    }
-
-    // a broadcast node must differ from the sync node so the two are not linked at the lightwalletd level;
-    // node-level separation only — without Tor both connections still originate from the user's IP.
-    // user-added custom nodes are deliberately excluded
-    func submissionEndpoint(excludingHost host: String) -> LightWalletEndpoint {
-        let nodes = network.networkType == .mainnet ? ZcashNode.defaultNodes : ZcashNode.defaultTestnetNodes
-        let node = nodes.first { $0.url.host != host } ?? nodes[0]
-        return ZcashAdapter.endpoint(url: node.url)
     }
 
     private func showAlert() {

--- a/packages/WalletCore/Sources/WalletCore/Core/Adapters/Zcash/ZcashMigrator.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Adapters/Zcash/ZcashMigrator.swift
@@ -71,6 +71,13 @@ class ZcashMigrator {
     }
 
     func handleCheck(orchardBalance: Decimal, latestHeight: Int, syncStatus: SyncStatus?) -> Bool {
+        // Only the active account's adapter may surface the global migration alert. An adapter from a
+        // previously-selected account can outlive the switch (async synchronizer teardown) and fire a
+        // late balance/state update — it must not present the sheet over the now-active account.
+        guard Core.shared.accountManager.activeAccount?.id == uniqueId else {
+            return false
+        }
+
         guard let syncStatus else {
             return false
         }

--- a/packages/WalletCore/Sources/WalletCore/Core/Adapters/Zcash/ZcashMigrator.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Adapters/Zcash/ZcashMigrator.swift
@@ -3,9 +3,7 @@ import HsToolKit
 import ZcashLightClientKit
 
 class ZcashMigrator {
-    // kill-switch for the Orchard → Ironwood migration flow. Flip to true together with the testnet
-    // E2E once the send-max migration is validated end to end.
-    // TEMPORARILY true for testnet debugging — revert to false before release.
+    // Orchard → Ironwood migration is live in production so users can migrate their Orchard funds.
     static let migrationEnabled = true
 
     private let uniqueId: String

--- a/packages/WalletCore/Sources/WalletCore/Core/Managers/AdapterManager.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Managers/AdapterManager.swift
@@ -242,9 +242,9 @@ extension AdapterManager {
 
         // switching reconfigures the synchronizer under a live broadcast; background-finishing
         // work is bounded (local proving + 30s gRPC timeout per tx), so the refusal is short-lived.
-        // the migration window blocks too: its gate watcher owns the synchronizer restart
+        // a migration is an ordinary send, so it holds the same "zcash-send" critical section.
         let busy = await MainActor.run { Core.shared.backgroundTaskManager.isCriticalActive }
-        guard !busy, !adapter.isMigrating else {
+        guard !busy else {
             throw ZcashEndpointValidationError.sendInProgress
         }
 

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/Jupiter/JupiterMultiSwapProvider.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/Jupiter/JupiterMultiSwapProvider.swift
@@ -108,9 +108,11 @@ class JupiterMultiSwapProvider: IMultiSwapProvider {
             let estimatedFee = try adapter.estimateFee(rawTransaction: rawTransaction)
             fee = estimatedFee
 
+            // fee is paid in native SOL, so check the SOL balance (not the tokenIn balance), else send fails with raw -32002
+            let solBalance = kit.balance
             let totalRequired = (tokenIn.type.isNative ? amountIn : 0) + estimatedFee
-            if adapter.balanceData.available < totalRequired {
-                throw SolanaSendHandler.TransactionError.insufficientSolBalance(balance: adapter.balanceData.available)
+            if solBalance < totalRequired {
+                throw SolanaSendHandler.TransactionError.insufficientSolBalance(balance: solBalance)
             }
         } catch {
             transactionError = error

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/USwap/USwapMultiSwapProvider.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/USwap/USwapMultiSwapProvider.swift
@@ -1186,9 +1186,12 @@ class USwapMultiSwapProvider: IMultiSwapProvider {
             let estimatedFee = try adapter.estimateFee(rawTransaction: rawTransaction)
             fee = estimatedFee
 
-            let totalRequired = (tokenIn.type.isNative ? amountIn : 0) + estimatedFee
-            if adapter.balanceData.available < totalRequired {
-                throw SolanaSendHandler.TransactionError.insufficientSolBalance(balance: adapter.balanceData.available)
+            // fee is paid in native SOL, so check the SOL balance (not the tokenIn balance), else send fails with raw -32002
+            if let solBalance = Core.shared.solanaKitManager.solanaKit?.balance {
+                let totalRequired = (tokenIn.type.isNative ? amountIn : 0) + estimatedFee
+                if solBalance < totalRequired {
+                    throw SolanaSendHandler.TransactionError.insufficientSolBalance(balance: solBalance)
+                }
             }
         } catch {
             transactionError = error

--- a/packages/WalletCore/Sources/WalletCore/Modules/Settings/Main/MainSettingsViewModel.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/Settings/Main/MainSettingsViewModel.swift
@@ -72,7 +72,7 @@ class MainSettingsViewModel: ObservableObject {
         didSet {
             localStorage.emulateZcashMigration = emulateZcashMigration
 
-            // turning emulation off resets the fake migration state so the cycle can be re-run
+            // turning the toggle off clears the migration-history markers so the flow can be re-run
             if !emulateZcashMigration,
                let token = try? Core.shared.coinManager.token(query: .init(blockchainType: .zcash, tokenType: .native)),
                let adapter = Core.shared.adapterManager.adapter(for: token) as? ZcashAdapter

--- a/packages/WalletCore/Sources/WalletCore/Modules/Wallet/Token/ZcashWalletTokenView.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/Wallet/Token/ZcashWalletTokenView.swift
@@ -25,7 +25,7 @@ struct ZcashWalletTokenView: View {
                             HorizontalDivider()
                         }
 
-                        if ZcashMigrator.migrationEnabled, viewModel.ironwoodActive, !viewModel.migrating, viewModel.zCashBalanceData.orchard > ZcashAdapter.minimalThreshold {
+                        if ZcashMigrator.migrationEnabled, viewModel.ironwoodActive, viewModel.zCashBalanceData.orchard > ZcashAdapter.minimalThreshold {
                             view(orchard: viewModel.zCashBalanceData.orchard)
                             HorizontalDivider()
                         }

--- a/packages/WalletCore/Sources/WalletCore/Modules/Wallet/Token/ZcashWalletTokenViewModel.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/Wallet/Token/ZcashWalletTokenViewModel.swift
@@ -16,7 +16,6 @@ class ZcashWalletTokenViewModel: ObservableObject {
     @Published var zCashBalanceData: ZcashBalanceData
     @Published var balanceHidden: Bool
     @Published var birthdayHeight: Int?
-    @Published var migrating: Bool
     @Published var ironwoodActive: Bool
 
     init(adapter: ZcashAdapter, wallet: Wallet) {
@@ -24,7 +23,6 @@ class ZcashWalletTokenViewModel: ObservableObject {
         self.wallet = wallet
         zCashBalanceData = adapter.zCashBalanceData
         balanceHidden = balanceHiddenManager.balanceHidden
-        migrating = adapter.isMigrating
         ironwoodActive = adapter.isIronwoodActive
 
         birthdayHeight = restoreSettingsService.settings(accountId: wallet.account.id, blockchainType: wallet.token.blockchainType).birthdayHeight
@@ -44,7 +42,6 @@ class ZcashWalletTokenViewModel: ObservableObject {
         adapter.balanceStateUpdatedObservable
             .observeOn(MainScheduler.instance)
             .subscribe(onNext: { [weak self] _ in
-                self?.migrating = self?.adapter.isMigrating ?? false
                 self?.ironwoodActive = self?.adapter.isIronwoodActive ?? false
             })
             .disposed(by: disposeBag)


### PR DESCRIPTION
## Zcash: Orchard→Ironwood migration on official SDK 2.7.0-rc.2

- Moves the migration off the custom send-max FFI onto the official `ZcashLightClientKit` `2.7.0-rc.2-hs.1` (`proposeOrchardToIronwoodMigration`) with the prebuilt `libzcashlc.xcframework`.
- 3-pool balance (sapling + orchard + ironwood), broadcast resubmit via `broadcaster.submit(_:to:)`.
- **Migration is enabled in production** (`ZcashMigrator.migrationEnabled = true`): users with Orchard funds get the migration alert and can migrate into the Ironwood pool.
- Fixes a stray migration bottom-sheet after account switch — root cause was a retain-cycle leak in `rewind(unmined:)` (now `[weak self]`); adds an active-account guard as cheap insurance.

## Solana: check native SOL balance for the swap fee on confirmation

- The confirmation quote compared the **tokenIn** balance against the SOL fee, so USDC→SOL with insufficient SOL passed confirmation and failed only at send with a raw `rpcError(-32002, AccountNotFound)`.
- Now checks the **native SOL balance** (from the kit) against `amountIn (when native) + estimatedFee`, mirroring the EVM/Tron/Stellar swap providers — surfaces the friendly `insufficientSolBalance` caution and disables the swap.
- Applied to both `JupiterMultiSwapProvider` and `USwapMultiSwapProvider`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Zcash Orchard-to-Ironwood migration is now enabled by default.
  - Migration suggestions and fee estimates are streamlined, with improved send-max handling.
  - Migration history is isolated per wallet account.
  - Orchard balances remain visible during migration.

- **Bug Fixes**
  - Improved Zcash balance calculations across supported pools.
  - Corrected SOL fee checks for Jupiter and USwap swaps.
  - Improved transaction recovery and migration handling during synchronization.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->