### PR TITLE
Add token filter to Swap History

### DIFF
--- a/packages/WalletCore/Sources/WalletCore/Core/Managers/SwapHistoryManager.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Managers/SwapHistoryManager.swift
@@ -1,5 +1,6 @@
 import Combine
 import Foundation
+import MarketKit
 
 public class SwapHistoryManager {
     private let accountManager: AccountManager
@@ -109,9 +110,9 @@ public extension SwapHistoryManager {
         try? storage.lastSwap(accountId: accountId)
     }
 
-    func swaps(accountId: String, from: Date? = nil, limit: Int) -> [Swap] {
+    func swaps(accountId: String, token: Token? = nil, from: Date? = nil, limit: Int) -> [Swap] {
         do {
-            return try storage.swaps(accountId: accountId, from: from, limit: limit)
+            return try storage.swaps(accountId: accountId, token: token, from: from, limit: limit)
         } catch {
             return []
         }

--- a/packages/WalletCore/Sources/WalletCore/Core/Storage/SwapStorage.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Storage/SwapStorage.swift
@@ -117,12 +117,19 @@ extension SwapStorage {
         return try swaps(records: [record]).first
     }
 
-    func swaps(accountId: String, from: Date? = nil, limit: Int) throws -> [Swap] {
+    func swaps(accountId: String, token: Token? = nil, from: Date? = nil, limit: Int) throws -> [Swap] {
         let records = try dbPool.read { db in
             var request = SwapRecord
                 .filter(SwapRecord.Columns.accountId == accountId)
                 .order(SwapRecord.Columns.date.desc)
                 .limit(limit)
+
+            if let tokenQueryId = token?.tokenQuery.id {
+                request = request.filter(
+                    SwapRecord.Columns.tokenQueryIdIn == tokenQueryId
+                        || SwapRecord.Columns.tokenQueryIdOut == tokenQueryId
+                )
+            }
 
             if let from {
                 request = request.filter(SwapRecord.Columns.date < from)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Swap history can now be filtered by a specific token.
  * Filtering includes swaps where the token was either exchanged in or exchanged out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->