### PR TITLE
UI tweaks: popular token chips, market search keyboard, EVM error badges

### DIFF
--- a/packages/WalletCore/Sources/WalletCore/Extensions/Token.swift
+++ b/packages/WalletCore/Sources/WalletCore/Extensions/Token.swift
@@ -44,6 +44,11 @@ extension Token {
         badge ?? "coin_platforms.native".localized
     }
 
+    // "ETH(Optimism)" for a token that carries a badge, plain coin code otherwise
+    var coinCodeWithBadge: String {
+        badge.map { "\(coin.code)(\($0))" } ?? coin.code
+    }
+
     var sendToSelfAllowed: Bool {
         if case .native = type, blockchainType == .zcash { return false }
         if blockchainType == .tron { return false }

--- a/packages/WalletCore/Sources/WalletCore/Modules/Market/Search/MarketSearchView.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/Market/Search/MarketSearchView.swift
@@ -75,6 +75,9 @@ struct MarketSearchView: View {
         let coin = fullCoin.coin
 
         ClickableRow(action: {
+            // The search field stays first responder under the presented coin page and
+            // iOS restores its keyboard on return: resign before presenting.
+            UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
             viewModel.handleOpen(coinUid: coin.uid)
             Coordinator.shared.presentCoinPage(coin: coin, page: .marketSearch)
         }) {

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/TokenSelect/MultiSwapTokenSelectView.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/TokenSelect/MultiSwapTokenSelectView.swift
@@ -123,13 +123,15 @@ struct MultiSwapTokenSelectView: View {
                             Button(action: {
                                 select(item.token)
                             }) {
-                                HStack(spacing: .margin8) {
+                                // The chain badge sticks out past the coin icon, so it absorbs
+                                // half of the icon-to-text gap.
+                                HStack(spacing: 6) {
                                     chipIcon(token: item.token)
 
-                                    Text(item.token.coin.code).textBody()
+                                    ThemeText(item.token.coin.code, style: .captionSB, colorStyle: .primary)
                                 }
-                                .padding(.leading, .margin8)
-                                .padding(.trailing, .margin12)
+                                .padding(.leading, .margin12)
+                                .padding(.trailing, .margin16)
                                 .frame(height: 36)
                                 .background(RoundedRectangle(cornerRadius: 24, style: .continuous).fill(Color.themeBlade))
                             }

--- a/packages/WalletCore/Sources/WalletCore/Modules/SendEvmTransaction/SendEvmCautionsFactory.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/SendEvmTransaction/SendEvmCautionsFactory.swift
@@ -17,7 +17,7 @@ class SendEvmCautionsFactory {
                     return [
                         TitledCaution(
                             title: "fee_settings.errors.insufficient_balance".localized,
-                            text: "fee_settings.errors.insufficient_balance.info".localized(baseCoinService.token.coin.code),
+                            text: "fee_settings.errors.insufficient_balance.info".localized(baseCoinService.token.coinCodeWithBadge),
                             type: .error
                         ),
                     ]
@@ -66,7 +66,7 @@ class SendEvmCautionsFactory {
             switch reason {
             case .insufficientBalanceWithFee:
                 title = "fee_settings.errors.insufficient_balance".localized
-                text = "ethereum_transaction.error.insufficient_balance_with_fee".localized(baseCoinService.token.coin.code)
+                text = "ethereum_transaction.error.insufficient_balance_with_fee".localized(baseCoinService.token.coinCodeWithBadge)
             case let .executionReverted(message):
                 title = "fee_settings.errors.unexpected_error".localized
                 text = message
@@ -92,10 +92,10 @@ class SendEvmCautionsFactory {
             switch reason {
             case .insufficientBalanceWithFee:
                 title = "fee_settings.errors.insufficient_balance".localized
-                text = "ethereum_transaction.error.insufficient_balance_with_fee".localized(baseCoinService.token.coin.code)
+                text = "ethereum_transaction.error.insufficient_balance_with_fee".localized(baseCoinService.token.coinCodeWithBadge)
             case .cannotEstimate:
                 title = "swap.one_inch.error.cannot_estimate".localized
-                text = "swap.one_inch.error.cannot_estimate.info".localized(baseCoinService.token.coin.code)
+                text = "swap.one_inch.error.cannot_estimate.info".localized(baseCoinService.token.coinCodeWithBadge)
             case .insufficientLiquidity:
                 text = "swap.one_inch.error.insufficient_liquidity".localized()
                 text = "swap.one_inch.error.insufficient_liquidity.info".localized()

--- a/packages/WalletCore/Sources/WalletCore/Modules/SendNew/EvmSendHelper.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/SendNew/EvmSendHelper.swift
@@ -22,7 +22,7 @@ class EvmSendHelper {
             switch reason {
             case .insufficientBalanceWithFee:
                 title = "fee_settings.errors.insufficient_balance".localized
-                text = "ethereum_transaction.error.insufficient_balance_with_fee".localized(feeToken.coin.code)
+                text = "ethereum_transaction.error.insufficient_balance_with_fee".localized(feeToken.coinCodeWithBadge)
             case let .executionReverted(message):
                 title = "fee_settings.errors.unexpected_error".localized
                 text = message


### PR DESCRIPTION
Restyles the popular token chips on the swap token select screen (captionSB text, updated paddings). Hides the keyboard when a coin page is opened from market search so it does not reappear on return. EVM insufficient-balance and estimate errors now show the coin code with its network badge, e.g. ETH(Optimism).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Token references now display the coin code together with its badge when available, improving clarity in transaction and fee warnings.

* **Bug Fixes**
  * Prevented the search keyboard from reappearing after opening and returning from a coin page.
  * Updated insufficient-balance and transaction cautions to show the correct token identification.

* **Style**
  * Refined popular-token chips with improved typography, spacing, icon alignment, and padding for a cleaner appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->