### PR TITLE
Add THORChain secured assets: swaps and held-denom auto-enable

### DIFF
--- a/Unstoppable/Tests/ThorChain/ThorChainAutoEnableTests.swift
+++ b/Unstoppable/Tests/ThorChain/ThorChainAutoEnableTests.swift
@@ -1,0 +1,131 @@
+import BigInt
+import Foundation
+import MarketKit
+import ObjectMapper
+import Testing
+import ThorChainKit
+@testable import WalletCore
+
+struct ThorChainAutoEnableTests {
+    private static let ownAddress = "thor1le9eykyndunax8k24w8fykd8ndx35w2h27c008"
+    private static let otherAddress = "thor1g98cy3n9mmjrpn0sxmn63lztelera37n8n67c0"
+
+    // MARK: - Secured asset map entries
+
+    @Test func securedAssetMapsToThorChainAssetKey() throws {
+        let entries = try BaseThorChainMultiSwapProvider.securedAssetMapEntries(
+            securedAssets: [Self.securedAsset("BTC-BTC")]
+        )
+
+        let expectedKey = TokenQuery(blockchainType: .thorChain, tokenType: .thorChainAsset(denom: "btc-btc")).id.lowercased()
+        #expect(entries == [expectedKey: "BTC-BTC"])
+    }
+
+    @Test func securedContractAssetKeepsContractInDenomAndOriginalValue() throws {
+        let notation = "ETH-USDC-0XA0B86991C6218B36C1D19D4A2E9EB0CE3606EB48"
+        let entries = try BaseThorChainMultiSwapProvider.securedAssetMapEntries(
+            securedAssets: [Self.securedAsset(notation)]
+        )
+
+        let expectedKey = TokenQuery(
+            blockchainType: .thorChain,
+            tokenType: .thorChainAsset(denom: "eth-usdc-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48")
+        ).id.lowercased()
+        #expect(entries == [expectedKey: notation])
+    }
+
+    @Test func invalidSecuredNotationIsSkipped() throws {
+        let entries = try BaseThorChainMultiSwapProvider.securedAssetMapEntries(
+            securedAssets: [Self.securedAsset("BTCBTC"), Self.securedAsset("AVAX-AVAX")]
+        )
+
+        let expectedKey = TokenQuery(blockchainType: .thorChain, tokenType: .thorChainAsset(denom: "avax-avax")).id.lowercased()
+        #expect(entries == [expectedKey: "AVAX-AVAX"])
+    }
+
+    private static func securedAsset(_ notation: String) throws -> BaseThorChainMultiSwapProvider.SecuredAsset {
+        try BaseThorChainMultiSwapProvider.SecuredAsset(JSONString: "{\"asset\":\"\(notation)\"}")
+    }
+
+    // MARK: - Auto-enable queries
+
+    @Test func nativeDenomIsNeverEnabled() throws {
+        let tcy = try ThorChainKit.Denom(rawValue: "tcy")
+        let queries = ThorChainKitManager.autoEnableQueries(
+            denoms: [.rune, tcy],
+            nativeDenom: .rune,
+            existingTokenTypeIds: [],
+            blockchainType: .thorChain
+        )
+
+        #expect(queries.map(\.tokenType) == [.thorChainAsset(denom: "tcy")])
+    }
+
+    @Test func alreadyEnabledTokensAreDeduped() throws {
+        let tcy = try ThorChainKit.Denom(rawValue: "tcy")
+        let secured = try ThorChainKit.Denom(rawValue: "btc-btc")
+        let existingId = TokenType.thorChainAsset(denom: "tcy").id
+
+        let queries = ThorChainKitManager.autoEnableQueries(
+            denoms: [tcy, secured],
+            nativeDenom: .rune,
+            existingTokenTypeIds: [existingId],
+            blockchainType: .thorChain
+        )
+
+        #expect(queries.map(\.tokenType) == [.thorChainAsset(denom: "btc-btc")])
+    }
+
+    @Test func emptyDenomsYieldNoQueries() {
+        let queries = ThorChainKitManager.autoEnableQueries(
+            denoms: [],
+            nativeDenom: .rune,
+            existingTokenTypeIds: [],
+            blockchainType: .thorChain
+        )
+
+        #expect(queries.isEmpty)
+    }
+
+    // MARK: - Incoming denoms from transactions
+
+    @Test func onlyTransfersToOwnAddressCount() throws {
+        let transactions = [
+            Self.transaction(incoming: [(Self.ownAddress, "THOR.TCY"), (Self.otherAddress, "BTC-BTC")]),
+        ]
+
+        let denoms = ThorChainKitManager.incomingDenoms(transactions: transactions, address: Self.ownAddress, chain: .thor)
+
+        let tcy = try ThorChainKit.Denom(rawValue: "tcy")
+        #expect(denoms == [tcy])
+    }
+
+    @Test func midgardNotationIsCanonicalizedToBankDenoms() throws {
+        let transactions = [
+            Self.transaction(incoming: [
+                (Self.ownAddress, "THOR.TCY"),
+                (Self.ownAddress, "BTC-BTC"),
+                (Self.ownAddress, "THOR.RUNE"),
+            ]),
+        ]
+
+        let denoms = ThorChainKitManager.incomingDenoms(transactions: transactions, address: Self.ownAddress, chain: .thor)
+
+        let tcy = try ThorChainKit.Denom(rawValue: "tcy")
+        let secured = try ThorChainKit.Denom(rawValue: "btc-btc")
+        #expect(denoms == [tcy, secured, .rune])
+    }
+
+    private static func transaction(incoming: [(String, String)]) -> ThorChainKit.Transaction {
+        ThorChainKit.Transaction(
+            transactionId: ThorChainKit.TransactionID(hash: "F0E1D2C3B4A5968778695A4B3C2D1E0F00112233445566778899AABBCCDDEEFF")!,
+            blockHeight: 27_000_000,
+            timestamp: Date(timeIntervalSince1970: 1_785_427_946),
+            type: "send",
+            status: "success",
+            memo: nil,
+            incoming: incoming.map { ThorChainKit.CoinTransfer(address: $0.0, asset: $0.1, amount: BigUInt(100_000_000)) },
+            outgoing: []
+        )
+    }
+}

--- a/packages/WalletCore/Sources/WalletCore/Core/Core.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Core.swift
@@ -290,12 +290,14 @@ public class Core {
             blockchainSettingsStorage: blockchainSettingsStorage,
             endpointProvider: ThorChainEndpointConfigurationProvider()
         )
-        let thorChainKitManager = ThorChainKitManager(endpointManager: thorChainEndpointManager)
+        let thorChainKitManager = ThorChainKitManager(endpointManager: thorChainEndpointManager, restoreStateManager: restoreStateManager, marketKit: marketKit, walletManager: walletManager)
         mayaChainEndpointManager = ThorChainEndpointManager(
             blockchainSettingsStorage: blockchainSettingsStorage,
             endpointProvider: MayaChainEndpointConfigurationProvider(),
             blockchainType: .mayaChain
         )
+        // No auto-enable deps for Maya: the catalog has no Maya denoms and the app maps
+        // .thorChainAsset to THOR only (AccountType.supports, AdapterFactory).
         let mayaChainKitManager = ThorChainKitManager(endpointManager: mayaChainEndpointManager, network: .mayaMainnet)
         tronAccountManager = TronAccountManager(accountManager: accountManager, walletManager: walletManager, marketKit: marketKit, tronKitManager: tronKitManager, restoreStateManager: restoreStateManager)
 

--- a/packages/WalletCore/Sources/WalletCore/Core/Managers/ThorChainKitManager.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Managers/ThorChainKitManager.swift
@@ -1,6 +1,8 @@
+import Combine
 import Foundation
 import HsCryptoKit
 import HsToolKit
+import MarketKit
 import RxRelay
 import RxSwift
 import ThorChainKit
@@ -119,10 +121,19 @@ final class ThorChainKitManager {
     private let queue: DispatchQueue
     private let endpointManager: ThorChainEndpointManager
     private let network: ThorChainKit.Network
+    // Auto-enable dependencies; nil leaves held-token auto-enable off (tests, factory convenience path)
+    private let restoreStateManager: RestoreStateManager?
+    private let marketKit: MarketKit.Kit?
+    private let walletManager: WalletManager?
     private let kitUpdatedRelay = PublishRelay<Void>()
+    private var balanceCancellable: AnyCancellable?
+    private var transactionsCancellable: AnyCancellable?
 
-    init(endpointManager: ThorChainEndpointManager, network: ThorChainKit.Network = .mainnet) {
+    init(endpointManager: ThorChainEndpointManager, restoreStateManager: RestoreStateManager? = nil, marketKit: MarketKit.Kit? = nil, walletManager: WalletManager? = nil, network: ThorChainKit.Network = .mainnet) {
         self.endpointManager = endpointManager
+        self.restoreStateManager = restoreStateManager
+        self.marketKit = marketKit
+        self.walletManager = walletManager
         self.network = network
         queue = DispatchQueue(label: "\(AppConfig.label).thor-chain-kit-manager.\(network.chain.rawValue)", qos: .userInitiated)
 
@@ -195,10 +206,109 @@ final class ThorChainKitManager {
             endpoints: endpointConfiguration.value
         )
         kit.start()
+        subscribeToAutoEnable(kit: kit, address: address, account: account)
         let wrapper = ThorChainKitWrapper(thorChainKit: kit, signer: signer)
         _wrapper = wrapper
         currentIdentity = identity
         return wrapper
+    }
+
+    // Auto-enable of held denoms (TCY, secured assets, …), mirroring TonKitManager's
+    // dual pattern: a one-shot balances pass for restore, then tx-driven enabling.
+    // Re-subscription is free: a new kit (endpoint or account switch) passes here again.
+    private func subscribeToAutoEnable(kit: ThorChainKit.Kit, address: ThorChainKit.Address, account: Account) {
+        guard let restoreStateManager else { return }
+
+        let blockchainType = blockchainType
+        let restoreState = restoreStateManager.restoreState(account: account, blockchainType: blockchainType)
+
+        if restoreState.shouldRestore || account.watchAccount, !restoreState.initialRestored {
+            balanceCancellable = kit.accountStatePublisher
+                .sink { [weak self] accountState in
+                    guard let balances = accountState?.balances, !balances.isEmpty else { return }
+
+                    self?.handle(denoms: balances.filter { $0.value > 0 }.map(\.key), account: account)
+
+                    restoreStateManager.setInitialRestored(account: account, blockchainType: blockchainType)
+
+                    self?.balanceCancellable?.cancel()
+                    self?.balanceCancellable = nil
+                }
+        }
+
+        // allTransactionsPublisher emits only unprocessed transactions, so a manually
+        // disabled token is not re-enabled by unchanged history.
+        transactionsCancellable = kit.allTransactionsPublisher
+            .sink { [weak self] transactions, initial in
+                self?.handle(transactions: transactions, initial: initial, address: address, account: account)
+            }
+    }
+
+    private func handle(transactions: [ThorChainKit.Transaction], initial: Bool, address: ThorChainKit.Address, account: Account) {
+        if initial, account.origin == .restored, !account.watchAccount,
+           let restoreStateManager, !restoreStateManager.shouldRestore(account: account, blockchainType: blockchainType)
+        {
+            return
+        }
+
+        let denoms = Self.incomingDenoms(transactions: transactions, address: address.raw, chain: network.chain)
+
+        handle(denoms: Array(denoms), account: account)
+    }
+
+    private func handle(denoms: [ThorChainKit.Denom], account: Account) {
+        guard let marketKit, let walletManager, Core.shared.config.autoEnableTokensOnReceive else {
+            return
+        }
+
+        let queries = Self.autoEnableQueries(
+            denoms: denoms,
+            nativeDenom: network.nativeDenom,
+            existingTokenTypeIds: walletManager.activeWallets.map(\.token.type.id),
+            blockchainType: blockchainType
+        )
+
+        guard !queries.isEmpty, let tokens = try? marketKit.tokens(queries: queries), !tokens.isEmpty else {
+            return
+        }
+
+        let enabledWallets = tokens.map { token in
+            EnabledWallet(
+                tokenQueryId: token.tokenQuery.id,
+                accountId: account.id,
+                coinName: token.coin.name,
+                coinCode: token.coin.code,
+                tokenDecimals: token.decimals
+            )
+        }
+
+        walletManager.save(enabledWallets: enabledWallets)
+    }
+
+    static func incomingDenoms(transactions: [ThorChainKit.Transaction], address: String, chain: ThorChainKit.Network.Chain) -> Set<ThorChainKit.Denom> {
+        var denoms = Set<ThorChainKit.Denom>()
+
+        for transaction in transactions {
+            for transfer in transaction.incoming where transfer.address == address {
+                guard let asset = try? chain.asset(for: transfer.asset),
+                      let denom = try? ThorChainKit.Denom(rawValue: chain.denom(for: asset))
+                else { continue }
+                denoms.insert(denom)
+            }
+        }
+
+        return denoms
+    }
+
+    static func autoEnableQueries(denoms: [ThorChainKit.Denom], nativeDenom: ThorChainKit.Denom, existingTokenTypeIds: [String], blockchainType: BlockchainType) -> [TokenQuery] {
+        denoms
+            .filter { $0 != nativeDenom }
+            .map { TokenQuery(blockchainType: blockchainType, tokenType: .thorChainAsset(denom: $0.rawValue)) }
+            .filter { !existingTokenTypeIds.contains($0.tokenType.id) }
+    }
+
+    private var blockchainType: BlockchainType {
+        network.chain == .maya ? .mayaChain : .thorChain
     }
 
     private func validate(endpointConfiguration: ThorChainEndpointConfiguration) throws {

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/DestinationHelper.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/DestinationHelper.swift
@@ -76,6 +76,10 @@ public enum DestinationHelper {
             address = ZanoAdapter.address(accountType: account.type)
         case .solana:
             address = try SolanaKitManager.address(accountType: account.type)
+        case .thorChain:
+            address = try AccountAddress.thorChainAddress(account: account, network: .mainnet).raw
+        case .mayaChain:
+            address = try AccountAddress.thorChainAddress(account: account, network: .mayaMainnet).raw
         default:
             throw SwapError.noDestinationAddress
         }

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/ThorChain/BaseThorChainMultiSwapProvider.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/ThorChain/BaseThorChainMultiSwapProvider.swift
@@ -13,7 +13,7 @@ import ThorChainKit
 class BaseThorChainMultiSwapProvider: IMultiSwapProvider {
     private let assetMapExpiration: TimeInterval = 60 * 60
     // Bump to discard maps cached by older mapping logic.
-    private let assetMapVersion = 3
+    private let assetMapVersion = 4
     private var assetMapKey: String { "\(id)-v\(assetMapVersion)" }
 
     let networkManager = Core.shared.networkManager
@@ -38,6 +38,9 @@ class BaseThorChainMultiSwapProvider: IMultiSwapProvider {
     }
 
     var baseUrl: String { fatalError("Must be overridden by subclass") }
+    // THORChain exposes secured assets (BTC-BTC, ETH-ETH, …) via /securedassets and makes
+    // them swappable through the standard `=:` memo. Maya has none, so it stays false.
+    var securedAssetsSupported: Bool { false }
     var id: String { fatalError("Must be overridden by subclass") }
     var name: String { fatalError("Must be overridden by subclass") }
     var type: SwapProviderType { fatalError("Must be overridden by subclass") }
@@ -342,13 +345,21 @@ class BaseThorChainMultiSwapProvider: IMultiSwapProvider {
             return
         }
 
-        Task { [weak self, networkManager, baseUrl] in
+        Task { [weak self, networkManager, baseUrl, securedAssetsSupported] in
             let pools: [Pool] = try await networkManager.fetch(url: "\(baseUrl)/pools")
-            self?.sync(pools: pools)
+
+            // Secured assets live in x/bank, not /pools. Fetched defensively: a
+            // /securedassets outage must not discard the pool-based map.
+            var securedAssets = [SecuredAsset]()
+            if securedAssetsSupported {
+                securedAssets = await (try? networkManager.fetch(url: "\(baseUrl)/securedassets") as [SecuredAsset]) ?? []
+            }
+
+            self?.sync(pools: pools, securedAssets: securedAssets)
         }
     }
 
-    private func sync(pools: [Pool]) {
+    private func sync(pools: [Pool], securedAssets: [SecuredAsset]) {
         var assetMap = [String: String]()
 
         let availablePools = pools.filter { $0.status.caseInsensitiveCompare("available") == .orderedSame }
@@ -404,6 +415,8 @@ class BaseThorChainMultiSwapProvider: IMultiSwapProvider {
 
         assetMap[TokenQuery(blockchainType: settlementBlockchainType, tokenType: .native).id.lowercased()] = settlementAsset
 
+        assetMap.merge(Self.securedAssetMapEntries(securedAssets: securedAssets)) { _, secured in secured }
+
         try? swapAssetStorage.save(swapAssetMap: assetMap, provider: assetMapKey)
         try? swapAssetStorage.save(lastSyncTimestamp: Date().timeIntervalSince1970, provider: assetMapKey)
 
@@ -411,6 +424,18 @@ class BaseThorChainMultiSwapProvider: IMultiSwapProvider {
             self.assetMap = assetMap
             self.syncSubject.send()
         }
+    }
+
+    static func securedAssetMapEntries(securedAssets: [SecuredAsset]) -> [String: String] {
+        var entries = [String: String]()
+
+        for securedAsset in securedAssets {
+            guard let asset = try? ThorChainKit.Asset(notation: securedAsset.asset) else { continue }
+            let denom = ThorChainKit.Denom.denom(for: asset)
+            entries[TokenQuery(blockchainType: .thorChain, tokenType: .thorChainAsset(denom: denom)).id.lowercased()] = securedAsset.asset
+        }
+
+        return entries
     }
 
     private func blockchainType(assetBlockchainId: String) -> BlockchainType? {
@@ -444,6 +469,15 @@ extension BaseThorChainMultiSwapProvider {
         init(map: Map) throws {
             asset = try map.value("asset")
             status = try map.value("status")
+        }
+    }
+
+    // /securedassets also reports supply and depth; only the asset notation is needed.
+    struct SecuredAsset: ImmutableMappable {
+        let asset: String
+
+        init(map: Map) throws {
+            asset = try map.value("asset")
         }
     }
 

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/ThorChain/ThorChainMultiSwapProvider.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/ThorChain/ThorChainMultiSwapProvider.swift
@@ -6,6 +6,8 @@ class ThorChainMultiSwapProvider: BaseThorChainMultiSwapProvider {
         "https://gateway.liquify.com/chain/thorchain_api/thorchain"
     }
 
+    override var securedAssetsSupported: Bool { true }
+
     override var id: String { Self.id }
     override var name: String { Self.name }
     override var type: SwapProviderType { .excellent }


### PR DESCRIPTION
- fetch /securedassets into the swap asset map (THOR only), bump map version to 4
- resolve THORChain/Maya swap destination address from the account seed
- auto-enable held denoms in ThorChainKitManager: one-shot restore pass + tx-driven

ref #7175 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic enabling of supported, non-native tokens received through THORChain transactions.
  * Added secured-asset support for THORChain swaps, including asset mapping and synchronization.
  * Added destination address resolution for THORChain and MayaChain assets.
* **Bug Fixes**
  * Improved filtering, deduplication, denomination handling, and invalid asset notation processing during token discovery.
  * Preserved available pool data when secured-asset synchronization fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->