### PR TITLE
Update swap UI

### DIFF
--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/MultiSwapView.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/MultiSwapView.swift
@@ -6,8 +6,13 @@ import SwiftUI
 struct MultiSwapView: View {
     @ObservedObject var viewModel: MultiSwapViewModel
     @Binding var sendPresented: Bool
+    var autoFocus = false
 
-    @FocusState var isInputActive: Bool
+    @FocusState var focusedField: FocusField?
+
+    private var isInputActive: Bool {
+        focusedField != nil
+    }
 
     var body: some View {
         ThemeView(style: .list) {
@@ -33,7 +38,7 @@ struct MultiSwapView: View {
                 }
                 .themeListScrollHeader()
                 .onTapGesture {
-                    isInputActive = false
+                    focusedField = nil
                 }
             } bottomContent: {
                 buttonView()
@@ -41,10 +46,10 @@ struct MultiSwapView: View {
                 if isInputActive {
                     AmountAccessoryView(
                         visible: isInputActive,
-                        hasPercents: viewModel.availableBalance != nil,
+                        enabledPercents: (viewModel.availableBalance ?? 0) > 0,
                         onPercent: { percent in
                             viewModel.setAmountIn(percent: percent)
-                            isInputActive = false
+                            focusedField = nil
                         },
                         onTrash: {
                             viewModel.clearAmountIn()
@@ -56,6 +61,11 @@ struct MultiSwapView: View {
         }
         .onAppear {
             viewModel.autoQuoteIfRequired()
+        }
+        .onFirstAppear {
+            if autoFocus {
+                focusedField = .amount
+            }
         }
         .onDisappear {
             viewModel.stopAutoQuoting()
@@ -92,7 +102,7 @@ struct MultiSwapView: View {
                     .font(.themeHeadline1)
                     .tint(.themeInputFieldTintColor)
                     .keyboardType(.decimalPad)
-                    .focused($isInputActive)
+                    .focused($focusedField, equals: .amount)
                     .frame(height: 33)
 
                 if viewModel.tokenIn != nil {
@@ -107,7 +117,7 @@ struct MultiSwapView: View {
                                 .font(.themeBody)
                                 .tint(.themeInputFieldTintColor)
                                 .keyboardType(.decimalPad)
-                                .focused($isInputActive)
+                                .focused($focusedField, equals: .fiat)
                                 .frame(height: 22)
                                 .disabled(coinPriceIn.expired)
                         }
@@ -215,7 +225,7 @@ struct MultiSwapView: View {
                         Text("swap.select".localized).textHeadline2(color: .themeJacob)
                     }
 
-                    ThemeImage("arrow_s_down", size: 20, colorStyle: .secondary)
+                    ThemeImage("arrow_s_down", size: 20, colorStyle: .primary)
                 }
             }
         }
@@ -304,11 +314,15 @@ struct MultiSwapView: View {
             Cell(
                 style: .secondary,
                 middle: {
-                    RightButtonText(text: ComponentText(text: "swap.provider.score".localized, colorStyle: .secondary), textStyle: .subhead, icon: "information", iconColorStyle: .secondary) {
-                        onTapProviderInfo()
+                    HStack(spacing: 8) {
+                        ThemeText("swap.provider.score".localized, style: .subhead, colorStyle: .secondary)
+                        Image("information").icon(size: 20, colorStyle: .secondary)
                     }
                 }, right: {
                     MultiSwapQuotesView.view(type: quote.provider.type)
+                },
+                action: {
+                    onTapProviderInfo()
                 }
             )
 
@@ -343,7 +357,7 @@ struct MultiSwapView: View {
                     viewModel.onAcceptTerms()
 
                     DispatchQueue.main.async {
-                        isInputActive = false
+                        focusedField = nil
                         sendPresented = true
                     }
                 }
@@ -351,7 +365,7 @@ struct MultiSwapView: View {
                 viewModel.autoQuoteIfRequired()
             }
         } else {
-            isInputActive = false
+            focusedField = nil
             sendPresented = true
         }
     }
@@ -456,6 +470,13 @@ struct MultiSwapView: View {
         }
 
         return (title, style, disabled, showProgress, preSwapStep)
+    }
+}
+
+extension MultiSwapView {
+    enum FocusField {
+        case amount
+        case fiat
     }
 }
 

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/RegularMultiSwapView.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/RegularMultiSwapView.swift
@@ -13,7 +13,7 @@ struct RegularMultiSwapView: View {
 
     var body: some View {
         ThemeNavigationStack {
-            MultiSwapView(viewModel: viewModel, sendPresented: $sendPresented)
+            MultiSwapView(viewModel: viewModel, sendPresented: $sendPresented, autoFocus: true)
                 .navigationDestination(isPresented: $sendPresented) {
                     MultiSwapSendDestinationView(viewModel: viewModel) {
                         presentationMode.wrappedValue.dismiss()

--- a/packages/WalletCore/Sources/WalletCore/Modules/RestoreAccount/RestoreMnemonic/RestoreMnemonicView.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/RestoreAccount/RestoreMnemonic/RestoreMnemonicView.swift
@@ -63,9 +63,9 @@ struct RestoreMnemonicView: View {
                 RestoreCoinsView(accountName: data.name, accountType: data.accountType, isParentPresented: $isParentPresented)
             }
         }
-        .onFirstAppear {
-            isMnemonicFocused = true
-        }
+        // .onFirstAppear {
+        //     isMnemonicFocused = true
+        // }
         .onReceive(viewModel.proceedPublisher) { name, accountType in
             handleProceed(name: name, accountType: accountType)
         }

--- a/packages/WalletCore/Sources/WalletCore/Modules/SendNew/PreSendView.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/SendNew/PreSendView.swift
@@ -56,7 +56,7 @@ struct PreSendView: View {
             } keyboardContent: {
                 AmountAccessoryView(
                     visible: focusField != nil,
-                    hasPercents: viewModel.availableBalance != nil,
+                    enabledPercents: (viewModel.availableBalance ?? 0) > 0,
                     onPercent: { percent in
                         viewModel.setAmountIn(percent: percent)
                         focusField = nil
@@ -68,9 +68,9 @@ struct PreSendView: View {
             }
             .animation(.easeOut(duration: 0.25), value: focusField)
         }
-        .onFirstAppear {
-            focusField = .amount
-        }
+        // .onFirstAppear {
+        //     focusField = .amount
+        // }
         .navigationDestination(for: ConfirmationData.self) { data in
             RegularSendView(sendData: data.sendData, address: data.address) {
                 HudHelper.instance.show(banner: .sent)

--- a/packages/WalletCore/Sources/WalletCore/UserInterface/SwiftUI/AmountAccessoryView.swift
+++ b/packages/WalletCore/Sources/WalletCore/UserInterface/SwiftUI/AmountAccessoryView.swift
@@ -4,24 +4,23 @@ struct AmountAccessoryView: View {
     private let height: CGFloat = 52
 
     let visible: Bool
-    let hasPercents: Bool
+    let enabledPercents: Bool
     let onPercent: (Int) -> Void
     let onTrash: () -> Void
 
     var body: some View {
         VStack {
             HStack(spacing: 6) {
-                if hasPercents {
-                    HStack(spacing: 12) {
-                        ForEach(1 ... 4, id: \.self) { multiplier in
-                            let percent = multiplier * 25
+                HStack(spacing: 12) {
+                    ForEach(1 ... 4, id: \.self) { multiplier in
+                        let percent = multiplier * 25
 
-                            ThemeButton(text: percent == 100 ? "send.max_button".localized : "\(percent)%", style: .secondary, size: .small) {
-                                onPercent(percent)
-                            }
+                        ThemeButton(text: percent == 100 ? "send.max_button".localized : "\(percent)%", style: .secondary, size: .small) {
+                            onPercent(percent)
                         }
                     }
                 }
+                .disabled(!enabledPercents)
 
                 Spacer()
 


### PR DESCRIPTION
selector arrow color, tappable score cell, amount autofocus, always-visible percent buttons

ref #7028
ref #7049

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved swap amount entry with clearer amount and fiat field focus handling.
  * Added optional autofocus for swap amount fields.
  * Percentage controls now remain visible but are disabled when no positive balance is available.
  * Refined provider score presentation and selector styling.
* **Bug Fixes**
  * Prevented unintended autofocus when restoring an account or preparing a send.
  * Improved keyboard and focus behavior when tapping, selecting percentages, or navigating swaps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->