### PR TITLE
Hide suspicious Solana transactions, readonly Solana account (#7164)

### DIFF
--- a/Unstoppable/Tests/SolanaSpamPolicyTests.swift
+++ b/Unstoppable/Tests/SolanaSpamPolicyTests.swift
@@ -1,0 +1,293 @@
+import EvmKit
+import Foundation
+import GRDB
+import MarketKit
+import Testing
+import TronKit
+@testable import WalletCore
+
+// Android-parity fixtures for the Solana spam decision path:
+// SpamFilterChain (OutgoingPoisoningFilter) + SolanaLowAmountCondition + AddressSimilarity/TimeCorrelation,
+// composed the same way SpamManager.evaluateSpam does. SOL limit 0.0001: spam < 0.00001, risk < 0.0001, danger < 0.0005.
+struct SolanaSpamPolicyTests {
+    // MARK: - Direct incoming
+
+    @Test func rawIncomingIsSpam() throws {
+        let events = TransferEvents(incoming: [event(raw: 1)])
+        let spam = try isSpam(events: events)
+        #expect(spam == true)
+    }
+
+    @Test func zeroNativeIncomingIsSpam() throws {
+        let events = TransferEvents(incoming: [event(sol: "0")])
+        let spam = try isSpam(events: events)
+        #expect(spam == true)
+    }
+
+    @Test func zeroKnownSplWithoutLimitIsSpam() throws {
+        let events = TransferEvents(incoming: [event(ray: "0")])
+        let spam = try isSpam(events: events)
+        #expect(spam == true)
+    }
+
+    @Test func nativeDustBelowSpamThresholdIsSpam() throws {
+        let events = TransferEvents(incoming: [event(sol: "0.000001")])
+        let spam = try isSpam(events: events)
+        #expect(spam == true)
+    }
+
+    @Test func nativeExactlyAtSpamThresholdIsNotSpam() throws {
+        let events = TransferEvents(incoming: [event(sol: "0.00001")])
+        let spam = try isSpam(events: events)
+        #expect(spam == false)
+    }
+
+    @Test func nativeBetweenSpamAndRiskLimitIsNotSpam() throws {
+        let events = TransferEvents(incoming: [event(sol: "0.00005")])
+        let spam = try isSpam(events: events)
+        #expect(spam == false)
+    }
+
+    @Test func nativeAboveDangerLimitIsNotSpam() throws {
+        let events = TransferEvents(incoming: [event(sol: "0.5")])
+        let spam = try isSpam(events: events)
+        #expect(spam == false)
+    }
+
+    @Test func suspiciousOnlyTokenAmountIsNotSpam() throws {
+        let events = TransferEvents(incoming: [event(usdc: "0.5")])
+        let spam = try isSpam(events: events)
+        #expect(spam == false)
+    }
+
+    @Test func emptyEventsAreNotSpam() throws {
+        let spam = try isSpam(events: TransferEvents())
+        #expect(spam == false)
+    }
+
+    // MARK: - Mixed Unknown
+
+    @Test func outgoingNativeDustLegIsInert() throws {
+        let events = TransferEvents(incoming: [event(usdc: "5")], outgoing: [event(sol: "-0.000001")])
+        let spam = try isSpam(events: events)
+        #expect(spam == false)
+    }
+
+    @Test func outgoingKnownSplDustLegIsSpam() throws {
+        let events = TransferEvents(incoming: [event(usdc: "5")], outgoing: [event(usdc: "-0.05")])
+        let spam = try isSpam(events: events)
+        #expect(spam == true)
+    }
+
+    @Test func outgoingKnownSplNormalLegIsNotSpam() throws {
+        let events = TransferEvents(incoming: [event(usdc: "5")], outgoing: [event(usdc: "-5")])
+        let spam = try isSpam(events: events)
+        #expect(spam == false)
+    }
+
+    @Test func outgoingRawLegIsSpam() throws {
+        let events = TransferEvents(incoming: [event(usdc: "5")], outgoing: [event(raw: 1)])
+        let spam = try isSpam(events: events)
+        #expect(spam == true)
+    }
+
+    @Test func outgoingZeroNativeLegIsSpam() throws {
+        let events = TransferEvents(incoming: [event(usdc: "5")], outgoing: [event(sol: "0")])
+        let spam = try isSpam(events: events)
+        #expect(spam == true)
+    }
+
+    @Test func nativeLegsScorePerEventNotAsSignedSum() throws {
+        let events = TransferEvents(incoming: [event(sol: "0.5")], outgoing: [event(sol: "-0.5")])
+        let spam = try isSpam(events: events)
+        #expect(spam == false)
+    }
+
+    // MARK: - Counterparty correlation (Android regression: watch address 3VHMK…LH7Q)
+
+    // 100 SOL arrived from realSender, seconds later 0.00001 SOL dust from a look-alike of that sender.
+    // Dust alone is +3 (at the spam threshold, strict <); prefix +4, suffix +4 and time +3 push it over.
+    @Test func dustMimicOfIncomingSenderIsSpam() throws {
+        let events = TransferEvents(incoming: [event(sol: "0.00001", from: Self.dustMimic)])
+        let spam = try isSpam(events: events, timestamp: 1000, counterparties: [(Self.realSender, 900)])
+        #expect(spam == true)
+    }
+
+    @Test func dustMimicWithoutContextIsNotSpam() throws {
+        let events = TransferEvents(incoming: [event(sol: "0.00001", from: Self.dustMimic)])
+        let spam = try isSpam(events: events, timestamp: 1000)
+        #expect(spam == false)
+    }
+
+    // A Solana counterparty carries no block height, so proximity is worth the time score (+3) only:
+    // dust +3 and time +3 stay below the threshold. A block bonus (+4) would wrongly make this spam.
+    @Test func timeCorrelationAloneStaysBelowThreshold() throws {
+        let events = TransferEvents(incoming: [event(sol: "0.00005", from: Self.dustMimic)])
+        let spam = try isSpam(events: events, timestamp: 1000, counterparties: [(Self.address, 900)])
+        #expect(spam == false)
+    }
+
+    // Correlation is gated to the gray zone: a normal amount scores 0 and exits before any look-alike check
+    @Test func normalAmountFromMimicIsNotSpam() throws {
+        let events = TransferEvents(incoming: [event(sol: "1", from: Self.dustMimic)])
+        let spam = try isSpam(events: events, timestamp: 1000, counterparties: [(Self.realSender, 900)])
+        #expect(spam == false)
+    }
+}
+
+// MARK: - Counterparty factory
+
+struct SpamCounterpartyFactoryTests {
+    private let factory = OutputTransactionFactory()
+
+    @Test func evmIncomingSenderIsCounterparty() {
+        let token = Self.token(blockchainType: .ethereum, code: "ETH")
+        let record = EvmIncomingTransactionRecord(
+            source: TransactionSource(blockchainType: .ethereum, meta: nil),
+            transaction: EvmKit.Transaction(hash: Data([0x01]), timestamp: 1000, isFailed: false, blockNumber: 777),
+            baseToken: token,
+            from: "0xsender",
+            value: AppValue(token: token, value: 1)
+        )
+
+        let cached = factory.cachedOutputs(from: record)
+
+        #expect(cached.map(\.address) == ["0xsender"])
+        #expect(cached.first?.timestamp == 1000)
+        #expect(cached.first?.blockHeight == 777)
+    }
+
+    @Test func evmOutgoingRecipientStillWins() {
+        let token = Self.token(blockchainType: .ethereum, code: "ETH")
+        let record = EvmOutgoingTransactionRecord(
+            source: TransactionSource(blockchainType: .ethereum, meta: nil),
+            transaction: EvmKit.Transaction(hash: Data([0x02]), timestamp: 1000, isFailed: false),
+            baseToken: token,
+            to: "0xrecipient",
+            value: AppValue(token: token, value: 1),
+            sentToSelf: false,
+            protected: false
+        )
+
+        #expect(factory.cachedOutputs(from: record).map(\.address) == ["0xrecipient"])
+    }
+
+    @Test func tronIncomingSenderIsCounterparty() {
+        let token = Self.token(blockchainType: .tron, code: "TRX")
+        let record = TronIncomingTransactionRecord(
+            source: TransactionSource(blockchainType: .tron, meta: nil),
+            transaction: TronKit.Transaction(hash: Data([0x03]), timestamp: 1000, isFailed: false, blockNumber: 55, confirmed: true),
+            baseToken: token,
+            from: "Tsender",
+            value: AppValue(token: token, value: 1)
+        )
+
+        #expect(factory.cachedOutputs(from: record).map(\.address) == ["Tsender"])
+    }
+
+    // Records that only carry a placeholder height (Solana stores 0 once confirmed) must not feed block correlation
+    @Test func placeholderBlockHeightIsDropped() {
+        let token = Self.token(blockchainType: .ethereum, code: "ETH")
+        let record = EvmIncomingTransactionRecord(
+            source: TransactionSource(blockchainType: .ethereum, meta: nil),
+            transaction: EvmKit.Transaction(hash: Data([0x04]), timestamp: 1000, isFailed: false, blockNumber: 0),
+            baseToken: token,
+            from: "0xsender",
+            value: AppValue(token: token, value: 1)
+        )
+
+        #expect(factory.cachedOutputs(from: record).first?.blockHeight == nil)
+    }
+
+    private static func token(blockchainType: BlockchainType, code: String) -> Token {
+        Token(
+            coin: Coin(uid: code.lowercased(), name: code, code: code),
+            blockchain: Blockchain(type: blockchainType, name: code, explorerUrl: nil),
+            type: .native,
+            decimals: 18
+        )
+    }
+}
+
+extension SolanaSpamPolicyTests {
+    private static let address = "5n7Qw3XkXm1WybwHHM2SGwiZTLc2yLYhcaAtGYRDR1Vp"
+    private static let realSender = "6pRr7fQbrfpYUXZERLmxoKCaqXrz3ix6LQJGHVxSibvF"
+    private static let dustMimic = "6pRrcG2PQrFfUL4dmGQFfFoD6bUnBNFGQ6AyQS2wibvF"
+    private static let accountId = "spam-policy-tests"
+
+    private static let solToken = Token(
+        coin: Coin(uid: "solana", name: "Solana", code: "SOL"),
+        blockchain: Blockchain(type: .solana, name: "Solana", explorerUrl: nil),
+        type: .native,
+        decimals: 9
+    )
+
+    private static let usdcToken = Token(
+        coin: Coin(uid: "usd-coin", name: "USD Coin", code: "USDC"),
+        blockchain: Blockchain(type: .solana, name: "Solana", explorerUrl: nil),
+        type: .spl(address: "usdc-mint"),
+        decimals: 6
+    )
+
+    private static let rayToken = Token(
+        coin: Coin(uid: "raydium", name: "Raydium", code: "RAY"),
+        blockchain: Blockchain(type: .solana, name: "Solana", explorerUrl: nil),
+        type: .spl(address: "ray-mint"),
+        decimals: 6
+    )
+
+    private func event(sol amount: String, from: String = SolanaSpamPolicyTests.address) -> TransferEvent {
+        TransferEvent(address: from, value: AppValue(token: Self.solToken, value: Decimal(string: amount)!))
+    }
+
+    private func event(usdc amount: String) -> TransferEvent {
+        TransferEvent(address: Self.address, value: AppValue(token: Self.usdcToken, value: Decimal(string: amount)!))
+    }
+
+    private func event(ray amount: String) -> TransferEvent {
+        TransferEvent(address: Self.address, value: AppValue(token: Self.rayToken, value: Decimal(string: amount)!))
+    }
+
+    private func event(raw amount: Decimal) -> TransferEvent {
+        TransferEvent(address: Self.address, value: AppValue(value: amount))
+    }
+
+    // Seeds the persisted counterparty context the way SpamManager builds it from earlier records
+    private func makeCache(counterparties: [(address: String, timestamp: Int)]) throws -> OutputTransactionCache {
+        let path = FileManager.default.temporaryDirectory.appendingPathComponent("spam-policy-tests-\(UUID().uuidString).sqlite").path
+        let storage = try ScannedTransactionStorage(dbPool: DatabasePool(path: path))
+
+        try storage.save(outgoingAddresses: counterparties.map {
+            OutgoingAddress(address: $0.address, blockchainTypeUid: BlockchainType.solana.uid, accountUid: Self.accountId, timestamp: $0.timestamp, blockHeight: nil)
+        })
+
+        let cache = OutputTransactionCache(storage: storage)
+        cache.loadCache(for: .solana, accountId: Self.accountId)
+        return cache
+    }
+
+    private func isSpam(events: TransferEvents, timestamp: Int = 0, counterparties: [(address: String, timestamp: Int)] = []) throws -> Bool {
+        // blockHeight 0 mirrors a confirmed Solana record
+        let info = SpamTransactionInfo(hash: "hash", blockchainType: .solana, timestamp: timestamp, blockHeight: 0, events: events)
+
+        let filterChain = SpamFilterChain().append(OutgoingPoisoningFilter())
+        if let result = filterChain.evaluate(info) {
+            switch result {
+            case .spam: return true
+            case .trusted: return false
+            case .ignore: break
+            }
+        }
+
+        let cache = try makeCache(counterparties: counterparties)
+        let evaluator = SpamScoreEvaluator().append(GrayZoneGateCondition(
+            value: SolanaLowAmountCondition(),
+            correlation: [AddressSimilarityCondition(cache: cache), TimeCorrelationCondition(cache: cache)]
+        ))
+
+        switch evaluator.evaluate(SpamEvaluationContext(transaction: info)) {
+        case .spam: return true
+        case .suspicious, .trusted: return false
+        }
+    }
+}

--- a/Unstoppable/Tests/SpamCorrelationTests.swift
+++ b/Unstoppable/Tests/SpamCorrelationTests.swift
@@ -1,0 +1,187 @@
+import EvmKit
+import Foundation
+import GRDB
+import MarketKit
+import Testing
+@testable import WalletCore
+
+// Android-parity fixtures for the shared correlation machinery:
+// prefix/suffix length, inclusive thresholds, any-entry proximity, a window of distinct counterparties.
+struct SpamCorrelationTests {
+    // MARK: - Address similarity
+
+    // EVM/Tron/Stellar are ungated, so they keep the 4-character match; Solana (gated) uses Android's 3
+    @Test func matchLengthIsFourByDefaultAndThreeForSolana() throws {
+        let cache = try makeCache(rows: [("0xabc000000000000000000000000000000000fed", 0, nil)])
+        let context = context(from: "0xabc111111111111111111111111111111111fed", timestamp: 0)
+
+        #expect(AddressSimilarityCondition(cache: cache).evaluate(context) == 0)
+        #expect(AddressSimilarityCondition(cache: cache, minMatchLength: 3).evaluate(context) == 8)
+    }
+
+    @Test func tronLeadingTIsStripped() throws {
+        let cached = "TABC" + String(repeating: "x", count: 29) + "1"
+        let incoming = "TABC" + String(repeating: "y", count: 29) + "2"
+        let cache = try makeCache(blockchainType: .tron, rows: [(cached, 0, nil)])
+        let context = context(blockchainType: .tron, from: incoming, timestamp: 0)
+
+        // without stripping, "TABC" == "TABC" would score the prefix
+        #expect(AddressSimilarityCondition(cache: cache).evaluate(context) == 0)
+    }
+
+    // MARK: - Time / block correlation
+
+    @Test func timeThresholdIsInclusive() throws {
+        let cache = try makeCache(rows: [(Self.counterparty, 0, nil)])
+
+        #expect(TimeCorrelationCondition(cache: cache).evaluate(context(timestamp: 1200)) == 3)
+        #expect(TimeCorrelationCondition(cache: cache).evaluate(context(timestamp: 1201)) == 0)
+    }
+
+    @Test func blockThresholdIsInclusiveAndPreferred() throws {
+        let cache = try makeCache(rows: [(Self.counterparty, 0, 100)])
+
+        #expect(TimeCorrelationCondition(cache: cache).evaluate(context(timestamp: 999_999, blockHeight: 105)) == 4)
+        #expect(TimeCorrelationCondition(cache: cache).evaluate(context(timestamp: 999_999, blockHeight: 106)) == 0)
+    }
+
+    // The most recent entry is far away; an older one in the window is close enough
+    @Test func anyEntryInWindowCorrelates() throws {
+        let cache = try makeCache(rows: [("0xfar", 5000, nil), ("0xnear", 900, nil)])
+
+        #expect(TimeCorrelationCondition(cache: cache).evaluate(context(timestamp: 1000)) == 3)
+    }
+
+    // MARK: - Window
+
+    @Test func windowKeepsTenMostRecentDistinctAddresses() throws {
+        let rows = (0 ..< 15).map { ("0xcounterparty$0", $0 * 10, Int?.none) }
+        let cache = try makeCache(rows: rows)
+
+        let window = cache.get(blockchainType: .ethereum)
+        #expect(window.count == 10)
+        #expect(window.first?.timestamp == 140)
+    }
+
+    // A repeated counterparty moves to the front instead of taking a second slot
+    @Test func addDedupsRepeatedAddress() throws {
+        let cache = try makeCache(rows: [])
+        let token = Self.ethToken
+
+        for hash: UInt8 in [1, 2] {
+            let record = EvmIncomingTransactionRecord(
+                source: TransactionSource(blockchainType: .ethereum, meta: nil),
+                transaction: EvmKit.Transaction(hash: Data([hash]), timestamp: Int(hash), isFailed: false),
+                baseToken: token,
+                from: Self.counterparty,
+                value: AppValue(token: token, value: 1)
+            )
+            cache.add(record: record, accountId: Self.accountId)
+        }
+
+        let window = cache.get(blockchainType: .ethereum)
+        #expect(window.count == 1)
+        #expect(window.first?.timestamp == 2)
+    }
+
+    // MARK: - Own send vs scored record
+
+    @Test func externalContractCallIsScoredNotTrusted() {
+        let token = Self.ethToken
+        let record = ExternalContractCallTransactionRecord(
+            source: TransactionSource(blockchainType: .ethereum, meta: nil),
+            transaction: EvmKit.Transaction(hash: Data([0x05]), timestamp: 1, isFailed: false),
+            baseToken: token,
+            incomingEvents: [TransferEvent(address: "0xsender", value: AppValue(token: token, value: 1))],
+            outgoingEvents: [TransferEvent(address: "0xrecipient", value: AppValue(token: token, value: 1))],
+            protected: false
+        )
+
+        #expect(OutputTransactionFactory.outgoingAddresses(from: record) == nil)
+        #expect(OutputTransactionFactory.counterpartyAddresses(from: record) == ["0xrecipient"])
+    }
+
+    @Test func ownContractCallWithoutSentLegIsTrustedAndCachesSender() {
+        let token = Self.ethToken
+        let record = ContractCallTransactionRecord(
+            source: TransactionSource(blockchainType: .ethereum, meta: nil),
+            transaction: EvmKit.Transaction(hash: Data([0x06]), timestamp: 1, isFailed: false),
+            baseToken: token,
+            contractAddress: "0xcontract",
+            method: nil,
+            incomingEvents: [TransferEvent(address: "0xpool", value: AppValue(token: token, value: 1))],
+            outgoingEvents: [],
+            protected: false
+        )
+
+        #expect(OutputTransactionFactory.outgoingAddresses(from: record) == [])
+        #expect(OutputTransactionFactory().cachedOutputs(from: record).map(\.address) == ["0xpool"])
+    }
+}
+
+extension SpamCorrelationTests {
+    private static let counterparty = "0x1111111111111111111111111111111111111111"
+    private static let accountId = "spam-correlation-tests"
+
+    private static let ethToken = Token(
+        coin: Coin(uid: "ethereum", name: "Ethereum", code: "ETH"),
+        blockchain: Blockchain(type: .ethereum, name: "Ethereum", explorerUrl: nil),
+        type: .native,
+        decimals: 18
+    )
+
+    private func makeCache(blockchainType: BlockchainType = .ethereum, rows: [(address: String, timestamp: Int, blockHeight: Int?)]) throws -> OutputTransactionCache {
+        let path = FileManager.default.temporaryDirectory.appendingPathComponent("spam-correlation-tests-\(UUID().uuidString).sqlite").path
+        let storage = try ScannedTransactionStorage(dbPool: DatabasePool(path: path))
+
+        try storage.save(outgoingAddresses: rows.map {
+            OutgoingAddress(address: $0.address, blockchainTypeUid: blockchainType.uid, accountUid: Self.accountId, timestamp: $0.timestamp, blockHeight: $0.blockHeight)
+        })
+
+        let cache = OutputTransactionCache(storage: storage)
+        cache.loadCache(for: blockchainType, accountId: Self.accountId)
+        return cache
+    }
+
+    private func context(blockchainType: BlockchainType = .ethereum, from: String = "0x9999999999999999999999999999999999999999", timestamp: Int, blockHeight: Int? = nil) -> SpamEvaluationContext {
+        let info = SpamTransactionInfo(
+            hash: "hash",
+            blockchainType: blockchainType,
+            timestamp: timestamp,
+            blockHeight: blockHeight,
+            events: TransferEvents(incoming: [TransferEvent(address: from, value: AppValue(token: Self.ethToken, value: 1))])
+        )
+        return SpamEvaluationContext(transaction: info)
+    }
+}
+
+// MARK: - Shared value scoring over both legs (External records are now scored)
+
+struct SpamSharedValueScoringTests {
+    private static let usdt = Token(
+        coin: Coin(uid: "tether", name: "Tether", code: "USDT"),
+        blockchain: Blockchain(type: .ethereum, name: "Ethereum", explorerUrl: nil),
+        type: .eip20(address: "0xusdt"),
+        decimals: 6
+    )
+
+    // Outgoing legs are stored negative; Android scores dust only for positive values
+    @Test func negativeOutgoingLegNeverScoresAsDust() {
+        let events = TransferEvents(
+            incoming: [TransferEvent(address: "0xsender", value: AppValue(token: Self.usdt, value: 5))],
+            outgoing: [TransferEvent(address: "0xrecipient", value: AppValue(token: Self.usdt, value: -0.05))]
+        )
+
+        #expect(LowAmountCondition().evaluate(context(events: events)) == 0)
+    }
+
+    @Test func positiveIncomingDustStillScores() {
+        let events = TransferEvents(incoming: [TransferEvent(address: "0xsender", value: AppValue(token: Self.usdt, value: 0.05))])
+
+        #expect(LowAmountCondition().evaluate(context(events: events)) == 7)
+    }
+
+    private func context(events: TransferEvents) -> SpamEvaluationContext {
+        SpamEvaluationContext(transaction: SpamTransactionInfo(hash: "hash", blockchainType: .ethereum, timestamp: 0, blockHeight: nil, events: events))
+    }
+}

--- a/Unstoppable/Tests/ZcashMigrationTests.swift
+++ b/Unstoppable/Tests/ZcashMigrationTests.swift
@@ -125,8 +125,7 @@ struct ZcashMigrationTests {
 
     @Test func ironwoodActivationBoundary() throws {
         let (migrator, _) = try makeMigrator(networkType: .mainnet)
-        let network = ZcashNetworkBuilder.network(for: .mainnet)
-        let activation = try #require(network.ironwoodActivationHeight)
+        let activation = 3_428_143 // NU6.3 mainnet activation, ZIP 258
 
         #expect(!migrator.ironwoodActive(latestHeight: activation - 1))
         #expect(migrator.ironwoodActive(latestHeight: activation))

--- a/packages/WalletCore/Sources/WalletCore/Core/Adapters/SolanaTransactionsAdapter.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Adapters/SolanaTransactionsAdapter.swift
@@ -7,6 +7,7 @@ import SolanaKit
 class SolanaTransactionsAdapter {
     private let solanaKit: SolanaKit.Kit
     private let converter: SolanaTransactionConverter
+    private let spamManager: SpamManager?
     private var cancellables = Set<AnyCancellable>()
 
     private let adapterStateSubject = PublishSubject<AdapterState>()
@@ -16,8 +17,9 @@ class SolanaTransactionsAdapter {
         }
     }
 
-    init(solanaKit: SolanaKit.Kit, source: TransactionSource, baseToken: Token, coinManager: CoinManager) {
+    init(solanaKit: SolanaKit.Kit, source: TransactionSource, baseToken: Token, coinManager: CoinManager, spamWrapper: SpamWrapper) {
         self.solanaKit = solanaKit
+        spamManager = spamWrapper.spamManager(source: source)
         converter = SolanaTransactionConverter(
             userAddress: solanaKit.address,
             source: source,
@@ -30,6 +32,20 @@ class SolanaTransactionsAdapter {
         solanaKit.transactionsSyncStatePublisher
             .sink { [weak self] in self?.adapterState = Self.adapterState(kitSyncState: $0) }
             .store(in: &cancellables)
+
+        spamManager?.initialize(adapter: self)
+    }
+
+    private func handleTransactions(_ transactions: [FullTransaction]) -> [TransactionRecord] {
+        // Preserve solanaKit order
+        let records = transactions.map { converter.transactionRecord(fullTransaction: $0) }
+
+        // Mutates .spam in-place via reference type.
+        // Internally sorts ascending for correct detection,
+        // but records array keeps its original order.
+        spamManager?.update(records: records)
+
+        return records
     }
 
     private func incomingFilter(filter: TransactionTypeFilter) -> Bool? {
@@ -109,9 +125,7 @@ extension SolanaTransactionsAdapter: ITransactionsAdapter {
         }
 
         return publisher
-            .map { [converter] transactions in
-                transactions.map { converter.transactionRecord(fullTransaction: $0) }
-            }
+            .map { [weak self] in self?.handleTransactions($0) ?? [] }
             .asObservable()
     }
 
@@ -129,7 +143,7 @@ extension SolanaTransactionsAdapter: ITransactionsAdapter {
         let fromHash = paginationData
         let incoming = incomingFilter(filter: filter)
 
-        return Single.create { [solanaKit, converter] observer in
+        return Single.create { [weak self, solanaKit] observer in
             Task {
                 let transactions: [FullTransaction]
 
@@ -146,8 +160,7 @@ extension SolanaTransactionsAdapter: ITransactionsAdapter {
                     transactions = solanaKit.transactions(incoming: incoming, fromHash: fromHash, limit: limit)
                 }
 
-                let records = transactions.map { converter.transactionRecord(fullTransaction: $0) }
-                observer(.success(records))
+                observer(.success(self?.handleTransactions(transactions) ?? []))
             }
 
             return Disposables.create()

--- a/packages/WalletCore/Sources/WalletCore/Core/Factories/AdapterFactory.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Factories/AdapterFactory.swift
@@ -245,7 +245,7 @@ extension AdapterFactory {
         let query = TokenQuery(blockchainType: .solana, tokenType: .native)
 
         if let solanaKit = solanaKitManager.solanaKit, let baseToken = try? coinManager.token(query: query) {
-            return SolanaTransactionsAdapter(solanaKit: solanaKit, source: transactionSource, baseToken: baseToken, coinManager: coinManager)
+            return SolanaTransactionsAdapter(solanaKit: solanaKit, source: transactionSource, baseToken: baseToken, coinManager: coinManager, spamWrapper: spamWrapper)
         }
 
         return nil

--- a/packages/WalletCore/Sources/WalletCore/Core/Managers/SolanaKitManager.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Managers/SolanaKitManager.swift
@@ -51,12 +51,7 @@ public class SolanaKitManager {
             return _solanaKit
         }
 
-        guard let seed = account.type.mnemonicSeed else {
-            throw AdapterError.unsupportedAccount
-        }
-
-        let address = try SolanaKit.Signer.address(seed: seed)
-        let addressString = address.base58
+        let addressString = try Self.address(accountType: account.type)
 
         let kit = try SolanaKit.Kit.instance(
             address: addressString,
@@ -145,10 +140,17 @@ extension SolanaKitManager {
 
 extension SolanaKitManager {
     static func address(accountType: AccountType) throws -> String {
-        guard let seed = accountType.mnemonicSeed else {
+        switch accountType {
+        case .mnemonic:
+            guard let seed = accountType.mnemonicSeed else {
+                throw AdapterError.unsupportedAccount
+            }
+            return try SolanaKit.Signer.address(seed: seed).base58
+        case let .solanaAddress(address):
+            return address
+        default:
             throw AdapterError.unsupportedAccount
         }
-        return try SolanaKit.Signer.address(seed: seed).base58
     }
 
     static func signer(accountType: AccountType) throws -> SolanaKit.Signer {

--- a/packages/WalletCore/Sources/WalletCore/Core/Managers/Spam/SpamEvaluation/Conditions/AddressSimilarityCondition.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Managers/Spam/SpamEvaluation/Conditions/AddressSimilarityCondition.swift
@@ -38,28 +38,11 @@ final class AddressSimilarityCondition: SpamCondition {
 
         let incomingAddresses = context.transaction.events.incoming.map { normalize($0.address) }
 
-        let (score, matchedOutput) = bestMatch(
-            incomingAddresses: incomingAddresses,
-            cachedOutputs: cachedOutputs
-        )
-
-        if let matched = matchedOutput ?? cachedOutputs.first {
-            context.set(SpamContextKeys.matchedAddress, value: matched.address)
-            context.set(SpamContextKeys.matchedTimestamp, value: Int(matched.timestamp))
-            if let blockHeight = matched.blockHeight {
-                context.set(SpamContextKeys.matchedBlockHeight, value: blockHeight)
-            }
-        }
-
-        return score
+        return bestMatch(incomingAddresses: incomingAddresses, cachedOutputs: cachedOutputs)
     }
 
-    private func bestMatch(
-        incomingAddresses: [String],
-        cachedOutputs: [CachedOutputTransaction]
-    ) -> (Int, CachedOutputTransaction?) {
+    private func bestMatch(incomingAddresses: [String], cachedOutputs: [CachedOutputTransaction]) -> Int {
         var bestScore = 0
-        var matchedOutput: CachedOutputTransaction?
         let maxScore = prefixScore + suffixScore
 
         for incomingAddress in incomingAddresses {
@@ -83,20 +66,23 @@ final class AddressSimilarityCondition: SpamCondition {
 
                 if score > bestScore {
                     bestScore = score
-                    matchedOutput = cached
 
                     if bestScore >= maxScore {
-                        return (bestScore, matchedOutput)
+                        return bestScore
                     }
                 }
             }
         }
 
-        return (bestScore, matchedOutput)
+        return bestScore
     }
 
+    // "T" opens every 34-char Tron address and carries no more information than "0x"
     private func normalize(_ address: String) -> String {
-        address.stripping(prefix: "0x").lowercased()
+        if address.count == 34, address.hasPrefix("T") {
+            return address.dropFirst().lowercased()
+        }
+        return address.stripping(prefix: "0x").lowercased()
     }
 
     private func hasSimilarPrefix(_ address1: String, _ address2: String) -> Bool {

--- a/packages/WalletCore/Sources/WalletCore/Core/Managers/Spam/SpamEvaluation/Conditions/GrayZoneGateCondition.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Managers/Spam/SpamEvaluation/Conditions/GrayZoneGateCondition.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+// Android's two-pass scoring: the value score alone decides when it is conclusive
+// (0 → trusted, ≥ spam → spam); correlation runs only for the gray zone in between
+final class GrayZoneGateCondition: SpamCondition {
+    var identifier: String { "gray_zone_gate" }
+
+    private let value: SpamCondition
+    private let correlation: [SpamCondition]
+    private let spamThreshold: Int
+
+    init(value: SpamCondition, correlation: [SpamCondition], spamThreshold: Int = 7) {
+        self.value = value
+        self.correlation = correlation
+        self.spamThreshold = spamThreshold
+    }
+
+    func evaluate(_ context: SpamEvaluationContext) -> Int {
+        let valueScore = value.evaluate(context)
+
+        guard valueScore > 0, valueScore < spamThreshold else {
+            return valueScore
+        }
+
+        return correlation.reduce(valueScore) { $0 + $1.evaluate(context) }
+    }
+}

--- a/packages/WalletCore/Sources/WalletCore/Core/Managers/Spam/SpamEvaluation/Conditions/LowAmountCondition.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Managers/Spam/SpamEvaluation/Conditions/LowAmountCondition.swift
@@ -36,7 +36,8 @@ class LowAmountCondition: SpamCondition {
             }
         }
 
-        if let nativeCode {
+        // Outgoing legs are stored negative and never score as dust, as on Android
+        if let nativeCode, nativeTotal > 0 {
             let score = evaluateWithLimits(code: nativeCode, value: nativeTotal)
             if score >= spamScore {
                 return spamScore
@@ -54,6 +55,9 @@ class LowAmountCondition: SpamCondition {
         case .raw, .eip20Token:
             return spamScore
         default:
+            guard event.value.value > 0 else {
+                return 0
+            }
             return evaluateWithLimits(code: event.value.code, value: event.value.value)
         }
     }
@@ -87,8 +91,9 @@ extension LowAmountCondition {
         "BSC-USD": .init(1),
         "TRX": .init(1),
         "ETH": .init(0.0005),
-        "BNB": .init(0.002),
+        "BNB": .init(0.0002),
         "POL": .init(1),
+        "SOL": .init(0.0001),
     ]
 
     struct AmountLimit {

--- a/packages/WalletCore/Sources/WalletCore/Core/Managers/Spam/SpamEvaluation/Conditions/SolanaLowAmountCondition.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Managers/Spam/SpamEvaluation/Conditions/SolanaLowAmountCondition.swift
@@ -1,0 +1,73 @@
+import Foundation
+import HsToolKit
+
+// Mirrors Android's Solana value scoring: per-event maximum, never a signed native aggregate.
+// Zero-value coin transfers are instant spam; token legs score by absolute value, while
+// negative (outgoing) native legs never score — matching the Android converter's data shape.
+class SolanaLowAmountCondition: SpamCondition {
+    var identifier: String { "solana_low_amount" }
+
+    private let spamScore: Int
+    private let riskScore: Int
+    private let dangerScore: Int
+    private let logger: Logger?
+
+    init(spamScore: Int = 7, riskScore: Int = 3, dangerScore: Int = 2, logger: Logger? = nil) {
+        self.spamScore = spamScore
+        self.riskScore = riskScore
+        self.dangerScore = dangerScore
+        self.logger = logger
+    }
+
+    func evaluate(_ context: SpamEvaluationContext) -> Int {
+        var maxScore = 0
+
+        let allEvents = context.transaction.events.incoming + context.transaction.events.outgoing
+
+        for event in allEvents {
+            let score = evaluateEvent(event)
+            if score >= spamScore {
+                return spamScore
+            }
+            maxScore = max(maxScore, score)
+        }
+
+        return maxScore
+    }
+
+    private func evaluateEvent(_ event: TransferEvent) -> Int {
+        switch event.value.kind {
+        case .nft:
+            return event.value.value > 0 ? 0 : riskScore
+        case .raw, .eip20Token:
+            return spamScore
+        default:
+            if event.value.value == 0 {
+                return spamScore
+            }
+            if event.value.kind.token?.type.isNative ?? false {
+                guard event.value.value > 0 else {
+                    return 0
+                }
+                return evaluateWithLimits(code: event.value.code, value: event.value.value)
+            }
+            return evaluateWithLimits(code: event.value.code, value: abs(event.value.value))
+        }
+    }
+
+    private func evaluateWithLimits(code: String, value: Decimal) -> Int {
+        guard let limit = LowAmountCondition.defaultLimits[code] else {
+            return 0
+        }
+
+        if value < limit.spam {
+            return spamScore
+        } else if value < limit.risk {
+            return riskScore
+        } else if value < limit.danger {
+            return dangerScore
+        }
+
+        return 0
+    }
+}

--- a/packages/WalletCore/Sources/WalletCore/Core/Managers/Spam/SpamEvaluation/Conditions/SpamEvaluationContext.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Managers/Spam/SpamEvaluation/Conditions/SpamEvaluationContext.swift
@@ -22,9 +22,3 @@ class SpamEvaluationContext {
         storage[key] != nil
     }
 }
-
-enum SpamContextKeys {
-    static let matchedAddress = "matched_address"
-    static let matchedTimestamp = "matched_timestamp"
-    static let matchedBlockHeight = "matched_block_height"
-}

--- a/packages/WalletCore/Sources/WalletCore/Core/Managers/Spam/SpamEvaluation/Conditions/TimeCorrelationCondition.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Managers/Spam/SpamEvaluation/Conditions/TimeCorrelationCondition.swift
@@ -1,9 +1,12 @@
 import Foundation
 import HsToolKit
 
+// Proximity to any counterparty in the window, most recent first; block distance is checked
+// before time for each entry, and the first entry within either threshold decides
 class TimeCorrelationCondition: SpamCondition {
     var identifier: String { "time_correlation" }
 
+    private let cache: OutputTransactionCache
     private let blockThreshold: Int
     private let timeThresholdMinutes: Int
     private let blockScore: Int
@@ -11,12 +14,14 @@ class TimeCorrelationCondition: SpamCondition {
     private let logger: Logger?
 
     init(
+        cache: OutputTransactionCache,
         blockThreshold: Int = 5,
         timeThresholdMinutes: Int = 20,
         blockScore: Int = 4,
         timeScore: Int = 3,
         logger: Logger? = nil
     ) {
+        self.cache = cache
         self.blockThreshold = blockThreshold
         self.timeThresholdMinutes = timeThresholdMinutes
         self.blockScore = blockScore
@@ -25,28 +30,21 @@ class TimeCorrelationCondition: SpamCondition {
     }
 
     func evaluate(_ context: SpamEvaluationContext) -> Int {
-        let matchedTimestamp: Int? = context.get(SpamContextKeys.matchedTimestamp)
-        let matchedBlockHeight: Int? = context.get(SpamContextKeys.matchedBlockHeight)
+        let transaction = context.transaction
+        let thresholdSeconds = timeThresholdMinutes * 60
 
-        guard matchedTimestamp != nil || matchedBlockHeight != nil else {
+        guard !transaction.events.incoming.isEmpty else {
             return 0
         }
 
-        // Check block correlation first (more precise)
-        if let matchedBlock = matchedBlockHeight,
-           let txBlock = context.transaction.blockHeight
-        {
-            let blockDiff = abs(txBlock - matchedBlock)
-            if blockDiff < blockThreshold {
+        for cached in cache.get(blockchainType: transaction.blockchainType) {
+            if let cachedBlock = cached.blockHeight, let txBlock = transaction.blockHeight,
+               abs(txBlock - cachedBlock) <= blockThreshold
+            {
                 return blockScore
             }
-        }
 
-        // Fall back to time correlation
-        if let matchedTime = matchedTimestamp {
-            let timeDiff = abs(context.transaction.timestamp - matchedTime)
-            let thresholdSeconds = timeThresholdMinutes * 60
-            if timeDiff < thresholdSeconds {
+            if abs(transaction.timestamp - cached.timestamp) <= thresholdSeconds {
                 return timeScore
             }
         }

--- a/packages/WalletCore/Sources/WalletCore/Core/Managers/Spam/SpamEvaluation/OutputTransactionCache.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Managers/Spam/SpamEvaluation/OutputTransactionCache.swift
@@ -27,7 +27,7 @@ final class OutputTransactionCache {
 
     // MARK: - Read
 
-    /// Returns cached outgoing addresses for blockchain.
+    /// Returns cached counterparty addresses (recipients of sends, senders of receives) for blockchain.
     /// Must be called after loadCache().
     func get(blockchainType: BlockchainType) -> [CachedOutputTransaction] {
         cache[blockchainType] ?? []
@@ -60,7 +60,7 @@ final class OutputTransactionCache {
 
     // MARK: - Write
 
-    /// Saves outgoing record to DB and updates in-memory cache.
+    /// Saves the record's counterparties to DB and updates in-memory cache.
     func add(record: TransactionRecord, accountId: String) {
         let blockchainType = record.source.blockchainType
         let outputs = factory.cachedOutputs(from: record)

--- a/packages/WalletCore/Sources/WalletCore/Core/Managers/Spam/SpamEvaluation/OutputTransactionFactory.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Managers/Spam/SpamEvaluation/OutputTransactionFactory.swift
@@ -2,9 +2,10 @@ import Foundation
 import MarketKit
 
 class OutputTransactionFactory {
-    /// Returns outgoing addresses from record.
-    /// - Returns: nil if record is not outgoing;
-    ///            empty array if outgoing but no extractable addresses (Bitcoin/Monero UTXO);
+    /// Returns addresses the user sent to, for records the user initiated.
+    /// Such records are trusted without scoring.
+    /// - Returns: nil if the record is not the user's own send;
+    ///            empty array if it is but has no extractable addresses;
     ///            non-empty array with destination addresses
     static func outgoingAddresses(from record: TransactionRecord) -> [String]? {
         switch record {
@@ -16,32 +17,78 @@ class OutputTransactionFactory {
 
         case let r as StellarTransactionRecord:
             let recipients = ([r.type] + r.additionalActions).compactMap { action -> String? in
-                if case let .sendPayment(_, to, _) = action {
-                    return to
+                switch action {
+                case let .sendPayment(_, to, _): return to
+                case let .accountFunded(_, account): return account
+                default: return nil
                 }
-                return nil
             }
             return recipients.isEmpty ? nil : recipients
 
-        case let r as ExternalContractCallTransactionRecord:
-            let addresses = filterZeroPoisoningEvents(r.outgoingEvents).map(\.address)
-            return addresses.isEmpty ? nil : addresses
-
-        case let r as TronExternalContractCallTransactionRecord:
-            let addresses = filterZeroPoisoningEvents(r.outgoingEvents).map(\.address)
-            return addresses.isEmpty ? nil : addresses
+        case let r as SolanaOutgoingTransactionRecord:
+            guard !r.sentToSelf, let to = r.to else {
+                return nil
+            }
+            return [to]
 
         case let r as ContractCallTransactionRecord:
-            let addresses = r.outgoingEvents.map(\.address)
-            return addresses.isEmpty ? nil : addresses
+            return r.outgoingEvents.map(\.address)
 
         case let r as TronContractCallTransactionRecord:
-            let addresses = r.outgoingEvents.map(\.address)
-            return addresses.isEmpty ? nil : addresses
+            return r.outgoingEvents.map(\.address)
 
         default:
             return nil
         }
+    }
+
+    // Counterparties of every other record: the recipient of a sent leg, otherwise the sender
+    // of a received one. Poisoning routinely mimics whoever just paid the user, and a watch-only
+    // wallet has no outgoing history at all, so senders are correlation context too.
+    static func counterpartyAddresses(from record: TransactionRecord) -> [String] {
+        switch record {
+        case let r as EvmIncomingTransactionRecord:
+            return [r.from]
+
+        case let r as TronIncomingTransactionRecord:
+            return [r.from]
+
+        case let r as StellarTransactionRecord:
+            return ([r.type] + r.additionalActions).compactMap { action -> String? in
+                switch action {
+                case let .receivePayment(_, from): return from
+                case let .accountCreated(_, funder): return funder
+                default: return nil
+                }
+            }
+
+        case let r as SolanaIncomingTransactionRecord:
+            return r.from.map { [$0] } ?? []
+
+        case let r as SolanaUnknownTransactionRecord:
+            let incoming = r.incomingTransfers.compactMap(\.address)
+            return incoming.isEmpty ? r.outgoingTransfers.compactMap(\.address) : incoming
+
+        case let r as ExternalContractCallTransactionRecord:
+            return sentElseReceived(outgoing: filterZeroPoisoningEvents(r.outgoingEvents), incoming: r.incomingEvents)
+
+        case let r as TronExternalContractCallTransactionRecord:
+            return sentElseReceived(outgoing: filterZeroPoisoningEvents(r.outgoingEvents), incoming: r.incomingEvents)
+
+        case let r as ContractCallTransactionRecord:
+            return r.incomingEvents.map(\.address)
+
+        case let r as TronContractCallTransactionRecord:
+            return r.incomingEvents.map(\.address)
+
+        default:
+            return []
+        }
+    }
+
+    private static func sentElseReceived(outgoing: [TransferEvent], incoming: [TransferEvent]) -> [String] {
+        let sent = outgoing.map(\.address)
+        return sent.isEmpty ? incoming.map(\.address) : sent
     }
 
     private static func filterZeroPoisoningEvents(_ events: [TransferEvent]) -> [TransferEvent] {
@@ -57,12 +104,13 @@ class OutputTransactionFactory {
 
     /// Creates CachedOutputTransaction entries from a TransactionRecord
     func cachedOutputs(from record: TransactionRecord) -> [CachedOutputTransaction] {
-        guard let addresses = Self.outgoingAddresses(from: record) else {
-            return []
-        }
+        let outgoing = Self.outgoingAddresses(from: record) ?? []
+        let addresses = outgoing.isEmpty ? Self.counterpartyAddresses(from: record) : outgoing
 
         let timestamp = Int(record.date.timeIntervalSince1970)
-        let blockHeight = record.blockHeight
+        // Solana records carry 0 as a confirmed placeholder (the kit stores no slot);
+        // only a real height may feed block correlation
+        let blockHeight = record.blockHeight.flatMap { $0 > 0 ? $0 : nil }
 
         return addresses.map {
             CachedOutputTransaction(address: $0, timestamp: timestamp, blockHeight: blockHeight)

--- a/packages/WalletCore/Sources/WalletCore/Core/Managers/Spam/SpamManager.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Managers/Spam/SpamManager.swift
@@ -158,9 +158,15 @@ final class SpamManager {
 
     /// Mutates .spam on each record. No return value needed —
     /// caller holds references to the same objects.
+    // EVM/Tron/Stellar hashes are hex; Solana signatures are base58 —
+    // fall back to raw bytes, as Android does (hash.toByteArray())
+    private func hashData(record: TransactionRecord) -> Data? {
+        record.transactionHash.hs.hexData ?? record.transactionHash.data(using: .utf8)
+    }
+
     private func performUpdate(records: [TransactionRecord]) {
         for record in records {
-            guard let hashData = record.transactionHash.hs.hexData else {
+            guard let hashData = hashData(record: record) else {
                 continue
             }
 
@@ -181,7 +187,7 @@ final class SpamManager {
         var lastPaginationData: String?
 
         for record in transactions {
-            guard let hashData = record.transactionHash.hs.hexData else {
+            guard let hashData = hashData(record: record) else {
                 continue
             }
 
@@ -204,23 +210,10 @@ final class SpamManager {
     /// Process single record: check spam, update caches, save to DB.
     /// Returns isSpam result.
     private func processRecord(record: TransactionRecord, hashData: Data, spamInfo: SpamTransactionInfo?) -> Bool {
-        // Outgoing transactions: save addresses to cache/DB, mark not spam
-        if let outgoingAddresses = OutputTransactionFactory.outgoingAddresses(from: record), !outgoingAddresses.isEmpty {
+        // The user's own sends: counterparties to cache/DB, trusted without scoring
+        if OutputTransactionFactory.outgoingAddresses(from: record) != nil {
             outputCache.add(record: record, accountId: accountId)
 
-            let scanned = ScannedTransaction(
-                transactionHash: hashData,
-                blockchainTypeUid: blockchainType.uid,
-                isSpam: false,
-                spamAddress: nil
-            )
-            try? storage.save(scannedTransaction: scanned)
-
-            return false
-        }
-
-        // Outgoing without addresses (Bitcoin/Monero UTXO): mark not spam, no cache
-        if OutputTransactionFactory.outgoingAddresses(from: record) != nil {
             let scanned = ScannedTransaction(
                 transactionHash: hashData,
                 blockchainTypeUid: blockchainType.uid,
@@ -246,6 +239,12 @@ final class SpamManager {
         // Evaluate spam
         let isSpam = evaluateSpam(spamInfo: spamInfo)
         let spamAddress = isSpam ? spamInfo.events.incoming.first?.address : nil
+
+        // Senders of received transfers are correlation context too (a look-alike of whoever just
+        // paid the user), but never spam senders: dust must not flush or poison the window
+        if !isSpam {
+            outputCache.add(record: record, accountId: accountId)
+        }
 
         let scanned = ScannedTransaction(
             transactionHash: hashData,

--- a/packages/WalletCore/Sources/WalletCore/Core/Managers/Spam/SpamWrapper.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Managers/Spam/SpamWrapper.swift
@@ -44,10 +44,27 @@ public class SpamWrapper {
             .append(OutgoingPoisoningFilter(logger: logger))
 
         let evaluator = SpamScoreEvaluator(spamThreshold: Self.spamThreshold, suspiciousThreshold: Self.suspiciousThreshold, logger: logger)
-            .append(ZeroValueCondition(score: Self.zeroValueIncoming, logger: logger))
-            .append(AddressSimilarityCondition(cache: outputCache, prefixScore: Self.addressPartScore, suffixScore: Self.addressPartScore, logger: logger))
-            .append(LowAmountCondition(spamScore: Self.spamThreshold, riskScore: Self.amountRiskScore, dangerScore: Self.amountDangerScore, logger: logger))
-            .append(TimeCorrelationCondition(blockScore: Self.correlationBlockScore, timeScore: Self.correlationTimeScore, logger: logger))
+
+        // Solana scores values per event (never a signed native aggregate) and has no zero-value
+        // bonus: a zero coin transfer is instant spam there, so ZeroValueCondition would double-score.
+        // Correlation is gated to the gray zone and matches 3 address characters, as on Android;
+        // the other chains stay ungated, so they keep the stricter 4-character match
+        if source.blockchainType == .solana {
+            evaluator.append(GrayZoneGateCondition(
+                value: SolanaLowAmountCondition(spamScore: Self.spamThreshold, riskScore: Self.amountRiskScore, dangerScore: Self.amountDangerScore, logger: logger),
+                correlation: [
+                    AddressSimilarityCondition(cache: outputCache, minMatchLength: 3, prefixScore: Self.addressPartScore, suffixScore: Self.addressPartScore, logger: logger),
+                    TimeCorrelationCondition(cache: outputCache, blockScore: Self.correlationBlockScore, timeScore: Self.correlationTimeScore, logger: logger),
+                ],
+                spamThreshold: Self.spamThreshold
+            ))
+        } else {
+            evaluator
+                .append(ZeroValueCondition(score: Self.zeroValueIncoming, logger: logger))
+                .append(AddressSimilarityCondition(cache: outputCache, prefixScore: Self.addressPartScore, suffixScore: Self.addressPartScore, logger: logger))
+                .append(LowAmountCondition(spamScore: Self.spamThreshold, riskScore: Self.amountRiskScore, dangerScore: Self.amountDangerScore, logger: logger))
+                .append(TimeCorrelationCondition(cache: outputCache, blockScore: Self.correlationBlockScore, timeScore: Self.correlationTimeScore, logger: logger))
+        }
 
         return SpamManager(
             accountId: accountId,

--- a/packages/WalletCore/Sources/WalletCore/Core/Storage/AccountStorage.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Storage/AccountStorage.swift
@@ -81,6 +81,12 @@ public class AccountStorage {
             }
 
             type = .tonAddress(address: address)
+        case .solanaAddress:
+            guard let address = record.dataKey else {
+                return nil
+            }
+
+            type = .solanaAddress(address: address)
         case .stellarAccount:
             guard let accountId = record.dataKey else {
                 return nil
@@ -174,6 +180,9 @@ public class AccountStorage {
             dataKey = try store(data: address.raw, id: id, typeName: typeName, keyName: .data)
         case let .tonAddress(address):
             typeName = .tonAddress
+            dataKey = address
+        case let .solanaAddress(address):
+            typeName = .solanaAddress
             dataKey = address
         case let .stellarAccount(accountId):
             typeName = .stellarAccount
@@ -326,6 +335,7 @@ extension AccountStorage {
         case evmAddress = "address"
         case tronAddress
         case tonAddress
+        case solanaAddress
         case stellarAccount
         case hdExtendedKey
         case btcAddress

--- a/packages/WalletCore/Sources/WalletCore/Extensions/BlockchainType.swift
+++ b/packages/WalletCore/Sources/WalletCore/Extensions/BlockchainType.swift
@@ -154,6 +154,8 @@ extension BlockchainType {
             return self == .tron
         case .tonAddress:
             return self == .ton
+        case .solanaAddress:
+            return self == .solana
         case let .btcAddress(_, blockchainType, _):
             return self == blockchainType
         case .moneroWatchAccount:

--- a/packages/WalletCore/Sources/WalletCore/Models/Account.swift
+++ b/packages/WalletCore/Sources/WalletCore/Models/Account.swift
@@ -21,7 +21,7 @@ public class Account: Identifiable {
 
     var watchAccount: Bool {
         switch type {
-        case .evmAddress, .tronAddress, .tonAddress, .stellarAccount, .btcAddress, .moneroWatchAccount:
+        case .evmAddress, .tronAddress, .tonAddress, .solanaAddress, .stellarAccount, .btcAddress, .moneroWatchAccount:
             return true
         case .passkeyOwned:
             return false

--- a/packages/WalletCore/Sources/WalletCore/Models/AccountType.swift
+++ b/packages/WalletCore/Sources/WalletCore/Models/AccountType.swift
@@ -15,6 +15,7 @@ public enum AccountType: Identifiable {
     case evmAddress(address: EvmKit.Address)
     case tronAddress(address: TronKit.Address)
     case tonAddress(address: String)
+    case solanaAddress(address: String)
     case stellarAccount(accountId: String)
     case hdExtendedKey(key: HDExtendedKey)
     case btcAddress(address: String, blockchainType: BlockchainType, tokenType: TokenType)
@@ -64,6 +65,8 @@ public enum AccountType: Identifiable {
         case let .tronAddress(address):
             privateData = address.hex.hs.data
         case let .tonAddress(address):
+            privateData = address.hs.data
+        case let .solanaAddress(address):
             privateData = address.hs.data
         case let .stellarAccount(accountId):
             privateData = accountId.hs.data
@@ -170,6 +173,11 @@ public enum AccountType: Identifiable {
             case (.ton, .native), (.ton, .jetton): return true
             default: return false
             }
+        case .solanaAddress:
+            switch (token.blockchainType, token.type) {
+            case (.solana, .native), (.solana, .spl): return true
+            default: return false
+            }
         case let .btcAddress(_, blockchainType, tokenType):
             return token.blockchainType == blockchainType && token.type == tokenType
         case .moneroWatchAccount:
@@ -219,6 +227,8 @@ public enum AccountType: Identifiable {
             return "TRON Address"
         case .tonAddress:
             return "TON Address"
+        case .solanaAddress:
+            return "Solana Address"
         case .stellarAccount:
             return "Stellar Account"
         case let .hdExtendedKey(key):
@@ -264,6 +274,8 @@ public enum AccountType: Identifiable {
             return "tron_address"
         case .tonAddress:
             return "ton_address"
+        case .solanaAddress:
+            return "solana_address"
         case .stellarAccount:
             return "stellar_account"
         case let .hdExtendedKey(key):
@@ -299,6 +311,8 @@ public enum AccountType: Identifiable {
             return address.base58
         case let .tonAddress(address):
             return address
+        case let .solanaAddress(address):
+            return address
         case let .stellarAccount(accountId):
             return accountId
         case let .hdExtendedKey(key):
@@ -330,6 +344,7 @@ public enum AccountType: Identifiable {
         case .evmAddress: return "EVM"
         case .tronAddress: return "TRON"
         case .tonAddress: return "TON"
+        case .solanaAddress: return "Solana"
         case .stellarAccount: return "Stellar"
         case let .hdExtendedKey(key):
             switch key {
@@ -425,6 +440,8 @@ extension AccountType {
             return address.map { AccountType.tronAddress(address: $0) }
         case .tonAddress:
             return AccountType.tonAddress(address: string)
+        case .solanaAddress:
+            return AccountType.solanaAddress(address: string)
         case .stellarAccount:
             return AccountType.stellarAccount(accountId: string)
         case .moneroWatchAccount:
@@ -458,6 +475,7 @@ extension AccountType {
         case evmAddress = "evm_address"
         case tronAddress = "tron_address"
         case tonAddress = "ton_address"
+        case solanaAddress = "solana_address"
         case stellarAccount = "stellar_account"
         case hdExtendedKey = "hd_extended_key"
         case btcAddress = "btc_address_key"
@@ -474,6 +492,7 @@ extension AccountType {
             case .evmAddress: self = .evmAddress
             case .tronAddress: self = .tronAddress
             case .tonAddress: self = .tonAddress
+            case .solanaAddress: self = .solanaAddress
             case .stellarAccount: self = .stellarAccount
             case .hdExtendedKey: self = .hdExtendedKey
             case .btcAddress: self = .btcAddress
@@ -502,6 +521,8 @@ extension AccountType: Hashable {
         case let (.tronAddress(lhsAddress), .tronAddress(rhsAddress)):
             return lhsAddress == rhsAddress
         case let (.tonAddress(lhsAddress), .tonAddress(rhsAddress)):
+            return lhsAddress == rhsAddress
+        case let (.solanaAddress(lhsAddress), .solanaAddress(rhsAddress)):
             return lhsAddress == rhsAddress
         case let (.stellarAccount(lhsAccountId), .stellarAccount(rhsAccountId)):
             return lhsAccountId == rhsAccountId
@@ -544,6 +565,9 @@ extension AccountType: Hashable {
             hasher.combine(address.raw)
         case let .tonAddress(address):
             hasher.combine("tonAddress")
+            hasher.combine(address)
+        case let .solanaAddress(address):
+            hasher.combine("solanaAddress")
             hasher.combine(address)
         case let .stellarAccount(accountId):
             hasher.combine("stellarAccount")

--- a/packages/WalletCore/Sources/WalletCore/Models/TransactionRecords/Solana/SolanaTransactionRecord.swift
+++ b/packages/WalletCore/Sources/WalletCore/Models/TransactionRecords/Solana/SolanaTransactionRecord.swift
@@ -42,7 +42,7 @@ extension SolanaTransactionRecord {
     }
 }
 
-class SolanaIncomingTransactionRecord: SolanaTransactionRecord {
+class SolanaIncomingTransactionRecord: SolanaTransactionRecord, TransferEventsProvider {
     let from: String?
     let value: AppValue
 
@@ -54,6 +54,13 @@ class SolanaIncomingTransactionRecord: SolanaTransactionRecord {
 
     override var mainValue: AppValue? {
         value
+    }
+
+    var transferEvents: TransferEvents {
+        guard let from else {
+            return .init()
+        }
+        return .init(incoming: [.init(address: from, value: value)])
     }
 }
 
@@ -74,7 +81,7 @@ class SolanaOutgoingTransactionRecord: SolanaTransactionRecord {
     }
 }
 
-class SolanaUnknownTransactionRecord: SolanaTransactionRecord {
+class SolanaUnknownTransactionRecord: SolanaTransactionRecord, TransferEventsProvider {
     let incomingTransfers: [Transfer]
     let outgoingTransfers: [Transfer]
 
@@ -82,6 +89,16 @@ class SolanaUnknownTransactionRecord: SolanaTransactionRecord {
         self.incomingTransfers = incomingTransfers
         self.outgoingTransfers = outgoingTransfers
         super.init(transaction: transaction, baseToken: baseToken, source: source)
+    }
+
+    var transferEvents: TransferEvents {
+        guard !incomingTransfers.isEmpty else {
+            return .init()
+        }
+        return .init(
+            incoming: incomingTransfers.compactMap { transfer in transfer.address.map { TransferEvent(address: $0, value: transfer.value) } },
+            outgoing: outgoingTransfers.compactMap { transfer in transfer.address.map { TransferEvent(address: $0, value: transfer.value) } }
+        )
     }
 }
 

--- a/packages/WalletCore/Sources/WalletCore/Modules/Watch/WatchViewModel.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/Watch/WatchViewModel.swift
@@ -107,6 +107,7 @@ class WatchViewModel: ObservableObject {
                 }
                 + AddressParserFactory.parserChainHandlers(blockchainType: .tron)
                 + AddressParserFactory.parserChainHandlers(blockchainType: .ton)
+                + AddressParserFactory.parserChainHandlers(blockchainType: .solana)
                 + AddressParserFactory.parserChainHandlers(blockchainType: .stellar)
                 + AddressParserFactory.parserChainHandlers(blockchainType: .monero)
         )
@@ -194,6 +195,8 @@ class WatchViewModel: ObservableObject {
                     accountType = try .tronAddress(address: TronKit.Address(address: address.raw))
                 case .ton:
                     accountType = .tonAddress(address: address.raw)
+                case .solana:
+                    accountType = .solanaAddress(address: address.raw)
                 case .stellar:
                     accountType = .stellarAccount(accountId: address.raw)
                 case .monero:
@@ -249,6 +252,9 @@ class WatchViewModel: ObservableObject {
 
         case .tonAddress:
             tokenQueries = BlockchainType.ton.nativeTokenQueries
+
+        case .solanaAddress:
+            tokenQueries = BlockchainType.solana.nativeTokenQueries
 
         case .stellarAccount:
             tokenQueries = BlockchainType.stellar.nativeTokenQueries


### PR DESCRIPTION
## Summary

- **Solana spam classification** — `SolanaTransactionsAdapter` runs records through `SpamManager`; Incoming/Unknown records expose transfer events. Policy mirrors Android 0.51 (`0c5eac773`): per-event value scoring (`SolanaLowAmountCondition`), SOL limit `0.0001`, gray-zone gate (`GrayZoneGateCondition`), 3-char address match, time-only correlation (the kit stores no slot).
- **Counterparty context is direction-agnostic on all chains** — senders of non-spam incoming transfers join the correlation window, so a look-alike of whoever just paid the user is caught (watch-only wallets had no context at all). `External*ContractCall` records are scored over both legs; dust scoring ignores negative (outgoing) legs; proximity is checked against the whole window with inclusive thresholds; Tron `T` is stripped before matching; `BNB` limit `0.0002`.
- **Scan verdicts for base58 hashes** — `SpamManager` persisted by `hexData` only, so every Solana record was silently skipped.
- **Readonly Solana account** — `AccountType.solanaAddress`, backup tag `solana_address` byte-identical to Android.

## Deliberate differences from Android

- Window stays **10 distinct counterparties** (Android: last 20 transactions, repeats included) — superset at equal N, no schema change.
- **Spam senders never enter the window** — dust cannot flush real counterparties or poison the window.
- EVM/TRON/Stellar keep the **ungated sum with 4-char matching**; the gate + 3 chars apply to Solana only.
- Raw/zero outgoing legs are not cached as counterparties.

## Testing

- `SolanaSpamPolicyTests` (thresholds, Android regression `3VHMK…`: dust from a look-alike of the incoming sender is hidden, same dust without context is visible, normal amount from a look-alike stays visible).
- `SpamCorrelationTests` (match length 4/3, Tron `T`, inclusive thresholds, any-entry proximity, window dedup, External vs own contract call, negative-leg guard).
- Smoke on a Solana watch address with real dust history.
- Stable: no exhaustive `switch` over `AccountType`; GasFree records reach `SpamManager` as raw Tron External records and stay visible thanks to the negative-leg guard.