### PR TITLE
Make Thorchain swap provider public

### DIFF
--- a/.github/workflows/notify_telegram.yml
+++ b/.github/workflows/notify_telegram.yml
@@ -16,3 +16,6 @@ jobs:
           token: ${{ secrets.TELEGRAM_TOKEN }}
           message: |
             ${{ github.event.pull_request.html_url }}
+
+            Title: ${{ github.event.pull_request.title }}
+            Author: ${{ github.actor }}

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/IMultiSwapProvider.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/IMultiSwapProvider.swift
@@ -21,12 +21,12 @@ public protocol IMultiSwapProvider {
     func track(swap: Swap) async throws -> Swap
 }
 
-extension IMultiSwapProvider {
+public extension IMultiSwapProvider {
     var requireTerms: Bool {
         false
     }
 
-    public var preciseEstimateTime: Bool {
+    var preciseEstimateTime: Bool {
         true
     }
 

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/ThorChain/BaseThorChainMultiSwapProvider.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/ThorChain/BaseThorChainMultiSwapProvider.swift
@@ -10,7 +10,7 @@ import ObjectMapper
 import SwiftUI
 import ThorChainKit
 
-class BaseThorChainMultiSwapProvider: IMultiSwapProvider {
+public class BaseThorChainMultiSwapProvider: IMultiSwapProvider {
     private let assetMapExpiration: TimeInterval = 60 * 60
     // Bump to discard maps cached by older mapping logic.
     private let assetMapVersion = 4
@@ -31,7 +31,7 @@ class BaseThorChainMultiSwapProvider: IMultiSwapProvider {
     private var assetMap = [String: String]()
     private let syncSubject = PassthroughSubject<Void, Never>()
 
-    init(tracker: USwapTracker) {
+    public init(tracker: USwapTracker) {
         self.tracker = tracker
         assetMap = (try? swapAssetStorage.swapAssetMap(provider: assetMapKey, as: String.self)) ?? [:]
         syncAssets()
@@ -41,12 +41,12 @@ class BaseThorChainMultiSwapProvider: IMultiSwapProvider {
     // THORChain exposes secured assets (BTC-BTC, ETH-ETH, …) via /securedassets and makes
     // them swappable through the standard `=:` memo. Maya has none, so it stays false.
     var securedAssetsSupported: Bool { false }
-    var id: String { fatalError("Must be overridden by subclass") }
-    var name: String { fatalError("Must be overridden by subclass") }
-    var type: SwapProviderType { fatalError("Must be overridden by subclass") }
-    var icon: String { fatalError("Must be overridden by subclass") }
+    public var id: String { fatalError("Must be overridden by subclass") }
+    public var name: String { fatalError("Must be overridden by subclass") }
+    public var type: SwapProviderType { fatalError("Must be overridden by subclass") }
+    public var icon: String { fatalError("Must be overridden by subclass") }
 
-    var syncPublisher: AnyPublisher<Void, Never>? {
+    public var syncPublisher: AnyPublisher<Void, Never>? {
         syncSubject.eraseToAnyPublisher()
     }
 
@@ -74,11 +74,11 @@ class BaseThorChainMultiSwapProvider: IMultiSwapProvider {
         token.type == .native && token.blockchainType == settlementBlockchainType ? token.decimals : 8
     }
 
-    func supports(tokenIn: Token, tokenOut: Token) -> Bool {
+    public func supports(tokenIn: Token, tokenOut: Token) -> Bool {
         assetMap[tokenIn.tokenQuery.id.lowercased()] != nil && assetMap[tokenOut.tokenQuery.id.lowercased()] != nil
     }
 
-    func quote(tokenIn: Token, tokenOut: Token, amountIn: Decimal) async throws -> MultiSwapQuote {
+    public func quote(tokenIn: Token, tokenOut: Token, amountIn: Decimal) async throws -> MultiSwapQuote {
         let swapQuote = try await swapQuote(tokenIn: tokenIn, tokenOut: tokenOut, amountIn: amountIn)
 
         let blockchainType = tokenIn.blockchainType
@@ -101,7 +101,7 @@ class BaseThorChainMultiSwapProvider: IMultiSwapProvider {
         }
     }
 
-    func confirmationQuote(multiSwapQuote _: MultiSwapQuote, tokenIn: Token, tokenOut: Token, amountIn: Decimal, slippage: Decimal, recipient: String?, transactionSettings: TransactionSettings?) async throws -> SwapFinalQuote {
+    public func confirmationQuote(multiSwapQuote _: MultiSwapQuote, tokenIn: Token, tokenOut: Token, amountIn: Decimal, slippage: Decimal, recipient: String?, transactionSettings: TransactionSettings?) async throws -> SwapFinalQuote {
         let swapQuote = try await swapQuote(tokenIn: tokenIn, tokenOut: tokenOut, amountIn: amountIn, slippage: slippage, recipient: recipient)
         let toAddress = try await resolveDestination(recipient: nil, token: tokenOut)
 
@@ -270,11 +270,11 @@ class BaseThorChainMultiSwapProvider: IMultiSwapProvider {
         return inbound + swap + outbound
     }
 
-    func preSwapView(step: MultiSwapPreSwapStep, tokenIn: Token, tokenOut _: Token, amount: Decimal, isPresented: Binding<Bool>, onSuccess: @escaping () -> Void) -> AnyView {
+    public func preSwapView(step: MultiSwapPreSwapStep, tokenIn: Token, tokenOut _: Token, amount: Decimal, isPresented: Binding<Bool>, onSuccess: @escaping () -> Void) -> AnyView {
         allowanceHelper.preSwapView(step: step, tokenIn: tokenIn, amount: amount, isPresented: isPresented, onSuccess: onSuccess)
     }
 
-    func track(swap: Swap) async throws -> Swap {
+    public func track(swap: Swap) async throws -> Swap {
         // Native THORChain/Maya swaps aren't recorded by us → the stateless reader.
         try await tracker.track(
             swap: swap,

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/ThorChain/MayaMultiSwapProvider.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/ThorChain/MayaMultiSwapProvider.swift
@@ -6,8 +6,8 @@ import ObjectMapper
 import SwiftUI
 import ZcashLightClientKit
 
-class MayaMultiSwapProvider: BaseThorChainMultiSwapProvider {
-    static let id = "MAYACHAIN"
+public class MayaMultiSwapProvider: BaseThorChainMultiSwapProvider {
+    public static let id = "MAYACHAIN"
     static let name = "Maya Protocol"
 
     private let testNetManager = Core.shared.testNetManager
@@ -24,10 +24,10 @@ class MayaMultiSwapProvider: BaseThorChainMultiSwapProvider {
         return "https://\(stagenet)mayanode.mayachain.info/mayachain"
     }
 
-    override var id: String { Self.id }
-    override var name: String { Self.name }
-    override var type: SwapProviderType { .excellent }
-    override var icon: String { "swap_provider_maya" }
+    override public var id: String { Self.id }
+    override public var name: String { Self.name }
+    override public var type: SwapProviderType { .excellent }
+    override public var icon: String { "swap_provider_maya" }
 
     override var affiliate: String? {
         AppConfig.mayaAffiliate
@@ -80,7 +80,7 @@ class MayaMultiSwapProvider: BaseThorChainMultiSwapProvider {
         return try await adapter.sendProposal(outputs: [transparentOutput, memoOutput])
     }
 
-    override func confirmationQuote(multiSwapQuote: MultiSwapQuote, tokenIn: Token, tokenOut: Token, amountIn: Decimal, slippage: Decimal, recipient: String?, transactionSettings: TransactionSettings?) async throws -> SwapFinalQuote {
+    override public func confirmationQuote(multiSwapQuote: MultiSwapQuote, tokenIn: Token, tokenOut: Token, amountIn: Decimal, slippage: Decimal, recipient: String?, transactionSettings: TransactionSettings?) async throws -> SwapFinalQuote {
         // use base scenario for all tokens except zcash
         guard tokenIn.blockchainType == .zcash else {
             return try await super.confirmationQuote(multiSwapQuote: multiSwapQuote, tokenIn: tokenIn, tokenOut: tokenOut, amountIn: amountIn, slippage: slippage, recipient: recipient, transactionSettings: transactionSettings)

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/ThorChain/ThorChainMultiSwapProvider.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/Providers/ThorChain/ThorChainMultiSwapProvider.swift
@@ -1,5 +1,5 @@
-class ThorChainMultiSwapProvider: BaseThorChainMultiSwapProvider {
-    static let id = "THORCHAIN"
+public class ThorChainMultiSwapProvider: BaseThorChainMultiSwapProvider {
+    public static let id = "THORCHAIN"
     static let name = "THORChain"
 
     override var baseUrl: String {
@@ -8,10 +8,10 @@ class ThorChainMultiSwapProvider: BaseThorChainMultiSwapProvider {
 
     override var securedAssetsSupported: Bool { true }
 
-    override var id: String { Self.id }
-    override var name: String { Self.name }
-    override var type: SwapProviderType { .excellent }
-    override var icon: String { "swap_provider_thorchain" }
+    override public var id: String { Self.id }
+    override public var name: String { Self.name }
+    override public var type: SwapProviderType { .excellent }
+    override public var icon: String { "swap_provider_thorchain" }
 
     override var affiliate: String? {
         AppConfig.thorchainAffiliate


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded public access to multi-swap providers and their metadata.
  - Enabled external access to provider initialization, swap quoting, tracking, and related functionality.
  - Made ThorChain and Maya provider identifiers publicly available.

- **Chores**
  - Telegram pull request notifications now include the pull request title and author alongside its URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->