### PR TITLE
Stop offering AllBridge as a swap provider

### DIFF
--- a/packages/WalletCore/Sources/WalletCore/Core/Factories/SwapProviderFactory.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Factories/SwapProviderFactory.swift
@@ -43,12 +43,18 @@ public class SwapProviderFactory {
         return nil
     }
 
-    // The ordinary swap screen must never offer a confidential provider. Not automatic: a registered
-    // entry resolves through `provider(id:)` (which tracking needs) and DefaultUSwapSubProvider.rate
-    // sends an explicit `providers` list, which overrides the server-side privacy filter.
+    /// Providers no longer offered for swapping. They stay resolvable through `provider(id:)` so
+    /// swaps already made with them keep resolving their type and stage layout in history, but no
+    /// quote card is built for them — the server may still list the id purely to carry policy.
+    private static let retiredProviderIds: Set<String> = [AllBridgeMultiSwapProvider.id]
+
+    // The ordinary swap screen must never offer a confidential or retired provider. Not automatic:
+    // a registered entry resolves through `provider(id:)` (which tracking needs) and
+    // DefaultUSwapSubProvider.rate sends an explicit `providers` list, which overrides the
+    // server-side privacy filter.
     public static func swappableProviders(ids: [String]) -> [IMultiSwapProvider] {
         ids
-            .filter { providerInfo(id: $0)?.confidential != true }
+            .filter { !retiredProviderIds.contains($0) && providerInfo(id: $0)?.confidential != true }
             .compactMap { provider(id: $0) }
     }
 

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/MultiSwapProviderManager.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/MultiSwapProviderManager.swift
@@ -57,7 +57,6 @@ class MultiSwapProviderManager {
         PancakeV3MultiSwapProvider.id,
         ThorChainMultiSwapProvider.id,
         MayaMultiSwapProvider.id,
-        AllBridgeMultiSwapProvider.id,
     ]
 
     private func syncProviders(uSwapProviders: [String]) {

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/SwapSuspension.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/SwapSuspension.swift
@@ -7,7 +7,7 @@ import ObjectMapper
 /// Two kinds of provider need this and for different reasons:
 ///  - Providers uswap-server quotes: it already refuses a suspended request, so honouring the rule
 ///    here is purely so the user never sees a card that is going to fail.
-///  - Providers the APP quotes itself (Uniswap, PancakeSwap, AllBridge, and 1inch/THORChain/Maya,
+///  - Providers the APP quotes itself (Uniswap, PancakeSwap, and 1inch/THORChain/Maya,
 ///    which have native implementations here): no server call happens at all, so this filter is the
 ///    ONLY enforcement that exists. Dropping it would make those providers unsuspendable.
 public struct SwapSuspension: ImmutableMappable {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Retired AllBridge from newly available swap provider options.
  - Removed AllBridge from the initial provider list shown before synchronization.
  - Historical AllBridge provider records remain resolvable for tracking.
- **Documentation**
  - Updated swap provider documentation to reflect AllBridge’s retired status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->