### PR TITLE
Disable UI stats by default, omit 100% for swap assets that pay own fees

### DIFF
--- a/packages/WalletCore/Sources/WalletCore/Core/Core.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Core.swift
@@ -581,7 +581,7 @@ public extension Core {
         let autoEnableTokensOnReceive: Bool
         let autoEnableStats: Bool
 
-        public init(autoEnableTokensOnReceive: Bool = true, autoEnableStats: Bool = true) {
+        public init(autoEnableTokensOnReceive: Bool = true, autoEnableStats: Bool = false) {
             self.autoEnableTokensOnReceive = autoEnableTokensOnReceive
             self.autoEnableStats = autoEnableStats
         }

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/MultiSwapView.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/MultiSwapView.swift
@@ -47,6 +47,7 @@ struct MultiSwapView: View {
                     AmountAccessoryView(
                         visible: isInputActive,
                         enabledPercents: (viewModel.availableBalance ?? 0) > 0,
+                        percents: viewModel.percentOptions,
                         onPercent: { percent in
                             viewModel.setAmountIn(percent: percent)
                             focusedField = nil

--- a/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/MultiSwapViewModel.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/MultiSwap/MultiSwapViewModel.swift
@@ -817,6 +817,18 @@ public extension MultiSwapViewModel {
         syncPrice()
     }
 
+    // The network fee is only estimated on the confirmation screen, so 100% of an asset that also
+    // pays its own fee always ends in an insufficient balance error — offer it only for tokens
+    // whose fee is paid with a separate native asset.
+    var percentOptions: [Int] {
+        let feePaidFromAsset: Bool
+        switch tokenIn?.type {
+        case nil, .native, .derived, .addressType, .unsupported: feePaidFromAsset = true
+        default: feePaidFromAsset = false
+        }
+        return feePaidFromAsset ? [25, 50, 75] : [25, 50, 75, 100]
+    }
+
     func setAmountIn(percent: Int) {
         guard let tokenIn, let availableBalance else {
             return

--- a/packages/WalletCore/Sources/WalletCore/UserInterface/SwiftUI/AmountAccessoryView.swift
+++ b/packages/WalletCore/Sources/WalletCore/UserInterface/SwiftUI/AmountAccessoryView.swift
@@ -5,6 +5,7 @@ struct AmountAccessoryView: View {
 
     let visible: Bool
     let enabledPercents: Bool
+    var percents: [Int] = [25, 50, 75, 100]
     let onPercent: (Int) -> Void
     let onTrash: () -> Void
 
@@ -12,9 +13,7 @@ struct AmountAccessoryView: View {
         VStack {
             HStack(spacing: 6) {
                 HStack(spacing: 12) {
-                    ForEach(1 ... 4, id: \.self) { multiplier in
-                        let percent = multiplier * 25
-
+                    ForEach(percents, id: \.self) { percent in
                         ThemeButton(text: percent == 100 ? "send.max_button".localized : "\(percent)%", style: .secondary, size: .small) {
                             onPercent(percent)
                         }


### PR DESCRIPTION
Stats are off unless the user explicitly opts in; the 100% shortcut is hidden in swap when the input asset pays its own fee.

ref #7196
ref #7201

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Multi-swap amount selectors now display percentage options based on the selected token and its network-fee configuration.
  - The 100% option is unavailable when network fees are paid from the same asset; other configurations retain 25%, 50%, 75%, and 100% options.

- **Configuration**
  - Automatic statistics collection is now disabled by default.
  - Automatic token enabling upon receipt remains enabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->