### PR TITLE
Fix Token-2022 balances: bump solana-kit-ios to 1.0.5

### DIFF
--- a/packages/WalletCore/Package.swift
+++ b/packages/WalletCore/Package.swift
@@ -42,7 +42,7 @@ let package = Package(
         .package(url: "https://github.com/ReactiveX/RxSwift.git", from: "5.1.3"),
         .package(url: "https://github.com/horizontalsystems/SectionsTableView.Swift", exact: "1.0.0"),
         .package(url: "https://github.com/SnapKit/SnapKit.git", from: "5.7.1"),
-        .package(url: "https://github.com/horizontalsystems/solana-kit-ios.git", exact: "1.0.4"),
+        .package(url: "https://github.com/horizontalsystems/solana-kit-ios.git", exact: "1.0.5"),
         .package(url: "https://github.com/daltoniam/Starscream", from: "3.1.2"),
         .package(url: "https://github.com/horizontalsystems/StellarKit.Swift", exact: "1.2.1"),
         .package(url: "https://github.com/horizontalsystems/TonConnectAPI", exact: "1.0.0"),


### PR DESCRIPTION
solana-kit 1.0.5 fetches token accounts from both token programs (classic + token-2022), so Token-2022 balances (e.g. PUMP) show correctly instead of 0. Token-2022 call is fail-soft and does not affect classic balance sync.

ref #7156

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Solana Kit iOS package to version 1.0.5 for the latest improvements and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->