### PR TITLE
Add CrossPay payment flow for Zcash

### DIFF
--- a/Unstoppable/Unstoppable/App/UnstoppableApp.swift
+++ b/Unstoppable/Unstoppable/App/UnstoppableApp.swift
@@ -97,6 +97,14 @@ struct UnstoppableApp: App {
             // handing the provider the sender's address defeats the point of a private send.
             commitRequestBuilder: { USwapCommitRequestBuilder(providerId: $0, shouldIncludeSourceAddress: { _ in false }) }
         )
+
+        // Shares the API and repository cache; the factory keeps the NEAR repository (and its
+        // first /v2/tokens fetch) uncreated until the CrossPay screen opens.
+        Core.crossPayService = CrossPayService(
+            api: uSwapApi,
+            assetRepository: repositoryCache.repository(providerId:),
+            commitRequestBuilder: USwapCommitRequestBuilder(providerId: CrossPayService.providerId, shouldIncludeSourceAddress: { _ in false })
+        )
     }
 }
 

--- a/Unstoppable/Unstoppable/Resources/Strings/de.lproj/Localizable.strings
+++ b/Unstoppable/Unstoppable/Resources/Strings/de.lproj/Localizable.strings
@@ -2595,3 +2595,20 @@
 "open_crypto_pay.tx_info.proof_status.submitted" = "Eingereicht";
 "open_crypto_pay.tx_info.proof_status.pending" = "Ausstehend";
 "open_crypto_pay.tx_info.proof_status.reconciliation" = "Abgleich erforderlich";
+
+"balance.pay" = "Bezahlen";
+"cross_pay.title" = "Bezahlen";
+"cross_pay.send_to" = "Senden an";
+"cross_pay.select_token" = "Token auswählen";
+"cross_pay.review" = "Überprüfen";
+"cross_pay.you_pay" = "Sie zahlen";
+"cross_pay.you_pay.info" = "Der eingezahlte Betrag zur Finanzierung dieser Zahlung, einschließlich der Umtauschkosten des Anbieters und einer erstattungsfähigen Slippage-Reserve. Nicht verwendete Teile der Reserve werden an Ihre Wallet zurückgegeben.";
+"cross_pay.caution.insufficient_balance %@" = "Diese Zahlung erfordert %@ in Ihrer Wallet, einschließlich Gebühren.";
+"cross_pay.error.token_unsupported" = "Dieser Token wird für Zahlungen nicht unterstützt.";
+"cross_pay.error.below_minimum %@" = "Der Mindestzahlungsbetrag beträgt %@.";
+"cross_pay.error.above_maximum %@" = "Der Höchstzahlungsbetrag beträgt %@.";
+"cross_pay.error.no_route" = "Für diesen Token und Betrag ist keine Zahlungsroute verfügbar.";
+"cross_pay.error.provider_suspended" = "Der Zahlungsanbieter ist vorübergehend ausgesetzt. Versuchen Sie es später erneut.";
+"cross_pay.error.network" = "Ein Netzwerkfehler ist aufgetreten. Überprüfen Sie Ihre Verbindung und versuchen Sie es erneut.";
+"cross_pay.error.commit_failed" = "Diese Zahlung konnte nicht eingerichtet werden. Aktualisieren Sie, um es erneut zu versuchen.";
+"cross_pay.unavailable" = "Zahlung nicht verfügbar";

--- a/Unstoppable/Unstoppable/Resources/Strings/en.lproj/Localizable.strings
+++ b/Unstoppable/Unstoppable/Resources/Strings/en.lproj/Localizable.strings
@@ -2595,3 +2595,20 @@
 "open_crypto_pay.tx_info.proof_status.submitted" = "Submitted";
 "open_crypto_pay.tx_info.proof_status.pending" = "Pending";
 "open_crypto_pay.tx_info.proof_status.reconciliation" = "Reconciliation needed";
+
+"balance.pay" = "Pay";
+"cross_pay.title" = "Pay";
+"cross_pay.send_to" = "Send To";
+"cross_pay.select_token" = "Select Token";
+"cross_pay.review" = "Review";
+"cross_pay.you_pay" = "You Pay";
+"cross_pay.you_pay.info" = "The amount deposited to fund this payment, including the provider's exchange cost and a refundable slippage reserve. Any unused part of the reserve is returned to your wallet.";
+"cross_pay.caution.insufficient_balance %@" = "This payment needs %@ in your wallet, including fees.";
+"cross_pay.error.token_unsupported" = "This token is not supported for payments.";
+"cross_pay.error.below_minimum %@" = "Minimum payment amount is %@.";
+"cross_pay.error.above_maximum %@" = "Maximum payment amount is %@.";
+"cross_pay.error.no_route" = "No payment route is available for this token and amount.";
+"cross_pay.error.provider_suspended" = "The payment provider is temporarily suspended. Try again later.";
+"cross_pay.error.network" = "A network error occurred. Check your connection and try again.";
+"cross_pay.error.commit_failed" = "This payment could not be set up. Refresh to try again.";
+"cross_pay.unavailable" = "Payment unavailable";

--- a/Unstoppable/Unstoppable/Resources/Strings/es.lproj/Localizable.strings
+++ b/Unstoppable/Unstoppable/Resources/Strings/es.lproj/Localizable.strings
@@ -2595,3 +2595,20 @@
 "open_crypto_pay.tx_info.proof_status.submitted" = "Enviado";
 "open_crypto_pay.tx_info.proof_status.pending" = "Pendiente";
 "open_crypto_pay.tx_info.proof_status.reconciliation" = "Reconciliación necesaria";
+
+"balance.pay" = "Pagar";
+"cross_pay.title" = "Pagar";
+"cross_pay.send_to" = "Enviar a";
+"cross_pay.select_token" = "Seleccionar token";
+"cross_pay.review" = "Revisar";
+"cross_pay.you_pay" = "Tú pagas";
+"cross_pay.you_pay.info" = "El monto depositado para financiar este pago, incluido el costo de cambio del proveedor y una reserva de deslizamiento reembolsable. Cualquier parte no utilizada de la reserva se devuelve a tu wallet.";
+"cross_pay.caution.insufficient_balance %@" = "Este pago necesita %@ en tu wallet, incluidas las comisiones.";
+"cross_pay.error.token_unsupported" = "Este token no es compatible para pagos.";
+"cross_pay.error.below_minimum %@" = "El monto mínimo de pago es %@.";
+"cross_pay.error.above_maximum %@" = "El monto máximo de pago es %@.";
+"cross_pay.error.no_route" = "No hay una ruta de pago disponible para este token y monto.";
+"cross_pay.error.provider_suspended" = "El proveedor de pagos está temporalmente suspendido. Inténtalo de nuevo más tarde.";
+"cross_pay.error.network" = "Ocurrió un error de red. Verifica tu conexión e inténtalo de nuevo.";
+"cross_pay.error.commit_failed" = "No se pudo configurar este pago. Actualiza para intentarlo de nuevo.";
+"cross_pay.unavailable" = "Pago no disponible";

--- a/Unstoppable/Unstoppable/Resources/Strings/fr.lproj/Localizable.strings
+++ b/Unstoppable/Unstoppable/Resources/Strings/fr.lproj/Localizable.strings
@@ -2595,3 +2595,20 @@
 "open_crypto_pay.tx_info.proof_status.submitted" = "Soumis";
 "open_crypto_pay.tx_info.proof_status.pending" = "En attente";
 "open_crypto_pay.tx_info.proof_status.reconciliation" = "Réconciliation nécessaire";
+
+"balance.pay" = "Payer";
+"cross_pay.title" = "Payer";
+"cross_pay.send_to" = "Envoyer à";
+"cross_pay.select_token" = "Sélectionner un token";
+"cross_pay.review" = "Vérifier";
+"cross_pay.you_pay" = "Vous payez";
+"cross_pay.you_pay.info" = "Le montant déposé pour financer ce paiement, y compris le coût de change du fournisseur et une réserve de glissement remboursable. Toute partie inutilisée de la réserve est retournée à votre wallet.";
+"cross_pay.caution.insufficient_balance %@" = "Ce paiement nécessite %@ dans votre wallet, frais inclus.";
+"cross_pay.error.token_unsupported" = "Ce token n'est pas pris en charge pour les paiements.";
+"cross_pay.error.below_minimum %@" = "Le montant minimum de paiement est de %@.";
+"cross_pay.error.above_maximum %@" = "Le montant maximum de paiement est de %@.";
+"cross_pay.error.no_route" = "Aucune route de paiement n'est disponible pour ce token et ce montant.";
+"cross_pay.error.provider_suspended" = "Le fournisseur de paiement est temporairement suspendu. Réessayez plus tard.";
+"cross_pay.error.network" = "Une erreur réseau s'est produite. Vérifiez votre connexion et réessayez.";
+"cross_pay.error.commit_failed" = "Ce paiement n'a pas pu être configuré. Actualisez pour réessayer.";
+"cross_pay.unavailable" = "Paiement indisponible";

--- a/Unstoppable/Unstoppable/Resources/Strings/ko.lproj/Localizable.strings
+++ b/Unstoppable/Unstoppable/Resources/Strings/ko.lproj/Localizable.strings
@@ -2595,3 +2595,20 @@
 "open_crypto_pay.tx_info.proof_status.submitted" = "제출됨";
 "open_crypto_pay.tx_info.proof_status.pending" = "대기 중";
 "open_crypto_pay.tx_info.proof_status.reconciliation" = "조정 필요";
+
+"balance.pay" = "결제";
+"cross_pay.title" = "결제";
+"cross_pay.send_to" = "받는 곳";
+"cross_pay.select_token" = "토큰 선택";
+"cross_pay.review" = "검토";
+"cross_pay.you_pay" = "결제 금액";
+"cross_pay.you_pay.info" = "이 결제를 위해 입금되는 금액으로, 제공업체의 환전 비용과 환불 가능한 슬리피지 준비금이 포함됩니다. 사용되지 않은 준비금은 지갑으로 반환됩니다.";
+"cross_pay.caution.insufficient_balance %@" = "이 결제에는 수수료를 포함하여 지갑에 %@이(가) 필요합니다.";
+"cross_pay.error.token_unsupported" = "이 토큰은 결제에 지원되지 않습니다.";
+"cross_pay.error.below_minimum %@" = "최소 결제 금액은 %@입니다.";
+"cross_pay.error.above_maximum %@" = "최대 결제 금액은 %@입니다.";
+"cross_pay.error.no_route" = "이 토큰과 금액에 대해 사용 가능한 결제 경로가 없습니다.";
+"cross_pay.error.provider_suspended" = "결제 제공업체가 일시적으로 중단되었습니다. 나중에 다시 시도하세요.";
+"cross_pay.error.network" = "네트워크 오류가 발생했습니다. 연결을 확인하고 다시 시도하세요.";
+"cross_pay.error.commit_failed" = "이 결제를 설정할 수 없습니다. 새로고침하여 다시 시도하세요.";
+"cross_pay.unavailable" = "결제를 사용할 수 없습니다";

--- a/Unstoppable/Unstoppable/Resources/Strings/pt-BR.lproj/Localizable.strings
+++ b/Unstoppable/Unstoppable/Resources/Strings/pt-BR.lproj/Localizable.strings
@@ -2595,3 +2595,20 @@
 "open_crypto_pay.tx_info.proof_status.submitted" = "Enviado";
 "open_crypto_pay.tx_info.proof_status.pending" = "Pendente";
 "open_crypto_pay.tx_info.proof_status.reconciliation" = "Reconciliação necessária";
+
+"balance.pay" = "Pagar";
+"cross_pay.title" = "Pagar";
+"cross_pay.send_to" = "Enviar para";
+"cross_pay.select_token" = "Selecionar token";
+"cross_pay.review" = "Revisar";
+"cross_pay.you_pay" = "Você paga";
+"cross_pay.you_pay.info" = "O valor depositado para financiar este pagamento, incluindo o custo de câmbio do provedor e uma reserva de slippage reembolsável. Qualquer parte não utilizada da reserva é devolvida à sua carteira.";
+"cross_pay.caution.insufficient_balance %@" = "Este pagamento precisa de %@ na sua carteira, incluindo taxas.";
+"cross_pay.error.token_unsupported" = "Este token não é compatível com pagamentos.";
+"cross_pay.error.below_minimum %@" = "O valor mínimo de pagamento é %@.";
+"cross_pay.error.above_maximum %@" = "O valor máximo de pagamento é %@.";
+"cross_pay.error.no_route" = "Nenhuma rota de pagamento está disponível para este token e valor.";
+"cross_pay.error.provider_suspended" = "O provedor de pagamento está temporariamente suspenso. Tente novamente mais tarde.";
+"cross_pay.error.network" = "Ocorreu um erro de rede. Verifique sua conexão e tente novamente.";
+"cross_pay.error.commit_failed" = "Não foi possível configurar este pagamento. Atualize para tentar novamente.";
+"cross_pay.unavailable" = "Pagamento indisponível";

--- a/Unstoppable/Unstoppable/Resources/Strings/ru.lproj/Localizable.strings
+++ b/Unstoppable/Unstoppable/Resources/Strings/ru.lproj/Localizable.strings
@@ -2595,3 +2595,20 @@
 "open_crypto_pay.tx_info.proof_status.submitted" = "Отправлено";
 "open_crypto_pay.tx_info.proof_status.pending" = "В ожидании";
 "open_crypto_pay.tx_info.proof_status.reconciliation" = "Требуется сверка";
+
+"balance.pay" = "Оплатить";
+"cross_pay.title" = "Оплата";
+"cross_pay.send_to" = "Отправить";
+"cross_pay.select_token" = "Выбрать токен";
+"cross_pay.review" = "Проверить";
+"cross_pay.you_pay" = "Вы платите";
+"cross_pay.you_pay.info" = "Сумма, внесённая для финансирования этого платежа, включая стоимость обмена провайдера и возвращаемый резерв на проскальзывание. Любая неиспользованная часть резерва возвращается в ваш кошелёк.";
+"cross_pay.caution.insufficient_balance %@" = "Для этого платежа необходимо %@ в вашем кошельке, включая комиссии.";
+"cross_pay.error.token_unsupported" = "Этот токен не поддерживается для платежей.";
+"cross_pay.error.below_minimum %@" = "Минимальная сумма платежа — %@.";
+"cross_pay.error.above_maximum %@" = "Максимальная сумма платежа — %@.";
+"cross_pay.error.no_route" = "Для этого токена и суммы маршрут оплаты недоступен.";
+"cross_pay.error.provider_suspended" = "Платёжный провайдер временно приостановлен. Попробуйте позже.";
+"cross_pay.error.network" = "Произошла сетевая ошибка. Проверьте подключение и попробуйте снова.";
+"cross_pay.error.commit_failed" = "Не удалось настроить этот платёж. Обновите, чтобы попробовать снова.";
+"cross_pay.unavailable" = "Оплата недоступна";

--- a/Unstoppable/Unstoppable/Resources/Strings/tr.lproj/Localizable.strings
+++ b/Unstoppable/Unstoppable/Resources/Strings/tr.lproj/Localizable.strings
@@ -2595,3 +2595,20 @@
 "open_crypto_pay.tx_info.proof_status.submitted" = "Gönderildi";
 "open_crypto_pay.tx_info.proof_status.pending" = "Beklemede";
 "open_crypto_pay.tx_info.proof_status.reconciliation" = "Mutabakat gerekli";
+
+"balance.pay" = "Öde";
+"cross_pay.title" = "Öde";
+"cross_pay.send_to" = "Gönder";
+"cross_pay.select_token" = "Token Seç";
+"cross_pay.review" = "İncele";
+"cross_pay.you_pay" = "Ödediğiniz";
+"cross_pay.you_pay.info" = "Bu ödemeyi finanse etmek için yatırılan tutar; sağlayıcının döviz maliyeti ve iade edilebilir kayma payı rezervi dahildir. Rezervin kullanılmayan kısmı cüzdanınıza iade edilir.";
+"cross_pay.caution.insufficient_balance %@" = "Bu ödeme, ücretler dahil cüzdanınızda %@ gerektirir.";
+"cross_pay.error.token_unsupported" = "Bu token ödemeler için desteklenmiyor.";
+"cross_pay.error.below_minimum %@" = "Minimum ödeme tutarı %@.";
+"cross_pay.error.above_maximum %@" = "Maksimum ödeme tutarı %@.";
+"cross_pay.error.no_route" = "Bu token ve tutar için kullanılabilir bir ödeme rotası yok.";
+"cross_pay.error.provider_suspended" = "Ödeme sağlayıcısı geçici olarak askıya alındı. Daha sonra tekrar deneyin.";
+"cross_pay.error.network" = "Bir ağ hatası oluştu. Bağlantınızı kontrol edip tekrar deneyin.";
+"cross_pay.error.commit_failed" = "Bu ödeme ayarlanamadı. Tekrar denemek için yenileyin.";
+"cross_pay.unavailable" = "Ödeme kullanılamıyor";

--- a/Unstoppable/Unstoppable/Resources/Strings/translation_snapshot.json
+++ b/Unstoppable/Unstoppable/Resources/Strings/translation_snapshot.json
@@ -2004,5 +2004,21 @@
   "open_crypto_pay.tx_info.proof_status": "Proof Status",
   "open_crypto_pay.tx_info.proof_status.submitted": "Submitted",
   "open_crypto_pay.tx_info.proof_status.pending": "Pending",
-  "open_crypto_pay.tx_info.proof_status.reconciliation": "Reconciliation needed"
+  "open_crypto_pay.tx_info.proof_status.reconciliation": "Reconciliation needed",
+  "balance.pay": "Pay",
+  "cross_pay.title": "Pay",
+  "cross_pay.send_to": "Send To",
+  "cross_pay.select_token": "Select Token",
+  "cross_pay.review": "Review",
+  "cross_pay.you_pay": "You Pay",
+  "cross_pay.you_pay.info": "The amount deposited to fund this payment, including the provider's exchange cost and a refundable slippage reserve. Any unused part of the reserve is returned to your wallet.",
+  "cross_pay.caution.insufficient_balance %@": "This payment needs %@ in your wallet, including fees.",
+  "cross_pay.error.token_unsupported": "This token is not supported for payments.",
+  "cross_pay.error.below_minimum %@": "Minimum payment amount is %@.",
+  "cross_pay.error.above_maximum %@": "Maximum payment amount is %@.",
+  "cross_pay.error.no_route": "No payment route is available for this token and amount.",
+  "cross_pay.error.provider_suspended": "The payment provider is temporarily suspended. Try again later.",
+  "cross_pay.error.network": "A network error occurred. Check your connection and try again.",
+  "cross_pay.error.commit_failed": "This payment could not be set up. Refresh to try again.",
+  "cross_pay.unavailable": "Payment unavailable"
 }

--- a/Unstoppable/Unstoppable/Resources/Strings/zh.lproj/Localizable.strings
+++ b/Unstoppable/Unstoppable/Resources/Strings/zh.lproj/Localizable.strings
@@ -2595,3 +2595,20 @@
 "open_crypto_pay.tx_info.proof_status.submitted" = "已提交";
 "open_crypto_pay.tx_info.proof_status.pending" = "待处理";
 "open_crypto_pay.tx_info.proof_status.reconciliation" = "需要对账";
+
+"balance.pay" = "支付";
+"cross_pay.title" = "支付";
+"cross_pay.send_to" = "发送至";
+"cross_pay.select_token" = "选择代币";
+"cross_pay.review" = "审核";
+"cross_pay.you_pay" = "您支付";
+"cross_pay.you_pay.info" = "为此支付存入的金额，包括提供商的兑换费用和可退还的滑点准备金。准备金中未使用的部分将退回到您的钱包。";
+"cross_pay.caution.insufficient_balance %@" = "此支付需要您的钱包中有 %@（含手续费）。";
+"cross_pay.error.token_unsupported" = "此代币不支持用于支付。";
+"cross_pay.error.below_minimum %@" = "最低支付金额为 %@。";
+"cross_pay.error.above_maximum %@" = "最高支付金额为 %@。";
+"cross_pay.error.no_route" = "此代币和金额没有可用的支付路径。";
+"cross_pay.error.provider_suspended" = "支付提供商暂时停止服务，请稍后重试。";
+"cross_pay.error.network" = "发生网络错误。请检查您的连接并重试。";
+"cross_pay.error.commit_failed" = "无法设置此支付。请刷新后重试。";
+"cross_pay.unavailable" = "支付不可用";

--- a/packages/WalletCore/Sources/WalletCore/Core/Core.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Core.swift
@@ -44,6 +44,7 @@ public class Core {
     // Set by each app, because the service needs a USwapMultiSwapApi the app configures. Left nil,
     // private send is simply unavailable and nothing else changes.
     public static var privateSendService: PrivateSendService?
+    public static var crossPayService: CrossPayService?
 
     let config: Config
 

--- a/packages/WalletCore/Sources/WalletCore/Core/Managers/SwapHistoryManager.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Managers/SwapHistoryManager.swift
@@ -158,6 +158,24 @@ public extension SwapHistoryManager {
         }
     }
 
+    // mechanism-agnostic hook: a retried broadcast reuses the row it failed on. Scoped to the
+    // failed status — never resurrects a settled swap; false = nothing to retry.
+    func retryFailed(trackingHandle: String) -> Bool {
+        do {
+            guard try storage.markNotStarted(trackingHandle: trackingHandle) else {
+                return false
+            }
+
+            if let swap = try storage.swap(trackingHandle: trackingHandle) {
+                swapUpdateSubject.send(swap)
+            }
+
+            return true
+        } catch {
+            return false
+        }
+    }
+
     // mechanism-agnostic hook: the mechanism itself learned the swap failed (e.g. a reverted /
     // never-mined userOp) — no server tracking involved. Targeted update scoped to pending
     // statuses; a settled swap is never downgraded, a re-delivery is a no-op.

--- a/packages/WalletCore/Sources/WalletCore/Core/Storage/SwapStorage.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Storage/SwapStorage.swift
@@ -184,6 +184,16 @@ extension SwapStorage {
         }
     }
 
+    // the inverse of markFailed for a broadcast retry: only a failed row goes back to notStarted,
+    // so a settled or in-flight swap can never be reset
+    func markNotStarted(trackingHandle: String) throws -> Bool {
+        try dbPool.write { db in
+            try SwapRecord
+                .filter(SwapRecord.Columns.trackingHandle == trackingHandle && SwapRecord.Columns.status == Swap.Status.failed.rawValue)
+                .updateAll(db, SwapRecord.Columns.status.set(to: Swap.Status.notStarted.rawValue)) > 0
+        }
+    }
+
     // targeted status update for a swap whose mechanism reported failure; scoped to pending
     // statuses so a settled swap can never be downgraded and a re-delivery is a no-op
     func markFailed(trackingHandle: String) throws -> Bool {

--- a/packages/WalletCore/Sources/WalletCore/Models/Stats.swift
+++ b/packages/WalletCore/Sources/WalletCore/Models/Stats.swift
@@ -55,6 +55,7 @@ enum StatPage: String {
     case contactNew = "contact_new"
     case contacts
     case contactUs = "contact_us"
+    case crossPay = "cross_pay"
     case deepLink = "deep_link"
     case donate
     case donateAddressList = "donate_address_list"

--- a/packages/WalletCore/Sources/WalletCore/Modules/CrossPay/CrossPayData.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/CrossPay/CrossPayData.swift
@@ -1,0 +1,137 @@
+import Foundation
+import MarketKit
+
+// NOT a PrivateSendData subclass: that class is typed to the single-token PrivateSendOrder.
+public class CrossPayData: ISendData {
+    // A committed order is only honoured for this long; past it the screen dead-ends.
+    public static let quoteLifetime: TimeInterval = 15
+
+    public let order: CrossPayOrder
+    public let inner: ISendData
+    // The handler that produced `inner`: overlapping sendData calls each prepare their own pair,
+    // and broadcasting through the wrong one would use settings the user never confirmed.
+    public let innerHandler: ISendHandler
+    // ZEC balance snapshot at estimation time, only for the insufficient caution.
+    public let availableBalance: Decimal?
+
+    public init(order: CrossPayOrder, inner: ISendData, innerHandler: ISendHandler, availableBalance: Decimal?) {
+        self.order = order
+        self.inner = inner
+        self.innerHandler = innerHandler
+        self.availableBalance = availableBalance
+    }
+
+    public var feeData: FeeData? {
+        inner.feeData
+    }
+
+    public var rateCoins: [Coin] {
+        inner.rateCoins + [order.request.tokenIn.coin, order.request.tokenOut.coin]
+    }
+
+    public var amountAdjusted: Bool {
+        inner.amountAdjusted
+    }
+
+    public var canSend: Bool {
+        // Runs off committedAt, not the screen timer — the gap before the countdown starts must
+        // not hold a live slide button over an expired order.
+        inner.canSend && !inner.amountAdjusted && Date().timeIntervalSince(order.committedAt) < Self.quoteLifetime
+    }
+
+    public var customSendButtonTitle: String? {
+        inner.customSendButtonTitle
+    }
+
+    public func cautions(baseToken: Token, currency: Currency, rates: [String: Decimal]) -> [CautionNew] {
+        // The number the user needs is the DEPOSIT — one caution naming it replaces the inner
+        // handler's generic refusal.
+        if let availableBalance, order.depositAmount > availableBalance {
+            return [CautionNew(
+                title: "fee_settings.errors.insufficient_balance".localized,
+                text: "cross_pay.caution.insufficient_balance %@".localized(Self.formatted(amount: order.depositAmount, token: order.request.tokenIn)),
+                type: .error
+            )]
+        }
+
+        var cautions = inner.cautions(baseToken: baseToken, currency: currency, rates: rates)
+
+        if order.minSellAmount == nil {
+            // Without the floor the refundable buffer is unknown, so You Pay is an upper estimate.
+            cautions.append(CautionNew(
+                title: "cross_pay.you_pay".localized,
+                text: "private_send.caution.buffer_unknown".localized,
+                type: .warning
+            ))
+        }
+
+        return cautions
+    }
+
+    public func sections(baseToken: Token, currency: Currency, rates: [String: Decimal]) -> [SendDataSection] {
+        let tokenIn = order.request.tokenIn
+        let tokenOut = order.request.tokenOut
+        let rateIn = rates[tokenIn.coin.uid]
+        let rateOut = rates[tokenOut.coin.uid]
+
+        let amount = SendField.amount(
+            token: tokenOut,
+            appValueType: .regular(appValue: AppValue(token: tokenOut, value: order.amountOut)),
+            currencyValue: rateOut.map { CurrencyValue(currency: currency, value: $0 * order.amountOut) }
+        )
+
+        let to = SendField.address(
+            value: order.request.recipient,
+            blockchainType: tokenOut.blockchainType
+        )
+
+        var fields = [SendField]()
+
+        if let estimatedTime = order.estimatedTime {
+            fields.append(.simpleValue(
+                title: "private_send.estimated_time".localized,
+                value: Duration.seconds(estimatedTime).formatted(.units(allowed: [.hours, .minutes, .seconds], width: .narrow))
+            ))
+        }
+
+        fields.append(feeField(
+            title: "cross_pay.you_pay".localized,
+            info: InfoDescription(title: "cross_pay.you_pay".localized, description: "cross_pay.you_pay.info".localized),
+            value: order.depositAmount,
+            token: tokenIn,
+            currency: currency,
+            rate: rateIn
+        ))
+
+        if let buffer = order.refundableBuffer, buffer > 0 {
+            fields.append(feeField(
+                title: "private_send.reserved_amount".localized,
+                info: InfoDescription(title: "private_send.reserved_amount".localized, description: "private_send.reserved_amount.info".localized),
+                value: buffer,
+                token: tokenIn,
+                currency: currency,
+                rate: rateIn
+            ))
+        }
+
+        // The inner handler's own rows, in the FEE token — never summed with the rows above.
+        fields.append(contentsOf: inner.feeFields(baseToken: baseToken, currency: currency, rates: rates))
+
+        return [.init([amount, to], isFlow: true), .init(fields, isMain: false)]
+    }
+
+    private func feeField(title: String, info: InfoDescription, value: Decimal, token: Token, currency: Currency, rate: Decimal?) -> SendField {
+        .fee(
+            title: ComponentInformedTitle(title, info: info),
+            amountData: .init(
+                appValue: AppValue(token: token, value: value),
+                currencyValue: rate.map { CurrencyValue(currency: currency, value: $0 * value) }
+            )
+        )
+    }
+
+    private static func formatted(amount: Decimal, token: Token) -> String {
+        let figure = ValueFormatter.instance.formatFull(value: amount, decimalCount: token.decimals) ?? "\(amount)"
+        return "\(figure) \(token.coin.code)"
+    }
+}

--- a/packages/WalletCore/Sources/WalletCore/Modules/CrossPay/CrossPayHandler.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/CrossPay/CrossPayHandler.swift
@@ -1,0 +1,267 @@
+import Combine
+import Foundation
+import MarketKit
+
+// Deliberate copy of PrivateSendHandler's orchestration — it is final, typed to PrivateSendOrder,
+// and the concurrency-critical parts must not drift under a shared abstraction.
+final class CrossPayHandler {
+    typealias DataBuilder = (CrossPayOrder, ISendData, ISendHandler, Decimal?) -> CrossPayData
+
+    let baseToken: Token
+
+    private let request: CrossPayRequest
+    private let preSendHandler: IPreSendHandler
+    private let service: CrossPayService
+    private let swapHistoryManager: SwapHistoryManager
+    private let accountManager: AccountManager
+    private let dataBuilder: DataBuilder
+
+    private let stateLock = NSLock()
+    private var commitTask: Task<CrossPayOrder, Error>?
+    private var commitGeneration = 0
+    // A refresh racing a re-sync gives two concurrent sendData calls; only the newest may publish
+    // its inner handler.
+    private var syncGeneration = 0
+    private var innerHandler: ISendHandler?
+
+    // Re-entrancy guard: the same deposit must never be sent twice.
+    private var isSending = false
+
+    // A retried broadcast reuses the row it failed on; only a new order starts a new row.
+    private var savedRecordUids = [String: String]()
+
+    init(
+        request: CrossPayRequest,
+        baseToken: Token,
+        preSendHandler: IPreSendHandler,
+        service: CrossPayService,
+        swapHistoryManager: SwapHistoryManager,
+        accountManager: AccountManager,
+        dataBuilder: @escaping DataBuilder = { CrossPayData(order: $0, inner: $1, innerHandler: $2, availableBalance: $3) }
+    ) {
+        self.request = request
+        self.baseToken = baseToken
+        self.preSendHandler = preSendHandler
+        self.service = service
+        self.swapHistoryManager = swapHistoryManager
+        self.accountManager = accountManager
+        self.dataBuilder = dataBuilder
+    }
+}
+
+extension CrossPayHandler: ISendHandler {
+    var syncingText: String? { nil }
+
+    // Past the order's lifetime the screen offers Refresh, which commits a fresh order.
+    var expirationDuration: Int? { Int(CrossPayData.quoteLifetime) }
+    var autoRefreshEnabled: Bool { false }
+
+    var initialTransactionSettings: InitialTransactionSettings? { nil }
+
+    // No inner handler until the first sendData commits; SendView re-reads this on every render.
+    var menuItems: [SendMenuItem] {
+        withLock { self.innerHandler }?.menuItems ?? []
+    }
+
+    var refreshPublisher: AnyPublisher<Void, Never>? { nil }
+
+    func sendData(transactionSettings: TransactionSettings?) async throws -> ISendData {
+        let generation = withLock { () -> Int in
+            self.syncGeneration += 1
+            return self.syncGeneration
+        }
+
+        let order = try await committedOrder()
+
+        try Task.checkCancellation()
+
+        // Re-evaluated here: the deposit address only exists after the commit.
+        let memoText: String?
+
+        switch order.attachment {
+        case .none:
+            memoText = nil
+        case let .some(.text(value)):
+            // A deposit the provider cannot match by memo is typically unrecoverable — an
+            // undeliverable memo fails rather than being dropped.
+            guard preSendHandler.memoType(address: order.depositAddress).deliversAttachment else {
+                throw CrossPayError.commitFailed
+            }
+            memoText = value
+        case .some:
+            // No send path carries an unknown attachment kind.
+            throw CrossPayError.commitFailed
+        }
+
+        // The deposit, never the entered amount — different quantities in different tokens.
+        let result = preSendHandler.sendData(
+            amount: order.depositAmount,
+            address: order.depositAddress,
+            memo: memoText
+        )
+
+        guard case let .valid(innerSendData) = result else {
+            throw CrossPayError.commitFailed
+        }
+
+        guard let innerHandler = SendHandlerFactory.handler(sendData: innerSendData) else {
+            throw CrossPayError.commitFailed
+        }
+
+        // An auto-reduced deposit could drop below minSellAmount: refunded whole, recipient gets nothing.
+        (innerHandler as? IAmountAdjustingSendHandler)?.allowsAmountAdjustment = false
+
+        try Task.checkCancellation()
+
+        // Only the newest call publishes its handler.
+        let current = withLock { () -> Bool in
+            guard self.syncGeneration == generation else { return false }
+            self.innerHandler = innerHandler
+            return true
+        }
+
+        guard current else { throw CancellationError() }
+
+        let inner = try await innerHandler.sendData(transactionSettings: transactionSettings)
+
+        try Task.checkCancellation()
+
+        // Re-checked after the await: stale CrossPayData must never reach SendViewModel.
+        guard withLock({ self.syncGeneration == generation }) else { throw CancellationError() }
+
+        // The handler travels WITH its data so send(data:) broadcasts through the one that estimated it.
+        return dataBuilder(order, inner, innerHandler, preSendHandler.balance)
+    }
+
+    func send(data: ISendData) async throws {
+        let alreadySending = withLock { () -> Bool in
+            if self.isSending { return true }
+            self.isSending = true
+            return false
+        }
+
+        guard !alreadySending else { throw CrossPayError.commitFailed }
+        defer { withLock { self.isSending = false } }
+
+        guard let data = data as? CrossPayData else { throw CrossPayError.commitFailed }
+        guard let account = accountManager.activeAccount else { throw CrossPayError.commitFailed }
+
+        // Read off the confirmed data, never off `self` — the triple is indivisible.
+        let order = data.order
+        let innerHandler = data.innerHandler
+
+        // Pre-saved so the record survives the app dying mid-broadcast; a failed retry reuses its row.
+        let uid: String
+        let previousUid = withLock { savedRecordUids[order.providerSwapId] }
+
+        if let previousUid, swapHistoryManager.retryFailed(trackingHandle: previousUid) {
+            uid = previousUid
+        } else {
+            uid = UUID().uuidString
+            withLock { savedRecordUids[order.providerSwapId] = uid }
+
+            swapHistoryManager.save(swap: Swap(
+                uid: uid,
+                txHash: nil,
+                trackingHandle: uid,
+                accountId: account.id,
+                providerId: order.providerId,
+                status: .notStarted,
+                tokenIn: order.request.tokenIn,
+                tokenOut: order.request.tokenOut,
+                amountIn: order.depositAmount,
+                amountOut: order.amountOut,
+                recipient: order.request.recipient,
+                toAddress: order.request.recipient,
+                depositAddress: order.depositAddress,
+                providerSwapId: order.providerSwapId,
+                sourceAddress: nil,
+                refundAddress: order.refundAddress,
+                date: Date()
+            ))
+        }
+
+        let ref: String?
+
+        do {
+            if let capturing = innerHandler as? ISendHandlerRefCapturing {
+                ref = try await capturing.sendCapturingRef(data: data.inner)
+            } else {
+                try await innerHandler.send(data: data.inner)
+                ref = nil
+            }
+        } catch {
+            swapHistoryManager.markFailed(trackingHandle: uid)
+            throw error
+        }
+
+        // Empty ref = "submitted, id unknown" (Zcash resubmit path) — fall back to provider tracking.
+        if let ref, !ref.isEmpty {
+            swapHistoryManager.resolve(trackingHandle: uid, txHash: ref)
+        } else {
+            swapHistoryManager.beginProviderTracking(trackingHandle: uid)
+        }
+
+        // Saved under the DESTINATION chain; the generic save would key on baseToken (ZEC).
+        try? Core.shared.recentAddressStorage.save(
+            address: order.request.recipient,
+            blockchainUid: order.request.tokenOut.blockchainType.uid
+        )
+
+        // No wallet auto-add for tokenOut: paying a third party enables nothing for this account.
+    }
+}
+
+private extension CrossPayHandler {
+    func withLock<T>(_ action: () -> T) -> T {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return action()
+    }
+
+    // Memoised while the order is alive — each /v2/swap creates a REAL order, so concurrent callers
+    // await one task. An expired order is discarded and re-committed.
+    func committedOrder() async throws -> CrossPayOrder {
+        // Terminates: a fresh task returns an order stamped with a fresh committedAt.
+        while true {
+            let pending: (task: Task<CrossPayOrder, Error>, generation: Int) = withLock {
+                if let commitTask = self.commitTask {
+                    return (commitTask, self.commitGeneration)
+                }
+
+                self.commitGeneration += 1
+                let generation = self.commitGeneration
+                let request = self.request
+                let service = self.service
+                let task = Task { try await service.commit(request: request) }
+                self.commitTask = task
+
+                return (task, generation)
+            }
+
+            let order: CrossPayOrder
+
+            do {
+                order = try await pending.task.value
+            } catch {
+                // A failed commit created no order — clear the memo (if still ours) so refresh can retry.
+                withLock {
+                    if self.commitGeneration == pending.generation {
+                        self.commitTask = nil
+                    }
+                }
+                throw error
+            }
+
+            if Date().timeIntervalSince(order.committedAt) < CrossPayData.quoteLifetime {
+                return order
+            }
+
+            withLock {
+                if self.commitGeneration == pending.generation {
+                    self.commitTask = nil
+                }
+            }
+        }
+    }
+}

--- a/packages/WalletCore/Sources/WalletCore/Modules/CrossPay/CrossPayHandlerProvider.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/CrossPay/CrossPayHandlerProvider.swift
@@ -1,0 +1,30 @@
+import Foundation
+import MarketKit
+
+// Resolves an IPreSendHandler for the FUNDING token: there is no inner SendData until the commit.
+public final class CrossPayHandlerProvider: SendHandler {
+    override public class func instance(sendData: SendData) -> ISendHandler? {
+        guard case let .crossPay(request) = sendData else { return nil }
+        guard let service = Core.crossPayService else { return nil }
+        guard let account = Core.shared.accountManager.activeAccount else { return nil }
+        guard let baseToken = PrivateSendHandlerProvider.baseToken(token: request.tokenIn) else { return nil }
+
+        let wallet = Wallet(token: request.tokenIn, account: account)
+
+        // Placeholder for handler resolution only — the real destination is the deposit address,
+        // which does not exist yet.
+        guard let preSendHandler = SendHandlerFactory.preSendHandler(
+            wallet: wallet,
+            address: ResolvedAddress(address: request.recipient, issueTypes: [])
+        ) else { return nil }
+
+        return CrossPayHandler(
+            request: request,
+            baseToken: baseToken,
+            preSendHandler: preSendHandler,
+            service: service,
+            swapHistoryManager: Core.shared.swapHistoryManager,
+            accountManager: Core.shared.accountManager
+        )
+    }
+}

--- a/packages/WalletCore/Sources/WalletCore/Modules/CrossPay/CrossPayModels.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/CrossPay/CrossPayModels.swift
@@ -1,0 +1,107 @@
+import Foundation
+import MarketKit
+
+// What the `.crossPay` SendData case carries: deposit address and ZEC amount don't exist until commit.
+public struct CrossPayRequest {
+    public let tokenIn: Token // the funding token (ZEC)
+    public let tokenOut: Token // what the recipient receives
+    public let recipient: String // the REAL recipient on tokenOut's chain, never a deposit address
+    public let amount: Decimal // exact output — the amount of tokenOut the recipient receives
+
+    public init(tokenIn: Token, tokenOut: Token, recipient: String, amount: Decimal) {
+        self.tokenIn = tokenIn
+        self.tokenOut = tokenOut
+        self.recipient = recipient
+        self.amount = amount
+    }
+}
+
+// The committed order, produced by /v2/swap inside the handler on the confirmation screen.
+public struct CrossPayOrder {
+    public let request: CrossPayRequest
+    public let depositAmount: Decimal // execution.amount in tokenIn — EXACTLY what to transfer
+    public let minSellAmount: Decimal? // below it the deposit is refunded and no swap happens
+    public let amountOut: Decimal // what the recipient gets; == request.amount by the exactness check
+    public let providerId: String // tracking only — never shown in the UI
+    public let depositAddress: String
+    public let attachment: USwapMultiSwapApi.Attachment?
+    public let providerSwapId: String
+    public let refundAddress: String // non-optional: the buffer refund lands here
+    public let estimatedTime: TimeInterval?
+    public let committedAt: Date
+
+    public init(
+        request: CrossPayRequest,
+        depositAmount: Decimal,
+        minSellAmount: Decimal?,
+        amountOut: Decimal,
+        providerId: String,
+        depositAddress: String,
+        attachment: USwapMultiSwapApi.Attachment?,
+        providerSwapId: String,
+        refundAddress: String,
+        estimatedTime: TimeInterval?,
+        committedAt: Date
+    ) {
+        self.request = request
+        self.depositAmount = depositAmount
+        self.minSellAmount = minSellAmount
+        self.amountOut = amountOut
+        self.providerId = providerId
+        self.depositAddress = depositAddress
+        self.attachment = attachment
+        self.providerSwapId = providerSwapId
+        self.refundAddress = refundAddress
+        self.estimatedTime = estimatedTime
+        self.committedAt = committedAt
+    }
+
+    // No cross-asset fee figure: subtracting a tokenOut quantity from a tokenIn one is meaningless.
+    public var refundableBuffer: Decimal? {
+        minSellAmount.map { max(0, depositAmount - $0) }
+    }
+}
+
+// Raw server text never leaves the service. Min/max figures are in the DESTINATION token — the
+// amount field the user can act on.
+public enum CrossPayError: Error {
+    case tokenUnsupported
+    case belowMinimum(amount: Decimal, token: Token)
+    case aboveMaximum(amount: Decimal, token: Token)
+    case noRoute
+    case providerSuspended
+    case networkError(Error)
+    case commitFailed
+}
+
+extension CrossPayError: UserFacingError {
+    public var errorDescription: String? {
+        switch self {
+        case .tokenUnsupported:
+            return "cross_pay.error.token_unsupported".localized
+        case let .belowMinimum(amount, token):
+            return "cross_pay.error.below_minimum %@".localized(Self.formatted(amount: amount, token: token))
+        case let .aboveMaximum(amount, token):
+            return "cross_pay.error.above_maximum %@".localized(Self.formatted(amount: amount, token: token))
+        case .noRoute:
+            return "cross_pay.error.no_route".localized
+        case .providerSuspended:
+            return "cross_pay.error.provider_suspended".localized
+        case .networkError:
+            // Not surfaced: transport errors name hosts and provider ids.
+            return "cross_pay.error.network".localized
+        case .commitFailed:
+            // One message for the whole commit-side taxonomy — internals would not help the user act.
+            return "cross_pay.error.commit_failed".localized
+        }
+    }
+
+    public var failureReason: String? {
+        "cross_pay.unavailable".localized
+    }
+
+    private static func formatted(amount: Decimal, token: Token) -> String {
+        let figure = ValueFormatter.instance.formatFull(value: amount, decimalCount: token.decimals) ?? "\(amount)"
+        return "\(figure) \(token.coin.code)"
+    }
+}

--- a/packages/WalletCore/Sources/WalletCore/Modules/CrossPay/CrossPayService.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/CrossPay/CrossPayService.swift
@@ -1,0 +1,235 @@
+import Combine
+import Foundation
+import HsToolKit
+import MarketKit
+
+// /v2/swap in cross-asset exact-output mode; execution is a plain transfer to a deposit address.
+// Every /v2/swap creates a REAL order, so the entry screen's rate is display-only.
+public final class CrossPayService {
+    public static let providerId = "NEAR"
+
+    private let api: USwapMultiSwapApi
+    // A factory, as in PrivateSendService: the repository (and its first /v2/tokens fetch) is only
+    // created when the CrossPay screen actually asks for it.
+    private let assetRepository: (String) -> USwapAssetRepository
+    private let commitRequestBuilder: USwapCommitRequestBuilder
+
+    public init(
+        api: USwapMultiSwapApi,
+        assetRepository: @escaping (String) -> USwapAssetRepository,
+        commitRequestBuilder: USwapCommitRequestBuilder
+    ) {
+        self.api = api
+        self.assetRepository = assetRepository
+        self.commitRequestBuilder = commitRequestBuilder
+    }
+
+    // Reads only the already-synced asset map, never triggers a fetch: unsynced = "not supported yet".
+    public func supports(tokenIn: Token, tokenOut: Token) -> Bool {
+        supports(token: tokenIn) && supports(token: tokenOut)
+    }
+
+    // Also the entry screen's "has the asset map landed" probe: ZEC is always in the provider's map.
+    public func supports(token: Token) -> Bool {
+        assetRepository(Self.providerId).asset(token: token) != nil
+    }
+
+    public func syncAssets() {
+        assetRepository(Self.providerId).sync()
+    }
+
+    public var assetsSyncPublisher: AnyPublisher<Void, Never> {
+        assetRepository(Self.providerId).syncPublisher
+    }
+
+    // Display-only: what the sender pays in tokenIn for the entered exact output. Never funded —
+    // the confirmation commits its own order.
+    public func quote(tokenIn: Token, tokenOut: Token, amountOut: Decimal) async throws -> Decimal {
+        let repository = assetRepository(Self.providerId)
+
+        guard let sellAsset = repository.asset(token: tokenIn),
+              let buyAsset = repository.asset(token: tokenOut)
+        else {
+            throw CrossPayError.tokenUnsupported
+        }
+
+        let request = USwapMultiSwapApi.RateRequest(
+            sellAsset: sellAsset,
+            buyAsset: buyAsset,
+            amount: .buy(amountOut),
+            slippage: MultiSwapSlippage.default,
+            chainId: commitRequestBuilder.chainId(token: tokenIn),
+            providerIds: [Self.providerId]
+        )
+
+        let result: USwapMultiSwapApi.RateResult
+
+        do {
+            result = try await api.rate(request)
+        } catch {
+            throw Self.error(networkError: error, tokenOut: tokenOut)
+        }
+
+        // Every route delivers the identical requested output, so the cheapest deposit wins.
+        let sellAmounts = result.quotes.compactMap(\.sellAmount)
+
+        guard let sellAmount = sellAmounts.min() else {
+            throw Self.error(providerErrors: result.providerErrors, tokenOut: tokenOut) ?? .noRoute
+        }
+
+        return sellAmount
+    }
+
+    // Throws CrossPayError only. NO rate-quote fallbacks: minSellAmount and amountOut come from
+    // the /v2/swap response alone.
+    public func commit(request: CrossPayRequest) async throws -> CrossPayOrder {
+        let repository = assetRepository(Self.providerId)
+
+        guard let sellAsset = repository.asset(token: request.tokenIn),
+              let buyAsset = repository.asset(token: request.tokenOut)
+        else {
+            throw CrossPayError.tokenUnsupported
+        }
+
+        // The buffer refund lands on the success path too, so a missing address fails the commit.
+        // ZEC → unified (CrossPay-only, Android parity): a transparent refund links shielded and
+        // transparent activity.
+        let refundAddress: String?
+        do {
+            if request.tokenIn.blockchainType == .zcash {
+                refundAddress = try await DestinationHelper.resolveDestinationUnified(token: request.tokenIn).address
+            } else {
+                refundAddress = try await commitRequestBuilder.refundAddress(token: request.tokenIn)
+            }
+        } catch {
+            throw CrossPayError.commitFailed
+        }
+
+        guard let refundAddress, !refundAddress.isEmpty else {
+            throw CrossPayError.commitFailed
+        }
+
+        let swapRequest = USwapMultiSwapApi.SwapRequest(
+            sellAsset: sellAsset,
+            buyAsset: buyAsset,
+            amount: .buy(request.amount),
+            slippage: MultiSwapSlippage.default,
+            chainId: commitRequestBuilder.chainId(token: request.tokenIn),
+            providerId: Self.providerId,
+            destinationAddress: request.recipient,
+            // Omitted: the app builds the transfer itself, the provider has no use for it.
+            sourceAddress: nil,
+            refundAddress: refundAddress
+        )
+
+        let response: USwapMultiSwapApi.SwapResponse
+
+        do {
+            response = try await api.swap(swapRequest)
+        } catch {
+            throw Self.error(networkError: error, tokenOut: request.tokenOut)
+        }
+
+        guard let uuid = response.uuid, !uuid.isEmpty else {
+            throw CrossPayError.commitFailed
+        }
+
+        // Only a plain-transfer route may proceed — other kinds need real transaction building.
+        guard let execution = response.execution, case let .transfer(chain, depositAddress, amount, attachment, _) = execution else {
+            throw CrossPayError.commitFailed
+        }
+
+        // `execution.chain` is a chain id ("56") or name ("bsc"): only a recognised chain that
+        // resolves to a DIFFERENT blockchain is a mismatch.
+        if let executionBlockchainType = USwapAssetRepository.blockchainTypeMap[chain], executionBlockchainType != request.tokenIn.blockchainType {
+            throw CrossPayError.commitFailed
+        }
+
+        guard let depositAmount = amount else {
+            throw CrossPayError.commitFailed
+        }
+
+        let minSellAmount = response.minSellAmount
+
+        // A deposit below the floor is refunded whole and no swap happens.
+        if let minSellAmount, depositAmount < minSellAmount {
+            throw CrossPayError.commitFailed
+        }
+
+        // Never the entered amount: that's the requested output, not what the provider promised.
+        let amountOut = response.expectedBuyAmount
+
+        guard amountOut > 0 else {
+            throw CrossPayError.commitFailed
+        }
+
+        // Exact output: a re-priced amount would silently pay the recipient something else.
+        guard amountOut == request.amount else {
+            throw CrossPayError.commitFailed
+        }
+
+        // An undeliverable attachment fails once here at commit, not on every build re-entry.
+        do {
+            _ = try USwapMultiSwapApi.Attachment.memo(attachment, memoType: request.tokenIn.blockchainType.memoType)
+        } catch {
+            throw CrossPayError.commitFailed
+        }
+
+        return CrossPayOrder(
+            request: request,
+            depositAmount: depositAmount,
+            minSellAmount: minSellAmount,
+            amountOut: amountOut,
+            providerId: Self.providerId,
+            depositAddress: depositAddress,
+            attachment: attachment,
+            providerSwapId: uuid,
+            refundAddress: refundAddress,
+            estimatedTime: response.estimatedTime,
+            committedAt: Date()
+        )
+    }
+}
+
+private extension CrossPayService {
+    static func error(providerErrors: [USwapMultiSwapApi.ProviderError], tokenOut: Token) -> CrossPayError? {
+        let outOfRange = providerErrors.filter { $0.errorCode == "amountOutOfRange" }
+
+        if let minimum = outOfRange.compactMap(\.minimumAmount).min() {
+            return .belowMinimum(amount: minimum, token: tokenOut)
+        }
+
+        if let maximum = outOfRange.compactMap(\.maximumAmount).max() {
+            return .aboveMaximum(amount: maximum, token: tokenOut)
+        }
+
+        let routeLevelCodes: Set<String> = ["amountOutOfRange", "routeNotFound"]
+        let recognised = providerErrors.contains { providerError in providerError.errorCode.map(routeLevelCodes.contains) ?? false }
+
+        return recognised ? .noRoute : nil
+    }
+
+    static func error(networkError: Error, tokenOut: Token) -> CrossPayError {
+        guard let responseError = networkError as? NetworkManager.ResponseError else {
+            return .networkError(networkError)
+        }
+
+        if responseError.statusCode == 503 {
+            return .providerSuspended
+        }
+
+        // A failed /v2/swap carries the provider error as its body, same fields as /v2/rate's
+        // `providerErrors`; only the parsed fields are read.
+        if let providerError = USwapMultiSwapApi.providerError(networkError: networkError),
+           let reason = error(providerErrors: [providerError], tokenOut: tokenOut)
+        {
+            return reason
+        }
+
+        if responseError.statusCode == 404 {
+            return .noRoute
+        }
+
+        return .networkError(networkError)
+    }
+}

--- a/packages/WalletCore/Sources/WalletCore/Modules/CrossPay/CrossPayView.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/CrossPay/CrossPayView.swift
@@ -1,0 +1,197 @@
+import MarketKit
+import SwiftUI
+
+// CrossPay entry screen (ZEC token page → Pay): recipient token/address/exact amount, live ZEC
+// cost, then review — the confirmation screen commits the real order.
+struct CrossPayView: View {
+    @StateObject private var viewModel: CrossPayViewModel
+    @Binding var isPresented: Bool
+
+    private var addressBorderColor: Color {
+        viewModel.recipientResult.isInvalid ? .themeLucian : .themeBlade
+    }
+
+    init(wallet: Wallet, isPresented: Binding<Bool>) {
+        _viewModel = StateObject(wrappedValue: CrossPayViewModel(wallet: wallet))
+        _isPresented = isPresented
+    }
+
+    var body: some View {
+        ThemeNavigationStack {
+            ThemeView {
+                BottomGradientWrapper {
+                    ScrollView {
+                        VStack(spacing: .margin16) {
+                            balanceView()
+                            tokenView()
+
+                            if let tokenOut = viewModel.tokenOut {
+                                addressView(tokenOut: tokenOut)
+                                amountView()
+                                quoteView()
+                            }
+                        }
+                        .padding(EdgeInsets(top: .margin12, leading: .margin16, bottom: .margin32, trailing: .margin16))
+                    }
+                } bottomContent: {
+                    ThemeButton(text: "cross_pay.review".localized) {
+                        if let request = viewModel.reviewRequest {
+                            presentConfirmation(request: request)
+                        }
+                    }
+                    .disabled(!viewModel.canReview)
+                }
+            }
+            .navigationTitle("cross_pay.title".localized)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(action: {
+                        isPresented = false
+                    }) {
+                        Image("close")
+                    }
+                }
+            }
+        }
+    }
+
+    private func presentTokenSelect() {
+        Coordinator.shared.present { isPresented in
+            MultiSwapTokenSelectView(
+                title: "cross_pay.send_to".localized,
+                currentToken: $viewModel.selectedTokenOut,
+                otherToken: viewModel.tokenIn,
+                allowExternalReceive: true,
+                isPresented: isPresented
+            )
+        }
+    }
+
+    private func presentConfirmation(request: CrossPayRequest) {
+        Coordinator.shared.present { confirmPresented in
+            RegularSendViewWrapper(
+                sendData: .crossPay(request: request),
+                // nil: the handler saves the recipient under the destination chain itself.
+                address: nil,
+                isPresented: confirmPresented,
+                onSuccess: {
+                    HudHelper.instance.show(banner: .sent)
+                    isPresented = false
+                }
+            )
+        }
+    }
+
+    @ViewBuilder private func balanceView() -> some View {
+        ListSection {
+            Cell(
+                middle: {
+                    MiddleTextIcon(text: "send.available_balance".localized)
+                },
+                right: {
+                    RightTextIcon(text: balanceText)
+                }
+            )
+        }
+    }
+
+    private var balanceText: String {
+        guard let balance = viewModel.availableBalance else { return "n/a".localized }
+        return formatted(amount: balance, token: viewModel.tokenIn)
+    }
+
+    @ViewBuilder private func tokenView() -> some View {
+        ListSection {
+            ClickableRow {
+                presentTokenSelect()
+            } content: {
+                Text("cross_pay.send_to".localized).textSubhead2()
+
+                Spacer()
+
+                if let tokenOut = viewModel.tokenOut {
+                    Text(tokenOut.coin.code).textSubhead2(color: .themeLeah)
+                } else {
+                    Text("cross_pay.select_token".localized).textSubhead2()
+                }
+
+                Image("arrow_small_down_20").themeIcon()
+            }
+        }
+    }
+
+    @ViewBuilder private func addressView(tokenOut: Token) -> some View {
+        AddressViewNew(
+            initial: .init(blockchainType: tokenOut.blockchainType, showContacts: true),
+            text: $viewModel.recipientText,
+            result: $viewModel.recipientResult,
+            parserFilter: nil,
+            borderColor: Binding(get: { addressBorderColor }, set: { _ in })
+        )
+        // Re-created per target token: the parser chain is built once at init.
+        .id(tokenOut.tokenQuery.id)
+    }
+
+    @ViewBuilder private func amountView() -> some View {
+        VStack(spacing: 3) {
+            TextField("", text: $viewModel.amountString, prompt: Text("0").foregroundColor(.themeGray))
+                .foregroundColor(.themeLeah)
+                .font(.themeHeadline1)
+                .tint(.themeInputFieldTintColor)
+                .keyboardType(.decimalPad)
+
+            if let coinPrice = viewModel.coinPrice {
+                HStack(spacing: 0) {
+                    Text(viewModel.currency.symbol).textBody(color: .themeGray)
+
+                    TextField("", text: $viewModel.fiatAmountString, prompt: Text("0").foregroundColor(.themeGray))
+                        .foregroundColor(.themeGray)
+                        .font(.themeBody)
+                        .tint(.themeInputFieldTintColor)
+                        .keyboardType(.decimalPad)
+                        .frame(height: 20)
+                        .disabled(coinPrice.expired)
+                }
+            } else {
+                Text("swap.rate_not_available".localized)
+                    .themeSubhead2(color: .themeGray50, alignment: .leading)
+                    .frame(height: 20)
+            }
+        }
+        .padding(.horizontal, .margin16)
+        .padding(.vertical, 20)
+        .modifier(ThemeListStyleModifier(themeListStyle: .borderedLawrence))
+    }
+
+    @ViewBuilder private func quoteView() -> some View {
+        switch viewModel.quoteState {
+        case .none:
+            EmptyView()
+        case .loading:
+            HStack {
+                ProgressView()
+                Spacer()
+            }
+        case let .success(sellAmount):
+            let insufficient = viewModel.availableBalance.map { sellAmount > $0 } ?? false
+
+            HStack {
+                Text("cross_pay.you_pay".localized).textSubhead2()
+                Spacer()
+                Text(formatted(amount: sellAmount, token: viewModel.tokenIn))
+                    .textSubhead2(color: insufficient ? .themeLucian : .themeLeah)
+            }
+            .padding(.horizontal, .margin16)
+        case let .error(error):
+            Text(error.errorDescription ?? "cross_pay.error.commit_failed".localized)
+                .themeSubhead2(color: .themeLucian, alignment: .leading)
+                .padding(.horizontal, .margin16)
+        }
+    }
+
+    private func formatted(amount: Decimal, token: Token) -> String {
+        let figure = ValueFormatter.instance.formatFull(value: amount, decimalCount: token.decimals) ?? "\(amount)"
+        return "\(figure) \(token.coin.code)"
+    }
+}

--- a/packages/WalletCore/Sources/WalletCore/Modules/CrossPay/CrossPayViewModel.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/CrossPay/CrossPayViewModel.swift
@@ -1,0 +1,230 @@
+import Combine
+import Foundation
+import MarketKit
+import SwiftUI
+
+// Entry screen state: recipient token/address/EXACT amount, priced live. The quote is display-only —
+// the confirmation step commits its own order.
+final class CrossPayViewModel: ObservableObject {
+    private static let quoteDebounce: TimeInterval = 0.5
+
+    let wallet: Wallet
+    let currency: Currency
+
+    private let service: CrossPayService?
+    private let marketKit = Core.shared.marketKit
+    private let currencyManager = Core.shared.currencyManager
+    private var cancellables = Set<AnyCancellable>()
+    private var priceCancellable: AnyCancellable?
+    private var quoteTask: Task<Void, Never>?
+
+    var tokenIn: Token { wallet.token }
+
+    let availableBalance: Decimal?
+
+    @Published private(set) var tokenOut: Token?
+    // Sheet binding for the token selector; the reset logic runs once in onSelect.
+    @Published var selectedTokenOut: Token? {
+        didSet {
+            if let selectedTokenOut { onSelect(tokenOut: selectedTokenOut) }
+        }
+    }
+
+    @Published var recipientText: String = ""
+    @Published var recipientResult: AddressInput.Result = .idle
+
+    // Amount/fiat mirror as in PreSendViewModel; the amount is entered in the TARGET token.
+    @Published private(set) var amount: Decimal? {
+        didSet {
+            if oldValue != amount {
+                let string = AmountDecimalParser.string(from: amount)
+                if AmountDecimalParser.parseAnyDecimal(from: amountString) != amount {
+                    amountString = string
+                }
+                syncFiatAmount()
+                scheduleQuote()
+            }
+        }
+    }
+
+    @Published var amountString: String = "" {
+        didSet {
+            var parsed = AmountDecimalParser.parseAnyDecimal(from: amountString)
+            if parsed == 0 { parsed = nil }
+
+            // Rounded DOWN to the target token's precision: an over-precise value could never pass
+            // the strict exactness check at commit.
+            let rounded = parsed.flatMap { value in tokenOut.map { value.roundedDown(decimal: $0.decimals) } } ?? parsed
+
+            guard rounded != amount else { return }
+
+            enteringFiat = false
+            amount = rounded
+        }
+    }
+
+    @Published var fiatAmount: Decimal? {
+        didSet {
+            let string = AmountDecimalParser.string(from: fiatAmount)
+            if AmountDecimalParser.parseAnyDecimal(from: fiatAmountString)?.rounded(decimal: 2) != fiatAmount {
+                fiatAmountString = string
+            }
+            syncAmount()
+        }
+    }
+
+    @Published var fiatAmountString: String = "" {
+        didSet {
+            let parsed = AmountDecimalParser.parseAnyDecimal(from: fiatAmountString)?.rounded(decimal: 2)
+
+            guard parsed != fiatAmount else { return }
+
+            enteringFiat = true
+            fiatAmount = parsed
+        }
+    }
+
+    @Published private(set) var coinPrice: CoinPrice? {
+        didSet {
+            syncFiatAmount()
+        }
+    }
+
+    private var enteringFiat = false
+
+    @Published private(set) var quoteState: QuoteState?
+
+    init(wallet: Wallet) {
+        self.wallet = wallet
+        // The Pay button is gated on the service being wired; nil degrades to "token unsupported".
+        service = Core.crossPayService
+        currency = Core.shared.currencyManager.baseCurrency
+        availableBalance = (Core.shared.adapterManager.adapter(for: wallet.token) as? IBalanceAdapter)?.balanceData.available
+
+        // Until the token map lands, any pending quote stays in Loading via the re-schedule below.
+        service?.syncAssets()
+        service?.assetsSyncPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in self?.scheduleQuote() }
+            .store(in: &cancellables)
+    }
+
+    var canReview: Bool {
+        guard case .valid = recipientResult, case .success = quoteState else { return false }
+        return true
+    }
+
+    var reviewRequest: CrossPayRequest? {
+        guard let tokenOut, let amount, case let .valid(success) = recipientResult else { return nil }
+
+        return CrossPayRequest(
+            tokenIn: tokenIn,
+            tokenOut: tokenOut,
+            recipient: success.address.raw,
+            amount: amount
+        )
+    }
+}
+
+extension CrossPayViewModel {
+    enum QuoteState {
+        case loading
+        // What the sender pays in tokenIn for the entered exact output.
+        case success(sellAmount: Decimal)
+        case error(CrossPayError)
+    }
+}
+
+private extension CrossPayViewModel {
+    func onSelect(tokenOut token: Token) {
+        guard tokenOut != token else { return }
+
+        tokenOut = token
+
+        // The amount and recipient belong to the previous token/chain — never carried over.
+        enteringFiat = false
+        amount = nil
+        recipientText = ""
+        recipientResult = .idle
+        quoteState = nil
+        quoteTask?.cancel()
+
+        coinPrice = marketKit.coinPrice(coinUid: token.coin.uid, currencyCode: currency.code)
+        priceCancellable = marketKit.coinPricePublisher(coinUid: token.coin.uid, currencyCode: currency.code)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] price in self?.coinPrice = price }
+    }
+
+    func syncAmount() {
+        guard enteringFiat else { return }
+
+        guard let coinPrice, !coinPrice.expired, coinPrice.value > 0, let fiatAmount, let tokenOut else {
+            amount = nil
+            return
+        }
+
+        amount = (fiatAmount / coinPrice.value).roundedDown(decimal: tokenOut.decimals)
+    }
+
+    func syncFiatAmount() {
+        guard !enteringFiat else { return }
+
+        guard let coinPrice, !coinPrice.expired, let amount else {
+            fiatAmount = nil
+            return
+        }
+
+        fiatAmount = (amount * coinPrice.value).rounded(decimal: 2)
+    }
+
+    func scheduleQuote() {
+        quoteTask?.cancel()
+
+        guard let tokenOut, let amount, amount > 0 else {
+            quoteState = nil
+            return
+        }
+
+        guard let service else {
+            quoteState = .error(.tokenUnsupported)
+            return
+        }
+
+        quoteState = .loading
+
+        let tokenIn = tokenIn
+
+        quoteTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(Self.quoteDebounce * 1_000_000_000))
+            guard !Task.isCancelled else { return }
+
+            // Asset map not landed yet: re-kick the sync (deduped and expiration-guarded in the
+            // repository, so a failed fetch gets retried) and stay in Loading until it publishes.
+            guard service.supports(token: tokenIn) else {
+                service.syncAssets()
+                return
+            }
+
+            let state: QuoteState
+
+            if !service.supports(tokenIn: tokenIn, tokenOut: tokenOut) {
+                state = .error(.tokenUnsupported)
+            } else {
+                do {
+                    let sellAmount = try await service.quote(tokenIn: tokenIn, tokenOut: tokenOut, amountOut: amount)
+                    state = .success(sellAmount: sellAmount)
+                } catch let error as CrossPayError {
+                    state = .error(error)
+                } catch {
+                    state = .error(.networkError(error))
+                }
+            }
+
+            guard !Task.isCancelled else { return }
+
+            await MainActor.run { [weak self] in
+                self?.quoteState = state
+            }
+        }
+    }
+}

--- a/packages/WalletCore/Sources/WalletCore/Modules/SendNew/SendData.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/SendNew/SendData.swift
@@ -39,6 +39,9 @@ public enum SendData {
     // quoting and exact-output semantics, neither the deposit address nor the amount to transfer
     // exists yet. Both are the commit's answer, so the inner send is built inside the handler.
     case privateSend(request: PrivateSendRequest)
+    // Same shape as .privateSend, for the cross-asset exact-output payment: the deposit is the
+    // commit's answer, so the inner ZEC send is built inside the handler.
+    case crossPay(request: CrossPayRequest)
 }
 
 // App-agnostic display + reporting payload attached to a merchant payment send. Carried through the

--- a/packages/WalletCore/Sources/WalletCore/Modules/SendNew/SendHandlerFactory.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/SendNew/SendHandlerFactory.swift
@@ -51,6 +51,7 @@ public enum SendHandlerFactory {
 public extension SendHandlerFactory {
     static let unstoppableHandlers: [SendHandler.Type] = [
         PrivateSendHandlerProvider.self,
+        CrossPayHandlerProvider.self,
         EvmSendHandler.self,
         BitcoinSendHandler.self,
         ZcashSendHandler.self,

--- a/packages/WalletCore/Sources/WalletCore/Modules/SendNew/ZcashSendHandler.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/SendNew/ZcashSendHandler.swift
@@ -105,6 +105,16 @@ extension ZcashSendHandler {
             [token.coin]
         }
 
+        // Protocol member (default []) so a decorating handler's data can render the ZIP-317 row.
+        func feeFields(baseToken: Token, currency: Currency, rates: [String: Decimal]) -> [SendField] {
+            UtxoSendHelper.feeFields(
+                fee: proposal?.totalFeeRequired().decimalValue.decimalValue,
+                feeToken: baseToken,
+                currency: currency,
+                feeTokenRate: rates[baseToken.coin.uid]
+            )
+        }
+
         func cautions(baseToken: Token, currency _: Currency, rates _: [String: Decimal]) -> [CautionNew] {
             var cautions = [CautionNew]()
 
@@ -159,6 +169,19 @@ extension ZcashSendHandler {
                 .init(fields + feeFields, isMain: false),
             ]
         }
+    }
+}
+
+extension ZcashSendHandler: ISendHandlerRefCapturing {
+    // Same broadcast path as `send`, returning the txid. Empty string = submitted but id unknown
+    // (resubmit path) — caller falls back to provider-side tracking.
+    func sendCapturingRef(data: ISendData) async throws -> String {
+        guard let data = data as? SendData, let proposal = data.proposal else {
+            throw SendError.invalidData
+        }
+
+        let txId = try await adapter.send(proposal: proposal, zip317MarginalFee: data.zip317MarginalFee)
+        return txId ?? ""
     }
 }
 

--- a/packages/WalletCore/Sources/WalletCore/Modules/Wallet/Token/WalletTokenTopView.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/Wallet/Token/WalletTokenTopView.swift
@@ -94,6 +94,11 @@ struct WalletTokenTopView<Content: View, Status: View>: View {
                     }
                 }
             case .chart: Coordinator.shared.presentCoinPage(coin: viewModel.wallet.coin, page: .tokenPage)
+            case .pay:
+                Coordinator.shared.present { isPresented in
+                    CrossPayView(wallet: viewModel.wallet, isPresented: isPresented)
+                }
+                stat(page: .tokenPage, event: .open(page: .crossPay))
             default: ()
             }
         }

--- a/packages/WalletCore/Sources/WalletCore/Modules/Wallet/Token/WalletTokenViewModel.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/Wallet/Token/WalletTokenViewModel.swift
@@ -57,6 +57,12 @@ public class WalletTokenViewModel: ObservableObject {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] in self?.isReachable = $0 }
             .store(in: &cancellables)
+
+        // `buttons` is computed off swapEnabled; re-render when the flag flips mid-session.
+        appStateManager.$swapEnabled
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in self?.objectWillChange.send() }
+            .store(in: &cancellables)
     }
 
     public func refresh() async {
@@ -139,9 +145,17 @@ extension WalletTokenViewModel {
     var buttons: [WalletButton] {
         if wallet.account.watchAccount {
             return []
-        } else {
-            return [.chart, .receive, .send, .swap]
         }
+
+        var buttons: [WalletButton] = [.chart, .receive, .send]
+
+        // ZEC only, behind the same gate as swapping — the flow funds the payment through the swap rail.
+        if wallet.token.blockchainType == .zcash, swapEnabled, Core.crossPayService != nil {
+            buttons.append(.pay)
+        }
+
+        buttons.append(.swap)
+        return buttons
     }
 
     var swapEnabled: Bool {

--- a/packages/WalletCore/Sources/WalletCore/Modules/Wallet/WalletButton.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/Wallet/WalletButton.swift
@@ -4,6 +4,7 @@ enum WalletButton {
     case swap
     case chart
     case scan
+    case pay
 
     var title: String {
         switch self {
@@ -12,6 +13,7 @@ enum WalletButton {
         case .swap: return "balance.swap".localized
         case .chart: return "balance.chart".localized
         case .scan: return "balance.scan".localized
+        case .pay: return "balance.pay".localized
         }
     }
 
@@ -22,6 +24,7 @@ enum WalletButton {
         case .swap: return "swap_e"
         case .chart: return "chart"
         case .scan: return "scan"
+        case .pay: return "arrow_m_right"
         }
     }
 


### PR DESCRIPTION
Pay button on the ZEC token page opens a flow that pays an exact amount of any NEAR-supported token to an external address from ZEC, via exact-output USwap routes (/v2/rate and /v2/swap with buyAmount).

The confirmation commits one order per review, sends the deposit through ZcashSendHandler and tracks it in swap history by the order uuid. Mirrors the Android implementation.

ref #7025

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cross-chain payments from supported Zcash wallet screens.
  * Select a destination token, enter a recipient and exact amount, preview quotes, fees, timing, and refundable amounts, then review and confirm.
  * Added localized labels and messages for payment states and errors.
* **Bug Fixes**
  * Failed swap transactions can now be retried without resetting completed or in-progress swaps.
  * Improved handling for unsupported tokens, unavailable routes, amount limits, provider interruptions, and network failures.
* **Improvements**
  * Zcash send reviews now display applicable network fee details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->