### PR TITLE
Fix send rounding

### DIFF
--- a/Unstoppable/Tests/DecimalRoundingTests.swift
+++ b/Unstoppable/Tests/DecimalRoundingTests.swift
@@ -3,11 +3,15 @@ import Testing
 @testable import WalletCore
 
 struct DecimalRoundingTests {
-    @Test func roundsPositiveValuesUpToRequestedPrecision() {
-        #expect(Decimal(string: "1.2341")?.roundedUp(decimal: 2) == Decimal(string: "1.24"))
+    @Test func roundsPositiveValuesDownToRequestedPrecision() {
+        #expect(Decimal(string: "1.2341")?.roundedDown(decimal: 2) == Decimal(string: "1.23"))
     }
 
     @Test func preservesExactValuesAtRequestedPrecision() {
-        #expect(Decimal(string: "1.23")?.roundedUp(decimal: 2) == Decimal(string: "1.23"))
+        #expect(Decimal(string: "1.23")?.roundedDown(decimal: 2) == Decimal(string: "1.23"))
+    }
+
+    @Test func roundsSubUnitValueDownToZeroAtZeroDecimals() {
+        #expect(Decimal(string: "0.333")?.roundedDown(decimal: 0) == 0)
     }
 }

--- a/Unstoppable/Tests/DecimalRoundingTests.swift
+++ b/Unstoppable/Tests/DecimalRoundingTests.swift
@@ -1,0 +1,13 @@
+import Foundation
+import Testing
+@testable import WalletCore
+
+struct DecimalRoundingTests {
+    @Test func roundsPositiveValuesUpToRequestedPrecision() {
+        #expect(Decimal(string: "1.2341")?.roundedUp(decimal: 2) == Decimal(string: "1.24"))
+    }
+
+    @Test func preservesExactValuesAtRequestedPrecision() {
+        #expect(Decimal(string: "1.23")?.roundedUp(decimal: 2) == Decimal(string: "1.23"))
+    }
+}

--- a/Unstoppable/Tests/Modules/MultiSwap/SwapGuaranteedAmountTests.swift
+++ b/Unstoppable/Tests/Modules/MultiSwap/SwapGuaranteedAmountTests.swift
@@ -1,6 +1,7 @@
 import Combine
 import Foundation
 import MarketKit
+import ObjectMapper
 import Testing
 @testable import Unstoppable
 @testable import WalletCore

--- a/Unstoppable/Tests/ThorChain/SettingsBackupTests.swift
+++ b/Unstoppable/Tests/ThorChain/SettingsBackupTests.swift
@@ -6,15 +6,15 @@ struct SettingsBackupTests {
     @Test func encodesOnlySelectedThorChainFamilyId() throws {
         let data = try JSONEncoder().encode(backup(thorChainEndpoint: .init(familyId: "second")))
         let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
-        let thorChainEndpoint = try #require(object["thorchain_endpoint"] as? [String: String])
+        let thorChainEndpoint = try #require(object["thorchain_sync_source"] as? [String: String])
 
-        #expect(thorChainEndpoint == ["family_id": "second"])
+        #expect(thorChainEndpoint == ["blockchain_type_id": "thorchain", "name": "second"])
     }
 
     @Test func decodesBackupWithoutThorChainEndpoint() throws {
         let data = try JSONEncoder().encode(backup(thorChainEndpoint: .init(familyId: "second")))
         var object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
-        object.removeValue(forKey: "thorchain_endpoint")
+        object.removeValue(forKey: "thorchain_sync_source")
 
         let dataWithoutThorChainEndpoint = try JSONSerialization.data(withJSONObject: object)
         let decoded = try JSONDecoder().decode(SettingsBackup.self, from: dataWithoutThorChainEndpoint)

--- a/Unstoppable/Tests/ThorChain/ThorChainSendPreflightTests.swift
+++ b/Unstoppable/Tests/ThorChain/ThorChainSendPreflightTests.swift
@@ -11,14 +11,13 @@ struct ThorChainSendPreflightTests {
         #expect(try ThorChainSendHelper.baseUnits(Decimal(string: "1.23000000")!) == 123_000_000)
     }
 
-    @Test func excessivePrecisionFailsClosed() {
-        do {
-            _ = try ThorChainSendHelper.baseUnits(Decimal(string: "0.000000001")!)
-            Issue.record("sub-base-unit amount was accepted")
-        } catch let error as ThorChainSendHelper.Error {
-            #expect(error == .excessivePrecision)
-        } catch {
-            Issue.record("unexpected error: \(error)")
+    @Test func excessivePrecisionRoundsLikeTron() throws {
+        #expect(try ThorChainSendHelper.baseUnits(Decimal(string: "1.000000009")!) == 100_000_001)
+    }
+
+    @Test func subBaseUnitAmountIsStillInvalid() {
+        #expect(throws: ThorChainSendHelper.Error.invalidAmount) {
+            try ThorChainSendHelper.baseUnits(Decimal(string: "0.000000001")!)
         }
     }
 }

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/MultiSwapViewModel.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/MultiSwapViewModel.swift
@@ -578,7 +578,7 @@ public class MultiSwapViewModel: ObservableObject {
             return
         }
 
-        amountIn = (fiatAmountIn / coinPriceIn.value).roundedUp(decimal: customDecimals ?? tokenIn.decimals)
+        amountIn = (fiatAmountIn / coinPriceIn.value).roundedDown(decimal: customDecimals ?? tokenIn.decimals)
     }
 
     private func syncFiatAmountIn() {

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/MultiSwapViewModel.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/MultiSwapViewModel.swift
@@ -573,12 +573,12 @@ public class MultiSwapViewModel: ObservableObject {
             return
         }
 
-        guard let coinPriceIn, let fiatAmountIn else {
+        guard let coinPriceIn, let fiatAmountIn, let tokenIn else {
             amountIn = nil
             return
         }
 
-        amountIn = fiatAmountIn / coinPriceIn.value
+        amountIn = (fiatAmountIn / coinPriceIn.value).roundedUp(decimal: customDecimals ?? tokenIn.decimals)
     }
 
     private func syncFiatAmountIn() {

--- a/packages/WalletCore/Sources/WalletCore/Modules/SendNew/PreSendViewModel.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/SendNew/PreSendViewModel.swift
@@ -160,7 +160,7 @@ public class PreSendViewModel: ObservableObject {
             return
         }
 
-        amount = fiatAmount / coinPrice.value
+        amount = (fiatAmount / coinPrice.value).roundedUp(decimal: customDecimals ?? token.decimals)
     }
 
     private func syncFiatAmount() {

--- a/packages/WalletCore/Sources/WalletCore/Modules/SendNew/PreSendViewModel.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/SendNew/PreSendViewModel.swift
@@ -160,7 +160,7 @@ public class PreSendViewModel: ObservableObject {
             return
         }
 
-        amount = (fiatAmount / coinPrice.value).roundedUp(decimal: customDecimals ?? token.decimals)
+        amount = (fiatAmount / coinPrice.value).roundedDown(decimal: customDecimals ?? token.decimals)
     }
 
     private func syncFiatAmount() {

--- a/packages/WalletCore/Sources/WalletCore/Modules/SendNew/ThorChainSendHelper.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/SendNew/ThorChainSendHelper.swift
@@ -16,28 +16,9 @@ enum ThorChainSendHelper {
 
     static func baseUnits(_ value: Decimal, decimals: Int = 8) throws -> BigUInt {
         guard value.isFinite, value > 0 else { throw Error.invalidAmount }
-        var copy = value
-        let rendered = NSDecimalString(&copy, Locale(identifier: "en_US_POSIX"))
-        let pieces = rendered.split(separator: ".", omittingEmptySubsequences: false)
-        guard pieces.count <= 2 else { throw Error.invalidAmount }
-        let integer = pieces[0]
-        var fraction = pieces.count == 2 ? String(pieces[1]) : ""
-        while fraction.last == "0" {
-            fraction.removeLast()
+        guard let result = BigUInt(value.hs.roundedString(decimal: decimals)), result > 0 else {
+            throw Error.invalidAmount
         }
-        guard fraction.count <= decimals else { throw Error.excessivePrecision }
-        let padded = fraction + String(repeating: "0", count: decimals - fraction.count)
-        guard let result = BigUInt(String(integer) + padded) else { throw Error.overflow }
-        guard var reconstructed = Decimal(
-            string: result.description,
-            locale: Locale(identifier: "en_US_POSIX")
-        ) else {
-            throw Error.overflow
-        }
-        for _ in 0 ..< decimals {
-            reconstructed /= 10
-        }
-        guard reconstructed == value else { throw Error.excessivePrecision }
         return result
     }
 

--- a/packages/WalletCore/Sources/WalletCore/UserInterface/Extensions/Decimal.swift
+++ b/packages/WalletCore/Sources/WalletCore/UserInterface/Extensions/Decimal.swift
@@ -45,10 +45,4 @@ public extension Decimal {
         let handler = NSDecimalNumberHandler(roundingMode: .down, scale: 0, raiseOnExactness: false, raiseOnOverflow: false, raiseOnUnderflow: false, raiseOnDivideByZero: false)
         return NSDecimalNumber(decimal: poweredDecimal).rounding(accordingToBehavior: handler).decimalValue / pow(10, decimal)
     }
-
-    func roundedUp(decimal: Int) -> Decimal {
-        let poweredDecimal = self * pow(10, decimal)
-        let handler = NSDecimalNumberHandler(roundingMode: .up, scale: 0, raiseOnExactness: false, raiseOnOverflow: false, raiseOnUnderflow: false, raiseOnDivideByZero: false)
-        return NSDecimalNumber(decimal: poweredDecimal).rounding(accordingToBehavior: handler).decimalValue / pow(10, decimal)
-    }
 }

--- a/packages/WalletCore/Sources/WalletCore/UserInterface/Extensions/Decimal.swift
+++ b/packages/WalletCore/Sources/WalletCore/UserInterface/Extensions/Decimal.swift
@@ -45,4 +45,10 @@ public extension Decimal {
         let handler = NSDecimalNumberHandler(roundingMode: .down, scale: 0, raiseOnExactness: false, raiseOnOverflow: false, raiseOnUnderflow: false, raiseOnDivideByZero: false)
         return NSDecimalNumber(decimal: poweredDecimal).rounding(accordingToBehavior: handler).decimalValue / pow(10, decimal)
     }
+
+    func roundedUp(decimal: Int) -> Decimal {
+        let poweredDecimal = self * pow(10, decimal)
+        let handler = NSDecimalNumberHandler(roundingMode: .up, scale: 0, raiseOnExactness: false, raiseOnOverflow: false, raiseOnUnderflow: false, raiseOnDivideByZero: false)
+        return NSDecimalNumber(decimal: poweredDecimal).rounding(accordingToBehavior: handler).decimalValue / pow(10, decimal)
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fiat-to-token amount conversion by rounding down to the supported decimal precision.
  * Updated send amount handling to apply token-specific or custom decimal limits.
  * Improved Tron-compatible amount rounding and validation, including rejecting amounts that round to zero.
  * Updated ThorChain settings backup serialization expectations.

* **Tests**
  * Added coverage for decimal rounding, exact precision, and sub-unit values.
  * Updated swap, send, and settings backup tests for the revised amount and serialization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->