### PR TITLE
Enforce server-managed provider suspensions on the swap screen

### DIFF
--- a/packages/WalletCore/Sources/WalletCore/Core/Storage/LocalStorage.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Storage/LocalStorage.swift
@@ -31,6 +31,7 @@ public class LocalStorage {
     private let keySwapProvidersLastSyncTimestamp = "swap-providers-last-sync-timestamp"
     private let keySwapRecentTokenQueryIds = "swap-recent-token-query-ids"
     private let keyUSwapProviders = "uswap-providers"
+    private let keyUSwapSuspensions = "uswap-suspensions"
     private let keySwapEnabled = "swap_enabled"
     private let keyAppStateLastSyncTimestamp = "app-state-last-sync-timestamp"
     private let keyForceEnableSwap = "force-enable-swap"
@@ -206,6 +207,13 @@ extension LocalStorage {
     var uSwapProviders: String? {
         get { userDefaultsStorage.value(for: keyUSwapProviders) }
         set { userDefaultsStorage.set(value: newValue, for: keyUSwapProviders) }
+    }
+
+    // Scoped provider suspensions (JSON, provider id -> rules). Cached alongside the provider list
+    // so a cold launch keeps honouring them until the next sync.
+    var uSwapSuspensions: String? {
+        get { userDefaultsStorage.value(for: keyUSwapSuspensions) }
+        set { userDefaultsStorage.set(value: newValue, for: keyUSwapSuspensions) }
     }
 
     var swapEnabled: Bool {

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/MultiSwapProviderManager.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/MultiSwapProviderManager.swift
@@ -14,6 +14,9 @@ class MultiSwapProviderManager {
     private var headers: HTTPHeaders?
 
     @PostPublished private(set) var providers: [String] = []
+    /// Scoped asset/chain/pair suspensions, indexed by provider id. Applied by `MultiSwapViewModel`
+    /// when it decides which providers can serve the current pair.
+    @PostPublished private(set) var suspensions = SwapSuspensionIndex()
 
     init(localStorage: LocalStorage, networkManager: NetworkManager, apiKey: String?) {
         self.localStorage = localStorage
@@ -24,38 +27,155 @@ class MultiSwapProviderManager {
             headers = HTTPHeaders([HTTPHeader(name: "x-api-key", value: apiKey)])
         }
 
-        syncProviders(uSwapProviders: localStorage.uSwapProviders.map { $0.components(separatedBy: ",") } ?? [OneInchMultiSwapProvider.id, UniswapV3MultiSwapProvider.id, PancakeV3MultiSwapProvider.id, ThorChainMultiSwapProvider.id, MayaMultiSwapProvider.id, AllBridgeMultiSwapProvider.id])
-        sync()
+        if let cached = localStorage.uSwapProviders?.components(separatedBy: ",") {
+            syncProviders(uSwapProviders: cached)
+        } else {
+            syncProviders(uSwapProviders: Self.bootstrapProviders)
+        }
+
+        let hadSuspensions = restoreSuspensions()
+
+        // Force a fetch when suspensions have never been stored, even if the provider list is still
+        // within its TTL. Upgrading from a build that predates suspensions leaves a FRESH
+        // `swap-providers-last-sync-timestamp` beside an empty suspension cache, so the ordinary
+        // TTL check would skip the sync and leave the first hour after the update completely
+        // unenforced — precisely the window where a live suspension matters.
+        sync(force: !hadSuspensions)
     }
+
+    /// Used only until the first successful `/providers` response — a fresh install needs SOMETHING
+    /// to show. Everything here is a client-native provider, because those are the only ones that
+    /// can be quoted without the server having told us they exist.
+    ///
+    /// Note these are a starting point, NOT a floor: once the server answers, its list replaces
+    /// this wholesale. That is deliberate and load-bearing for suspension — the client-native ids
+    /// used to be unioned into every sync, which made them impossible to switch off from the
+    /// backend no matter what the server said.
+    private static let bootstrapProviders = [
+        OneInchMultiSwapProvider.id,
+        UniswapV3MultiSwapProvider.id,
+        PancakeV3MultiSwapProvider.id,
+        ThorChainMultiSwapProvider.id,
+        MayaMultiSwapProvider.id,
+        AllBridgeMultiSwapProvider.id,
+    ]
 
     private func syncProviders(uSwapProviders: [String]) {
-        providers = Array(Set([AllBridgeMultiSwapProvider.id, UniswapV3MultiSwapProvider.id, PancakeV3MultiSwapProvider.id] + uSwapProviders))
+        providers = uSwapProviders
     }
 
-    func sync() {
+    private func syncSuspensions(responses: [ProviderResponse]) {
+        var byProvider = [String: [SwapSuspension]]()
+
+        for response in responses where !response.suspensions.isEmpty {
+            byProvider[response.provider] = response.suspensions
+        }
+
+        suspensions = SwapSuspensionIndex(byProvider: byProvider)
+        localStorage.uSwapSuspensions = Self.encode(byProvider: byProvider)
+    }
+
+    /// Suspensions must survive a cold launch: the provider list is cached for an hour, so without
+    /// this a restart would quote a suspended provider until the next sync.
+    ///
+    /// Returns whether a stored cache was found at all — `false` means this install has never held
+    /// suspensions, which is what makes the caller override the sync TTL. Note an empty rule set
+    /// still round-trips as `{}`, so "no suspensions anywhere" reads as `true` and does not force a
+    /// fetch on every launch.
+    @discardableResult private func restoreSuspensions() -> Bool {
+        guard let raw = localStorage.uSwapSuspensions, let data = raw.data(using: .utf8) else { return false }
+
+        guard let json = (try? JSONSerialization.jsonObject(with: data)) as? [String: [[String: Any]]] else {
+            return false
+        }
+
+        var byProvider = [String: [SwapSuspension]]()
+        for (providerId, rules) in json {
+            byProvider[providerId] = rules.compactMap { try? SwapSuspension(JSON: $0) }
+        }
+
+        suspensions = SwapSuspensionIndex(byProvider: byProvider)
+        return true
+    }
+
+    private static func encode(byProvider: [String: [SwapSuspension]]) -> String? {
+        var json = [String: [[String: Any]]]()
+
+        for (providerId, rules) in byProvider {
+            json[providerId] = rules.map { rule in
+                var dict: [String: Any] = ["kind": rule.kind.rawValue, "side": rule.side.rawValue]
+                if let asset = rule.asset { dict["asset"] = asset }
+                if let chain = rule.chain { dict["chain"] = chain }
+                if let sellAsset = rule.sellAsset { dict["sellAsset"] = sellAsset }
+                if let buyAsset = rule.buyAsset { dict["buyAsset"] = buyAsset }
+                if let expiresAt = rule.expiresAt { dict["expiresAt"] = ISO8601DateFormatter().string(from: expiresAt) }
+                return dict
+            }
+        }
+
+        guard let data = try? JSONSerialization.data(withJSONObject: json) else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    func sync(force: Bool = false) {
         let lastSyncTimetamp = localStorage.swapProvidersLastSyncTimestamp
 
-        if let lastSyncTimetamp, Date().timeIntervalSince1970 - lastSyncTimetamp < expiration {
+        if !force, let lastSyncTimetamp, Date().timeIntervalSince1970 - lastSyncTimetamp < expiration {
             return
         }
 
         Task { [weak self, networkManager, baseUrl, headers] in
-            let responses: [ProviderResponse] = try await networkManager.fetch(url: "\(baseUrl)/providers", headers: headers)
-            let rawValues = responses.map(\.provider)
+            do {
+                let responses: [ProviderResponse] = try await networkManager.fetch(url: "\(baseUrl)/providers", headers: headers)
 
-            self?.syncProviders(uSwapProviders: rawValues)
-            self?.localStorage.uSwapProviders = rawValues.joined(separator: ",")
-            self?.localStorage.swapProvidersLastSyncTimestamp = Date().timeIntervalSince1970
+                // A wholly suspended provider is dropped here rather than filtered per-pair later —
+                // there is no pair it can serve, so it should not produce a card at all.
+                await self?.apply(responses: responses.filter { !$0.suspended })
+            } catch {
+                // The cached list stays in place and the sync timestamp is deliberately NOT
+                // stamped, so the next `sync()` — the swap screen calls it on appear — retries
+                // instead of waiting out the hour. Logged because a FORCED sync failing means an
+                // install that has never held suspensions stays unenforced until that retry.
+                print("[MultiSwapProviderManager] provider sync failed: \(error)")
+            }
         }
+    }
+
+    /// Applies a fetched provider list on the main actor.
+    ///
+    /// `@PostPublished` is a bare `PassthroughSubject` fired synchronously from `didSet`, with no
+    /// synchronisation of its own, and `MultiSwapViewModel` reads both properties from the main
+    /// thread — so the writes have to happen there too.
+    @MainActor
+    private func apply(responses: [ProviderResponse]) {
+        let ids = responses.map(\.provider)
+
+        // Suspensions FIRST. `providers` is the signal the view model subscribes to, so everything
+        // it will read must already be in place by the time that assignment publishes.
+        syncSuspensions(responses: responses)
+        syncProviders(uSwapProviders: ids)
+
+        localStorage.uSwapProviders = ids.joined(separator: ",")
+        localStorage.swapProvidersLastSyncTimestamp = Date().timeIntervalSince1970
     }
 }
 
 extension MultiSwapProviderManager {
     struct ProviderResponse: ImmutableMappable {
         let provider: String
+        /// Whole-provider kill switch.
+        let suspended: Bool
+        /// Whether uswap-server can quote this provider. `false` for ids the app implements
+        /// natively (Uniswap / PancakeSwap / AllBridge) — they are listed purely so their policy,
+        /// including suspension, is managed in one place.
+        let quotes: Bool
+        let suspensions: [SwapSuspension]
 
         init(map: Map) throws {
             provider = try map.value("provider")
+            suspended = (try? map.value("suspended")) ?? false
+            quotes = (try? map.value("quotes")) ?? true
+            suspensions = (try? map.value("suspensions")) ?? []
         }
     }
 }

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/MultiSwapViewModel.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/MultiSwapViewModel.swift
@@ -310,6 +310,13 @@ public class MultiSwapViewModel: ObservableObject {
             .sink { [weak self] in self?.currency = $0 }
             .store(in: &cancellables)
 
+        // Fires on EVERY successful sync, not only when the id list actually changes —
+        // `@PostPublished` is a plain PassthroughSubject with no equality check (that is the
+        // separate `DistinctPublished`). That is what lets this one subscription cover suspensions
+        // too: the manager assigns them just before `providers`, so a sync that only changes which
+        // PAIRS a provider may serve still refreshes here. A second subscription on `$suspensions`
+        // would fire from the same response and cancel this refresh mid-flight, wasting a full
+        // round of provider requests.
         swapProviderManager.$providers
             .receive(on: DispatchQueue.main)
             .sink { [weak self] in
@@ -535,7 +542,19 @@ public class MultiSwapViewModel: ObservableObject {
 
     private func syncValidProviders() {
         if let internalTokenIn, let internalTokenOut {
-            validProviders = providers.filter { $0.supports(tokenIn: internalTokenIn, tokenOut: internalTokenOut) }
+            let suspensions = swapProviderManager.suspensions
+
+            validProviders = providers.filter { provider in
+                // Scoped suspension from uswap-server (asset / chain / directed pair). Checked
+                // HERE, in the one place every provider passes through, rather than inside each
+                // `supports` implementation — and it is the only enforcement that exists for the
+                // providers this app quotes natively, since those never reach the server.
+                guard !suspensions.isSuspended(providerId: provider.id, tokenIn: internalTokenIn, tokenOut: internalTokenOut) else {
+                    return false
+                }
+
+                return provider.supports(tokenIn: internalTokenIn, tokenOut: internalTokenOut)
+            }
         } else {
             validProviders = []
         }

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/SwapSuspension.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/SwapSuspension.swift
@@ -1,0 +1,220 @@
+import Foundation
+import MarketKit
+import ObjectMapper
+
+/// A scoped restriction published by uswap-server on `GET /v2/providers`.
+///
+/// Two kinds of provider need this and for different reasons:
+///  - Providers uswap-server quotes: it already refuses a suspended request, so honouring the rule
+///    here is purely so the user never sees a card that is going to fail.
+///  - Providers the APP quotes itself (Uniswap, PancakeSwap, AllBridge, and 1inch/THORChain/Maya,
+///    which have native implementations here): no server call happens at all, so this filter is the
+///    ONLY enforcement that exists. Dropping it would make those providers unsuspendable.
+public struct SwapSuspension: ImmutableMappable {
+    public enum Kind: String {
+        case asset
+        case chain
+        case pair
+    }
+
+    /// Which side of the swap the rule covers. Provider deposit and payout capability break
+    /// independently, so "either side" is a default, not the only option.
+    public enum Side: String {
+        case any
+        case sell
+        case buy
+    }
+
+    public let kind: Kind
+    public let side: Side
+    /// The CANONICAL asset ID (`ETH.0XA0B86991…`, `BTC.BTC`, `ETH-ETH`) — an ordinary asset
+    /// identifier, the same vocabulary a quote request uses, but exactly ONE spelling per asset.
+    ///
+    /// The server normalizes here because an asset has several valid identifiers and which one we
+    /// send depends on the sub-provider — this app spells USDC `ETH.USDC-0XA0B8…` via the asset map,
+    /// `ETH.0xa0b8…` for LI.FI and a bare `0xa0b8…` for Barter. Comparing our request string against
+    /// whichever spelling an operator typed would catch one and silently miss the rest, so both
+    /// sides normalize first (`CanonicalAssetId.of(token:)`) and compare the result.
+    public let asset: String?
+    public let chain: String?
+    public let sellAsset: String?
+    public let buyAsset: String?
+    public let expiresAt: Date?
+
+    public init(map: Map) throws {
+        kind = Kind(rawValue: try map.value("kind")) ?? .asset
+        side = Side(rawValue: (try? map.value("side")) ?? "any") ?? .any
+        asset = try? map.value("asset")
+        chain = try? map.value("chain")
+        sellAsset = try? map.value("sellAsset")
+        buyAsset = try? map.value("buyAsset")
+
+        if let raw: String = try? map.value("expiresAt") {
+            expiresAt = ISO8601DateFormatter().date(from: raw)
+        } else {
+            expiresAt = nil
+        }
+    }
+
+    /// The server already filters expired rules out, but a cached list outlives its own contents —
+    /// a rule that expires during the hour we hold the response must stop applying on its own.
+    func isLive(at date: Date = Date()) -> Bool {
+        guard let expiresAt else { return true }
+        return expiresAt > date
+    }
+
+    func matches(sell: String?, buy: String?) -> Bool {
+        switch kind {
+        case .asset:
+            return matchesSided(sell: sell, buy: buy) { $0 == asset }
+        case .chain:
+            return matchesSided(sell: sell, buy: buy) { CanonicalAssetId.chain(of: $0) == chain }
+        case .pair:
+            // Directed — the reverse direction is a separate rule.
+            guard let sell, let buy else { return false }
+            return sell == sellAsset && buy == buyAsset
+        }
+    }
+
+    private func matchesSided(sell: String?, buy: String?, test: (String) -> Bool) -> Bool {
+        if side != .buy, let sell, test(sell) { return true }
+        if side != .sell, let buy, test(buy) { return true }
+        return false
+    }
+}
+
+/// Builds uswap-server's canonical asset ID for a local `Token`.
+///
+/// This is the client half of a two-implementation contract (the other is
+/// `uswap-server/src/core/canonicalAsset.ts`). It is deliberately the SMALLER half: the server has
+/// to parse every identifier spelling a client might send, whereas here the token is already
+/// structured — a blockchain and a token type — so this only has to FORMAT, never parse. Keep it
+/// that way; if this ever starts string-splitting identifiers, the two will drift.
+enum CanonicalAssetId {
+    /// Chain codes as uswap-server spells them (its `Chain` enum), which is what the ID is built
+    /// from. A blockchain absent here yields no ID, so no rule can match it — the safe direction:
+    /// a provider stays quotable rather than being silently suspended by a mapping gap.
+    private static let chainCodes: [BlockchainType: String] = [
+        .bitcoin: "BTC",
+        .bitcoinCash: "BCH",
+        .ecash: "XEC",
+        .litecoin: "LTC",
+        .dash: "DASH",
+        .zcash: "ZEC",
+        .monero: "XMR",
+        .zano: "ZANO",
+        .ethereum: "ETH",
+        .binanceSmartChain: "BSC",
+        .polygon: "POL",
+        .avalanche: "AVAX",
+        .optimism: "OP",
+        .arbitrumOne: "ARB",
+        .gnosis: "GNO",
+        .base: "BASE",
+        .tron: "TRON",
+        .solana: "SOL",
+        .ton: "TON",
+        .stellar: "XLM",
+        .thorChain: "THOR",
+    ]
+
+    /// The gas asset's ticker per chain — NOT always the chain code (`BASE.ETH`, `BSC.BNB`,
+    /// `GNO.XDAI`), which is exactly why this is a table and not a derivation.
+    private static let nativeTickers: [BlockchainType: String] = [
+        .bitcoin: "BTC",
+        .bitcoinCash: "BCH",
+        .ecash: "XEC",
+        .litecoin: "LTC",
+        .dash: "DASH",
+        .zcash: "ZEC",
+        .monero: "XMR",
+        .zano: "ZANO",
+        .ethereum: "ETH",
+        .binanceSmartChain: "BNB",
+        .polygon: "POL",
+        .avalanche: "AVAX",
+        .optimism: "ETH",
+        .arbitrumOne: "ETH",
+        .gnosis: "XDAI",
+        .base: "ETH",
+        .tron: "TRX",
+        .solana: "SOL",
+        .ton: "TON",
+        .stellar: "XLM",
+        .thorChain: "RUNE",
+    ]
+
+    private static let wrappedSolMint = "So11111111111111111111111111111111111111112"
+
+    static func of(token: Token) -> String? {
+        guard let chain = chainCodes[token.blockchainType] else { return nil }
+
+        switch token.type {
+        case .native, .derived, .addressType:
+            // Derivation / address type are wallet-side concerns; on the server they are all one
+            // asset (`BTC.BTC`).
+            guard let ticker = nativeTickers[token.blockchainType] else { return nil }
+            return "\(chain).\(ticker)"
+
+        case let .eip20(address):
+            // Covers EVM hex and Tron base58 alike — both are upper-cased, matching the catalog
+            // identifier's own convention (`ETH.USDC-0XA0B8…`).
+            return "\(chain).\(address.uppercased())"
+
+        case let .spl(address):
+            // Wrapped SOL is native SOL everywhere on the server.
+            guard address != wrappedSolMint else { return "\(chain).SOL" }
+            return "\(chain).\(address.uppercased())"
+
+        case let .jetton(address):
+            return "\(chain).\(address.uppercased())"
+
+        case let .stellar(code, issuer):
+            // The CODE stays verbatim — Stellar codes are case-sensitive (`yXLM` ≠ `YXLM`). The
+            // issuer is StrKey, uppercase-only, so normalizing it is safe.
+            return "\(chain).\(code)-\(issuer.uppercased())"
+
+        case let .thorChainAsset(denom):
+            // THORChain secured (`eth-eth` in x/bank). Deliberately NOT chain-prefixed: the
+            // canonical id is the identifier a quote itself uses, and `chainOfAsset` treats a
+            // dot-less id as THORChain — which is where the asset actually lives.
+            return denom.uppercased()
+
+        case .zanoAsset, .unsupported:
+            return nil
+        }
+    }
+
+    /// The chain a canonical ID belongs to — what a chain-scoped rule matches on. A dot-less id can
+    /// only be a THORChain secured asset (`ETH-ETH`), which lives in THORChain's x/bank — so a
+    /// `THOR` chain rule covers it and an `ETH` one correctly does not.
+    static func chain(of id: String) -> String {
+        guard let separator = id.firstIndex(of: ".") else { return "THOR" }
+        return String(id[id.startIndex ..< separator])
+    }
+}
+
+
+/// The provider-id → rules index, plus the one question the swap screen asks.
+public struct SwapSuspensionIndex {
+    private let byProvider: [String: [SwapSuspension]]
+
+    public init(byProvider: [String: [SwapSuspension]] = [:]) {
+        self.byProvider = byProvider
+    }
+
+    /// May this provider be offered for this pair?
+    ///
+    /// A token we cannot normalize (an unmapped blockchain) yields `nil` and therefore never
+    /// matches — deliberately failing OPEN. The alternative, treating "unknown" as suspended, would
+    /// let one missing chain-code entry silently disable providers with no visible cause.
+    public func isSuspended(providerId: String, tokenIn: Token, tokenOut: Token) -> Bool {
+        guard let rules = byProvider[providerId], !rules.isEmpty else { return false }
+
+        let sell = CanonicalAssetId.of(token: tokenIn)
+        let buy = CanonicalAssetId.of(token: tokenOut)
+        let now = Date()
+
+        return rules.contains { $0.isLive(at: now) && $0.matches(sell: sell, buy: buy) }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added provider-specific swap availability rules for assets, networks, trading pairs, and buy/sell direction.
  - Suspension rules can expire and are refreshed from the service.
- **Improvements**
  - Suspended providers are automatically excluded from swap options and quote results.
  - Swap providers and quotes update automatically when availability changes.
  - Provider availability is preserved between sessions for a smoother experience.
  - Initial provider availability is synchronized when no cached rules are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->