### PR TITLE
Hide synthetic coins (re-listed on other chains) from Market search

### DIFF
--- a/Unstoppable/Tests/CoinSyntheticTests.swift
+++ b/Unstoppable/Tests/CoinSyntheticTests.swift
@@ -1,0 +1,20 @@
+import MarketKit
+import Testing
+@testable import WalletCore
+
+struct CoinSyntheticTests {
+    @Test func originalCoinIsNotSynthetic() {
+        let coin = Coin(uid: "bitcoin", name: "Bitcoin", code: "BTC", coinGeckoId: "bitcoin")
+        #expect(coin.isSynthetic == false)
+    }
+
+    @Test func reListedCoinIsSynthetic() {
+        let coin = Coin(uid: "thorchain-secured-bitcoin", name: "Bitcoin (THORChain)", code: "BTC", coinGeckoId: "bitcoin")
+        #expect(coin.isSynthetic == true)
+    }
+
+    @Test func coinWithoutCoinGeckoIdIsNotSynthetic() {
+        let coin = Coin(uid: "custom-coin", name: "Custom", code: "CST", coinGeckoId: nil)
+        #expect(coin.isSynthetic == false)
+    }
+}

--- a/packages/WalletCore/Sources/WalletCore/Extensions/Coin.swift
+++ b/packages/WalletCore/Sources/WalletCore/Extensions/Coin.swift
@@ -11,4 +11,10 @@ extension Coin {
         let scale = Int(UIScreen.main.scale)
         return "https://cdn.blocksdecoded.com/coin-icons/32px/\(uid)@\(scale)x.png"
     }
+
+    // Same rule as the server: a coin re-listed on another chain keeps the original coingecko_id
+    var isSynthetic: Bool {
+        guard let coinGeckoId else { return false }
+        return coinGeckoId != uid
+    }
 }

--- a/packages/WalletCore/Sources/WalletCore/Modules/Market/Search/MarketSearchViewModel.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/Market/Search/MarketSearchViewModel.swift
@@ -33,11 +33,11 @@ class MarketSearchViewModel: ObservableObject {
             let recentMarketFullCoins = (try? marketKit.fullCoins(coinUids: recentCoinUids)) ?? []
             let recentFullCoins = recentCoinUids.compactMap { coinUid in recentMarketFullCoins.first { $0.coin.uid == coinUid } }
 
-            let popularFullCoins = (try? marketKit.topFullCoins()) ?? []
+            let popularFullCoins = ((try? marketKit.topFullCoins()) ?? []).filter { !$0.coin.isSynthetic }
 
             state = .placeholder(recentFullCoins: recentFullCoins, popularFullCoins: popularFullCoins)
         } else {
-            state = .searchResults(fullCoins: (try? marketKit.fullCoins(filter: searchText)) ?? [])
+            state = .searchResults(fullCoins: ((try? marketKit.fullCoins(filter: searchText)) ?? []).filter { !$0.coin.isSynthetic })
         }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Synthetic coins are no longer shown in popular coin lists or market search results.
  - Original and relisted coins are now correctly distinguished when filtering market data.
  - Recent coin history remains unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->