### PR TITLE
Allow explicit removal of unavailable wallet records

### DIFF
--- a/Unstoppable/Tests/Accounts/LostAccountRemovalTests.swift
+++ b/Unstoppable/Tests/Accounts/LostAccountRemovalTests.swift
@@ -1,0 +1,182 @@
+import Foundation
+import GRDB
+import Testing
+@testable import WalletCore
+
+struct LostAccountRemovalTests {
+    @Test func removingMigratedRecordPreservesRestoredWalletWithSameName() throws {
+        let env = try Environment()
+        let cache = env.cache()
+        let activeId = cache.activeAccount?.id
+
+        try cache.removeLostAccounts(ids: ["lost", "restored", "unknown"])
+
+        #expect(Set(env.records.all.map(\.id)) == ["restored", "other-lost"])
+        #expect(cache.lostAccountRecords.map(\.id) == ["other-lost"])
+        #expect(cache.allAccounts.map(\.id) == ["restored"])
+        #expect(cache.activeAccount?.id == activeId)
+        // Rebuild from the database, as on a cold launch.
+        #expect(env.cache().lostAccountRecords.map(\.id) == ["other-lost"])
+    }
+
+    @Test func openingAndDismissingWithoutRemovalPreservesRecords() throws {
+        let env = try Environment()
+        _ = env.cache().lostAccountRecords
+
+        #expect(Set(env.cache().lostAccountRecords.map(\.id)) == ["lost", "other-lost"])
+        #expect(env.records.all.count == 3)
+    }
+
+    @Test func removingAllLostRecordsIsPersistentAndIdempotent() throws {
+        let env = try Environment()
+        let cache = env.cache()
+
+        try cache.removeLostAccounts(ids: ["lost", "other-lost"])
+        try cache.removeLostAccounts(ids: ["lost", "other-lost"])
+
+        #expect(cache.lostAccountRecords.isEmpty)
+        #expect(env.cache().lostAccountRecords.isEmpty)
+        #expect(env.records.all.map(\.id) == ["restored"])
+    }
+
+    @Test func failedDatabaseDeletePreservesSnapshotAndRows() throws {
+        let env = try Environment()
+        let cache = env.cache()
+        try env.pool.write { db in
+            try db.execute(sql: """
+                CREATE TRIGGER reject_lost_delete BEFORE DELETE ON account_records
+                WHEN OLD.id = 'other-lost'
+                BEGIN SELECT RAISE(ABORT, 'simulated storage failure'); END;
+                """)
+        }
+
+        #expect(throws: DatabaseError.self) {
+            try cache.removeLostAccounts(ids: ["lost", "other-lost"])
+        }
+        #expect(env.records.all.count == 3)
+        #expect(Set(cache.lostAccountRecords.map(\.id)) == ["lost", "other-lost"])
+        #expect(Set(env.cache().lostAccountRecords.map(\.id)) == ["lost", "other-lost"])
+    }
+
+    @Test func currentPasscodeLevelLimitsRemovalEvenForPreviouslyDisplayedIds() throws {
+        let env = try Environment()
+        let cache = env.cache()
+        let previouslyDisplayedIds = Set(cache.lostAccountRecords.map(\.id))
+        cache.set(level: 1)
+
+        #expect(cache.lostAccountRecords.map(\.id) == ["other-lost"])
+        try cache.removeLostAccounts(ids: previouslyDisplayedIds)
+        cache.set(level: 0)
+
+        #expect(cache.lostAccountRecords.map(\.id) == ["lost"])
+        #expect(Set(env.records.all.map(\.id)) == ["lost", "restored"])
+    }
+
+    @Test func recordReconstructedSinceLaunchCannotBeRemovedAsLost() throws {
+        let env = try Environment()
+        let cache = env.cache()
+        cache.save(account: account(id: "lost"))
+
+        try cache.removeLostAccounts(ids: ["lost"])
+
+        #expect(env.records.all.count == 3)
+        #expect(cache.account(id: "lost") != nil)
+    }
+
+    @Test func clearingAccountsAlsoClearsLostSnapshot() throws {
+        let env = try Environment()
+        let cache = env.cache()
+        cache.clear()
+
+        #expect(cache.lostAccountRecords.isEmpty)
+        #expect(env.records.all.isEmpty)
+        #expect(env.cache().lostAccountRecords.isEmpty)
+    }
+}
+
+private func account(id: String) -> Account {
+    Account(id: id, level: 0, name: "Same display name", type: .mnemonic(words: ["synthetic-test-fixture"], salt: "", bip39Compliant: true), origin: .restored, backedUp: true, fileBackedUp: false)
+}
+
+private final class Environment {
+    let pool: DatabasePool
+    let records: AccountRecordStorage
+    let source: Source
+    private let directory: URL
+
+    init() throws {
+        directory = FileManager.default.temporaryDirectory.appendingPathComponent("lost-account-tests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        pool = try DatabasePool(path: directory.appendingPathComponent("bank.sqlite").path)
+        try pool.write { db in
+            try db.create(table: AccountRecord.databaseTableName) { t in
+                t.column("id", .text).primaryKey(onConflict: .replace)
+                t.column("level", .integer).notNull()
+                for column in ["name", "type", "origin"] {
+                    t.column(column, .text).notNull()
+                }
+                for column in ["backedUp", "fileBackedUp"] {
+                    t.column(column, .boolean).notNull()
+                }
+                for column in ["wordsKey", "saltKey", "dataKey"] {
+                    t.column(column, .text)
+                }
+                t.column("bip39Compliant", .boolean)
+            }
+            try db.create(table: ActiveAccount.databaseTableName) { t in
+                t.column("level", .integer).primaryKey(onConflict: .replace)
+                t.column("accountId", .text).notNull()
+            }
+        }
+        records = AccountRecordStorage(dbPool: pool)
+        source = Source(records: records)
+        source.save(account: account(id: "restored"))
+        for (id, level) in [("lost", 0), ("other-lost", 1)] {
+            records.save(record: AccountRecord(id: id, level: level, name: "Same display name", type: "mnemonic", origin: "restored", backedUp: true, fileBackedUp: false, wordsKey: nil, saltKey: nil, dataKey: nil, bip39Compliant: true))
+        }
+    }
+
+    deinit {
+        try? pool.close()
+        try? FileManager.default.removeItem(at: directory)
+    }
+
+    func cache() -> AccountCachedStorage {
+        AccountCachedStorage(level: 0, accountStorage: source, activeAccountStorage: ActiveAccountStorage(dbPool: pool))
+    }
+}
+
+// Inject unreadable/readable classification without touching the test host's Keychain.
+// Actual record deletion and cold-cache reconstruction still use a real SQLite database.
+private final class Source: IAccountStorage {
+    let records: AccountRecordStorage
+    private var readableAccounts = [String: Account]()
+
+    init(records: AccountRecordStorage) {
+        self.records = records
+    }
+
+    var allAccounts: ([Account], [AccountRecord]) {
+        let all = records.all
+        return (all.compactMap { readableAccounts[$0.id] }, all.filter { readableAccounts[$0.id] == nil })
+    }
+
+    func save(account: Account) {
+        records.save(record: AccountRecord(id: account.id, level: account.level, name: account.name, type: "mnemonic", origin: "restored", backedUp: true, fileBackedUp: false, wordsKey: nil, saltKey: nil, dataKey: nil, bip39Compliant: true))
+        readableAccounts[account.id] = account
+    }
+
+    func delete(account: Account) {
+        records.delete(by: account.id)
+        readableAccounts.removeValue(forKey: account.id)
+    }
+
+    func delete(accountIds: Set<String>) throws {
+        try records.delete(by: accountIds)
+    }
+
+    func clear() {
+        records.clear()
+        readableAccounts = [:]
+    }
+}

--- a/Unstoppable/Tests/Accounts/LostAccountRemovalTests.swift
+++ b/Unstoppable/Tests/Accounts/LostAccountRemovalTests.swift
@@ -83,6 +83,92 @@ struct LostAccountRemovalTests {
         #expect(cache.account(id: "lost") != nil)
     }
 
+    @Test func loweringPasscodeLevelRevealsPreviouslyHiddenLostRecords() throws {
+        let env = try Environment()
+        let cache = env.cache()
+        try cache.removeLostAccounts(ids: ["other-lost"])
+        cache.set(level: 1)
+        #expect(cache.lostAccountRecords.isEmpty)
+
+        cache.set(level: 0)
+
+        #expect(cache.lostAccountRecords.map(\.id) == ["lost"])
+    }
+
+    @Test func successfulRemovalPreservesRefreshedRecordsUntilAfterDismissal() throws {
+        let env = try Environment()
+        let cache = env.cache()
+        cache.set(level: 1)
+        var publishedRecords: [AccountRecord]? = cache.lostAccountRecords
+        let displayedIds = Set(cache.lostAccountRecords.map(\.id))
+        let state = LostAccountsAlertState()
+        state.beginPresentation()
+
+        // Another record becomes visible while this sheet still shows the previous IDs.
+        cache.set(level: 0)
+        try state.remove {
+            try cache.removeLostAccounts(ids: displayedIds)
+            publishedRecords = cache.lostAccountRecords
+            #expect(state.isPresented)
+        }
+
+        var presentedIds = [String]()
+        state.dismiss {
+            publishedRecords = nil
+        } showNextAlert: {
+            #expect(!state.isPresented)
+            presentedIds = publishedRecords?.map(\.id) ?? []
+            state.beginPresentation()
+        }
+        #expect(presentedIds == ["lost"])
+        #expect(publishedRecords?.map(\.id) == ["lost"])
+        #expect(state.isPresented)
+        #expect(env.cache().lostAccountRecords.map(\.id) == ["lost"])
+
+        // The follow-up sheet can still be acknowledged normally.
+        state.dismiss {
+            publishedRecords = nil
+        } showNextAlert: {
+            #expect(publishedRecords == nil)
+        }
+        #expect(!state.isPresented)
+    }
+
+    @Test func acknowledgementClearsWarningBeforeProcessingNextAlert() {
+        let state = LostAccountsAlertState()
+        state.beginPresentation()
+        var cleared = false
+        var nextAlertHandled = false
+
+        state.dismiss {
+            #expect(state.isPresented)
+            cleared = true
+        } showNextAlert: {
+            #expect(cleared)
+            #expect(!state.isPresented)
+            nextAlertHandled = true
+        }
+        #expect(nextAlertHandled)
+    }
+
+    @Test func failedRemovalDoesNotChangeAcknowledgementBehavior() {
+        enum RemovalError: Error { case failed }
+        let state = LostAccountsAlertState()
+        state.beginPresentation()
+        #expect(throws: RemovalError.self) {
+            try state.remove { throw RemovalError.failed }
+        }
+        #expect(state.isPresented)
+
+        var cleared = false
+        state.dismiss {
+            cleared = true
+        } showNextAlert: {
+            #expect(cleared)
+            #expect(!state.isPresented)
+        }
+    }
+
     @Test func clearingAccountsAlsoClearsLostSnapshot() throws {
         let env = try Environment()
         let cache = env.cache()

--- a/Unstoppable/Unstoppable/Resources/Strings/de.lproj/Localizable.strings
+++ b/Unstoppable/Unstoppable/Resources/Strings/de.lproj/Localizable.strings
@@ -335,6 +335,11 @@
 "balance_error.sync_error.description.without_source" = "Fehler beim Abrufen der Daten von der aktuellen Quelle. Bitte versuchen Sie es später erneut.";
 "lost_accounts.warning_title" = "iOS-Keychain-Fehler";
 "lost_accounts.warning_message" = "Aufgrund eines Fehlers im iOS-Schlüsselbund konnten wir auf die folgenden Wallets nicht zugreifen:\n\n%@\n\nEin Neustart der App behebt das Problem in der Regel. Falls das Problem weiterhin besteht, können Sie diese Wallets trennen und wiederherstellen.";
+"lost_accounts.recovery_message" = "We couldn't access the following wallets:\n\n%@\n\nThis can happen after transferring to another iPhone. If restarting does not help, you can remove these unavailable wallets from this app and restore them using your backup.";
+"lost_accounts.remove_title" = "Remove unavailable wallets?";
+"lost_accounts.remove_button" = "Remove unavailable wallets";
+"lost_accounts.remove_confirmation" = "Remove the local wallet records listed below?\n\n%@\n\nThis does not restore access to these wallets. You will need their recovery phrase or another wallet backup to restore them. Other wallets in this app will remain available.";
+"lost_accounts.remove_failed" = "Could not remove these wallets. No records were removed. Please try again.";
 
 // Token Balance Page
 "balance.token.locked" = "Gesperrt";

--- a/Unstoppable/Unstoppable/Resources/Strings/en.lproj/Localizable.strings
+++ b/Unstoppable/Unstoppable/Resources/Strings/en.lproj/Localizable.strings
@@ -335,6 +335,11 @@
 "balance_error.sync_error.description.without_source" = "Failed to fetch data from the current source. Please try again later.";
 "lost_accounts.warning_title" = "iOS Keychain Error";
 "lost_accounts.warning_message" = "Due to an iOS Keychain error, we couldn't access the following wallets:\n\n%@\n\nRestarting the app usually fixes this. If the issue persists, you can unlink and restore these wallets.";
+"lost_accounts.recovery_message" = "We couldn't access the following wallets:\n\n%@\n\nThis can happen after transferring to another iPhone. If restarting does not help, you can remove these unavailable wallets from this app and restore them using your backup.";
+"lost_accounts.remove_title" = "Remove unavailable wallets?";
+"lost_accounts.remove_button" = "Remove unavailable wallets";
+"lost_accounts.remove_confirmation" = "Remove the local wallet records listed below?\n\n%@\n\nThis does not restore access to these wallets. You will need their recovery phrase or another wallet backup to restore them. Other wallets in this app will remain available.";
+"lost_accounts.remove_failed" = "Could not remove these wallets. No records were removed. Please try again.";
 
 // Token Balance Page
 "balance.token.locked" = "Locked Balance";

--- a/Unstoppable/Unstoppable/Resources/Strings/es.lproj/Localizable.strings
+++ b/Unstoppable/Unstoppable/Resources/Strings/es.lproj/Localizable.strings
@@ -335,6 +335,11 @@
 "balance_error.sync_error.description.without_source" = "No se pudo obtener datos de la fuente actual. Por favor, inténtalo más tarde.";
 "lost_accounts.warning_title" = "Error de la cadena de Claves del iOs ";
 "lost_accounts.warning_message" = "Debido a un error del llavero de iOS, no pudimos acceder a las siguientes wallets:\n\n%@\n\nReiniciar la aplicación normalmente soluciona el problema. Si el inconveniente persiste, puedes desvincular y restaurar estas wallets.";
+"lost_accounts.recovery_message" = "We couldn't access the following wallets:\n\n%@\n\nThis can happen after transferring to another iPhone. If restarting does not help, you can remove these unavailable wallets from this app and restore them using your backup.";
+"lost_accounts.remove_title" = "Remove unavailable wallets?";
+"lost_accounts.remove_button" = "Remove unavailable wallets";
+"lost_accounts.remove_confirmation" = "Remove the local wallet records listed below?\n\n%@\n\nThis does not restore access to these wallets. You will need their recovery phrase or another wallet backup to restore them. Other wallets in this app will remain available.";
+"lost_accounts.remove_failed" = "Could not remove these wallets. No records were removed. Please try again.";
 
 // Token Balance Page
 "balance.token.locked" = "Bloqueado";

--- a/Unstoppable/Unstoppable/Resources/Strings/fr.lproj/Localizable.strings
+++ b/Unstoppable/Unstoppable/Resources/Strings/fr.lproj/Localizable.strings
@@ -335,6 +335,11 @@
 "balance_error.sync_error.description.without_source" = "Impossible d’obtenir les données depuis la source actuelle. Veuillez réessayer plus tard.";
 "lost_accounts.warning_title" = "Erreur du trousseau d’accès iOS";
 "lost_accounts.warning_message" = "En raison d’une erreur du trousseau iOS, nous n’avons pas pu accéder aux portefeuilles suivants :\n\n%@\n\nLe redémarrage de l’application résout généralement ce problème. Si celui-ci persiste, vous pouvez dissocier puis restaurer ces portefeuilles.";
+"lost_accounts.recovery_message" = "We couldn't access the following wallets:\n\n%@\n\nThis can happen after transferring to another iPhone. If restarting does not help, you can remove these unavailable wallets from this app and restore them using your backup.";
+"lost_accounts.remove_title" = "Remove unavailable wallets?";
+"lost_accounts.remove_button" = "Remove unavailable wallets";
+"lost_accounts.remove_confirmation" = "Remove the local wallet records listed below?\n\n%@\n\nThis does not restore access to these wallets. You will need their recovery phrase or another wallet backup to restore them. Other wallets in this app will remain available.";
+"lost_accounts.remove_failed" = "Could not remove these wallets. No records were removed. Please try again.";
 
 // Token Balance Page
 "balance.token.locked" = "Verrouillé";

--- a/Unstoppable/Unstoppable/Resources/Strings/ko.lproj/Localizable.strings
+++ b/Unstoppable/Unstoppable/Resources/Strings/ko.lproj/Localizable.strings
@@ -335,6 +335,11 @@
 "balance_error.sync_error.description.without_source" = "현재 소스에서 데이터를 가져오지 못했습니다. 나중에 다시 시도하세요.";
 "lost_accounts.warning_title" = "iOS 키체인 오류";
 "lost_accounts.warning_message" = "iOS 키체인 오류로 인해 다음 지갑에 접근할 수 없습니다:\n\n%@\n\n앱을 다시 시작하면 대부분의 경우 문제가 해결됩니다. 문제가 지속되면 해당 지갑을 연결 해제한 후 복원할 수 있습니다.";
+"lost_accounts.recovery_message" = "We couldn't access the following wallets:\n\n%@\n\nThis can happen after transferring to another iPhone. If restarting does not help, you can remove these unavailable wallets from this app and restore them using your backup.";
+"lost_accounts.remove_title" = "Remove unavailable wallets?";
+"lost_accounts.remove_button" = "Remove unavailable wallets";
+"lost_accounts.remove_confirmation" = "Remove the local wallet records listed below?\n\n%@\n\nThis does not restore access to these wallets. You will need their recovery phrase or another wallet backup to restore them. Other wallets in this app will remain available.";
+"lost_accounts.remove_failed" = "Could not remove these wallets. No records were removed. Please try again.";
 
 // Token Balance Page
 "balance.token.locked" = "잠김";

--- a/Unstoppable/Unstoppable/Resources/Strings/pt-BR.lproj/Localizable.strings
+++ b/Unstoppable/Unstoppable/Resources/Strings/pt-BR.lproj/Localizable.strings
@@ -335,6 +335,11 @@
 "balance_error.sync_error.description.without_source" = "Falha ao obter dados da fonte atual. Tente novamente mais tarde.";
 "lost_accounts.warning_title" = "Erro de Keychain do iOS";
 "lost_accounts.warning_message" = "Devido a um erro no Keychain do iOS, não foi possível acessar as seguintes carteiras:\n\n%@\n\nReiniciar o app geralmente resolve o problema. Se o erro persistir, você pode desvincular e restaurar essas carteiras.";
+"lost_accounts.recovery_message" = "We couldn't access the following wallets:\n\n%@\n\nThis can happen after transferring to another iPhone. If restarting does not help, you can remove these unavailable wallets from this app and restore them using your backup.";
+"lost_accounts.remove_title" = "Remove unavailable wallets?";
+"lost_accounts.remove_button" = "Remove unavailable wallets";
+"lost_accounts.remove_confirmation" = "Remove the local wallet records listed below?\n\n%@\n\nThis does not restore access to these wallets. You will need their recovery phrase or another wallet backup to restore them. Other wallets in this app will remain available.";
+"lost_accounts.remove_failed" = "Could not remove these wallets. No records were removed. Please try again.";
 
 // Token Balance Page
 "balance.token.locked" = "Bloqueado";

--- a/Unstoppable/Unstoppable/Resources/Strings/ru.lproj/Localizable.strings
+++ b/Unstoppable/Unstoppable/Resources/Strings/ru.lproj/Localizable.strings
@@ -335,6 +335,11 @@
 "balance_error.sync_error.description.without_source" = "Не удалось получить данные из текущего источника. Пожалуйста, попробуйте позже.";
 "lost_accounts.warning_title" = "Ошибка связки ключей iOS";
 "lost_accounts.warning_message" = "Из-за ошибки iOS Keychain не удалось получить доступ к следующим кошелькам:\n\n%@\n\nОбычно проблему решает перезапуск приложения. Если ошибка сохраняется, вы можете удалить эти кошельки из приложения и восстановить их заново.";
+"lost_accounts.recovery_message" = "We couldn't access the following wallets:\n\n%@\n\nThis can happen after transferring to another iPhone. If restarting does not help, you can remove these unavailable wallets from this app and restore them using your backup.";
+"lost_accounts.remove_title" = "Remove unavailable wallets?";
+"lost_accounts.remove_button" = "Remove unavailable wallets";
+"lost_accounts.remove_confirmation" = "Remove the local wallet records listed below?\n\n%@\n\nThis does not restore access to these wallets. You will need their recovery phrase or another wallet backup to restore them. Other wallets in this app will remain available.";
+"lost_accounts.remove_failed" = "Could not remove these wallets. No records were removed. Please try again.";
 
 // Token Balance Page
 "balance.token.locked" = "Заблокировано";

--- a/Unstoppable/Unstoppable/Resources/Strings/tr.lproj/Localizable.strings
+++ b/Unstoppable/Unstoppable/Resources/Strings/tr.lproj/Localizable.strings
@@ -335,6 +335,11 @@
 "balance_error.sync_error.description.without_source" = "Mevcut kaynaktan veri alınamadı. Lütfen daha sonra tekrar deneyin.";
 "lost_accounts.warning_title" = "iOS Keychain Hatası";
 "lost_accounts.warning_message" = "Bir iOS Keychain hatası nedeniyle aşağıdaki cüzdanlara erişemedik:\n\n%@\n\nUygulamayı yeniden başlatmak genellikle sorunu çözer. Sorun devam ederse bu cüzdanların bağlantısını kaldırıp yeniden yükleyebilirsiniz.";
+"lost_accounts.recovery_message" = "We couldn't access the following wallets:\n\n%@\n\nThis can happen after transferring to another iPhone. If restarting does not help, you can remove these unavailable wallets from this app and restore them using your backup.";
+"lost_accounts.remove_title" = "Remove unavailable wallets?";
+"lost_accounts.remove_button" = "Remove unavailable wallets";
+"lost_accounts.remove_confirmation" = "Remove the local wallet records listed below?\n\n%@\n\nThis does not restore access to these wallets. You will need their recovery phrase or another wallet backup to restore them. Other wallets in this app will remain available.";
+"lost_accounts.remove_failed" = "Could not remove these wallets. No records were removed. Please try again.";
 
 // Token Balance Page
 "balance.token.locked" = "Kilitli";

--- a/Unstoppable/Unstoppable/Resources/Strings/zh.lproj/Localizable.strings
+++ b/Unstoppable/Unstoppable/Resources/Strings/zh.lproj/Localizable.strings
@@ -335,6 +335,11 @@
 "balance_error.sync_error.description.without_source" = "无法从当前来源获取数据。请稍后重试。";
 "lost_accounts.warning_title" = "iOS Keychain 错误";
 "lost_accounts.warning_message" = "由于 iOS 钥匙串错误，无法访问以下钱包：\n\n%@\n\n重新启动应用通常可以解决此问题。如果问题仍然存在，您可以取消关联并恢复这些钱包。";
+"lost_accounts.recovery_message" = "无法访问以下钱包：\n\n%@\n\n转移到另一部 iPhone 后可能出现此问题。如果重启无效，你可以从此应用中移除这些无法访问的钱包，再使用备份恢复。";
+"lost_accounts.remove_title" = "移除无法访问的钱包？";
+"lost_accounts.remove_button" = "移除无法访问的钱包";
+"lost_accounts.remove_confirmation" = "是否移除以下钱包的本地记录？\n\n%@\n\n此操作不会恢复对这些钱包的访问。你需要使用对应的助记词或其他钱包备份恢复它们。此应用中的其他钱包仍可正常使用。";
+"lost_accounts.remove_failed" = "无法移除这些钱包，未删除任何记录。请重试。";
 
 // Token Balance Page
 "balance.token.locked" = "锁住";

--- a/packages/WalletCore/Sources/WalletCore/Core/Managers/AccountManager.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Managers/AccountManager.swift
@@ -38,6 +38,9 @@ public class AccountManager {
 
         accountsSubject.send(storage.accounts)
         activeAccountSubject.send(storage.activeAccount)
+        if lostAccountRecords != nil {
+            handleLaunch()
+        }
     }
 
     private func handleDisableDuress() {
@@ -137,8 +140,14 @@ extension AccountManager {
         }
     }
 
+    func removeLostAccounts(ids: Set<String>) throws {
+        try storage.removeLostAccounts(ids: ids)
+        handleLaunch()
+    }
+
     func clear() {
         storage.clear()
+        lostAccountRecords = nil
 
         accountsSubject.send(storage.accounts)
 
@@ -146,9 +155,8 @@ extension AccountManager {
     }
 
     func handleLaunch() {
-        if !storage.lostAccountRecords.isEmpty {
-            lostAccountRecords = storage.lostAccountRecords
-        }
+        let records = storage.lostAccountRecords
+        lostAccountRecords = records.isEmpty ? nil : records
     }
 
     func set(lastCreatedAccount: Account) {
@@ -175,18 +183,26 @@ extension AccountManager {
     }
 }
 
+protocol IAccountStorage {
+    var allAccounts: ([Account], [AccountRecord]) { get }
+    func save(account: Account)
+    func delete(account: Account)
+    func delete(accountIds: Set<String>) throws
+    func clear()
+}
+
 class AccountCachedStorage {
-    private let accountStorage: AccountStorage
+    private let accountStorage: IAccountStorage
     private let activeAccountStorage: ActiveAccountStorage
 
     private var _allAccounts: [String: Account]
-    let lostAccountRecords: [AccountRecord]
+    private var _lostAccountRecords: [AccountRecord]
 
     private var level: Int
     private var _accounts = [String: Account]()
     private var _activeAccount: Account?
 
-    init(level: Int, accountStorage: AccountStorage, activeAccountStorage: ActiveAccountStorage) {
+    init(level: Int, accountStorage: IAccountStorage, activeAccountStorage: ActiveAccountStorage) {
         self.level = level
         self.accountStorage = accountStorage
         self.activeAccountStorage = activeAccountStorage
@@ -194,7 +210,7 @@ class AccountCachedStorage {
         let (accounts, lostAccountRecords) = accountStorage.allAccounts
 
         _allAccounts = accounts.reduce(into: [String: Account]()) { $0[$1.id] = $1 }
-        self.lostAccountRecords = lostAccountRecords
+        _lostAccountRecords = lostAccountRecords
 
         syncAccounts()
     }
@@ -202,6 +218,10 @@ class AccountCachedStorage {
     private func syncAccounts() {
         _accounts = _allAccounts.filter { _, account in account.level >= level }
         _activeAccount = activeAccountStorage.activeAccountId(level: level).flatMap { _accounts[$0] } ?? _accounts.first?.value
+    }
+
+    var lostAccountRecords: [AccountRecord] {
+        _lostAccountRecords.filter { $0.level >= level }
     }
 
     var allAccounts: [Account] {
@@ -247,14 +267,23 @@ class AccountCachedStorage {
         _accounts.removeValue(forKey: account.id)
     }
 
-    func delete(accountId: String) {
-        accountStorage.delete(accountId: accountId)
-        _allAccounts.removeValue(forKey: accountId)
-        _accounts.removeValue(forKey: accountId)
+    // Only an explicit user action may discard an unavailable account's local record.
+    func removeLostAccounts(ids: Set<String>) throws {
+        let removableIds = Set(lostAccountRecords.compactMap { record in
+            ids.contains(record.id) && _allAccounts[record.id] == nil ? record.id : nil
+        })
+        guard !removableIds.isEmpty else {
+            return
+        }
+
+        // Keep the snapshot intact if the persistent transaction fails.
+        try accountStorage.delete(accountIds: removableIds)
+        _lostAccountRecords.removeAll { removableIds.contains($0.id) }
     }
 
     func clear() {
         accountStorage.clear()
+        _lostAccountRecords = []
         _allAccounts = [:]
         _accounts = [:]
     }

--- a/packages/WalletCore/Sources/WalletCore/Core/Managers/AccountManager.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Managers/AccountManager.swift
@@ -38,9 +38,7 @@ public class AccountManager {
 
         accountsSubject.send(storage.accounts)
         activeAccountSubject.send(storage.activeAccount)
-        if lostAccountRecords != nil {
-            handleLaunch()
-        }
+        handleLaunch()
     }
 
     private func handleDisableDuress() {

--- a/packages/WalletCore/Sources/WalletCore/Core/Storage/AccountRecordStorage.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Storage/AccountRecordStorage.swift
@@ -27,6 +27,16 @@ extension AccountRecordStorage {
         }
     }
 
+    func delete(by ids: Set<String>) throws {
+        guard !ids.isEmpty else {
+            return
+        }
+
+        _ = try dbPool.write { db in
+            try AccountRecord.filter(ids.contains(AccountRecord.Columns.id)).deleteAll(db)
+        }
+    }
+
     func clear() {
         _ = try! dbPool.write { db in
             try AccountRecord.deleteAll(db)

--- a/packages/WalletCore/Sources/WalletCore/Core/Storage/AccountStorage.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Storage/AccountStorage.swift
@@ -280,7 +280,7 @@ public class AccountStorage {
     }
 }
 
-extension AccountStorage {
+extension AccountStorage: IAccountStorage {
     var allAccounts: ([Account], [AccountRecord]) {
         var accounts = [Account]()
         var lostAccountRecords = [AccountRecord]()
@@ -307,8 +307,9 @@ extension AccountStorage {
         try? clearSecureStorage(account: account)
     }
 
-    func delete(accountId: String) {
-        storage.delete(by: accountId)
+    func delete(accountIds: Set<String>) throws {
+        // Preserve any temporarily inaccessible Keychain items. This removes metadata only.
+        try storage.delete(by: accountIds)
     }
 
     func clear() {

--- a/packages/WalletCore/Sources/WalletCore/Modules/Main/LostAccountsAlertState.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/Main/LostAccountsAlertState.swift
@@ -1,0 +1,28 @@
+/// Keeps a successful removal's refreshed records alive until the sheet has closed.
+final class LostAccountsAlertState {
+    private(set) var isPresented = false
+    private var removalSucceeded = false
+
+    /// Starts a new sheet with acknowledgement as its default dismissal behavior.
+    func beginPresentation() {
+        isPresented = true
+        removalSucceeded = false
+    }
+
+    /// Changes dismissal behavior only after persistent removal succeeds.
+    func remove(using action: () throws -> Void) rethrows {
+        try action()
+        removalSucceeded = true
+    }
+
+    /// Acknowledgement clears the warning; removal preserves the newly published records.
+    /// Resume alert handling after releasing the presentation guard in either case.
+    func dismiss(clearRecords: () -> Void, showNextAlert: () -> Void) {
+        if !removalSucceeded {
+            clearRecords()
+        }
+        isPresented = false
+        removalSucceeded = false
+        showNextAlert()
+    }
+}

--- a/packages/WalletCore/Sources/WalletCore/Modules/Main/MainView.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/Main/MainView.swift
@@ -214,19 +214,60 @@ extension MainView {
 struct AccountsLostView: View {
     let records: [AccountRecord]
     @Binding var isPresented: Bool
+    let onRemove: () throws -> Void
+
+    @State private var confirmingRemoval = false
+    @State private var removalFailed = false
+
+    private var walletNames: String {
+        records.map { "- \($0.name)" }.joined(separator: "\n")
+    }
 
     var body: some View {
-        BottomSheetView(
-            items: [
-                .title(icon: ThemeImage.warning, title: "lost_accounts.warning_title".localized),
-                .text(text: "lost_accounts.warning_message".localized(records.map { "- \($0.name)" }.joined(separator: "\n"))),
-                .buttonGroup(.init(buttons: [
-                    .init(style: .yellow, title: "button.i_understand".localized) {
-                        isPresented = false
-                    },
-                ])),
-            ],
-        )
+        Group {
+            if confirmingRemoval {
+                BottomSheetView(items: [
+                    .title(icon: ThemeImage.warning, title: "lost_accounts.remove_title".localized),
+                    .text(text: "lost_accounts.remove_confirmation".localized(walletNames)),
+                    .custom(AnyView(Group {
+                        if removalFailed {
+                            Text("lost_accounts.remove_failed".localized)
+                                .themeBody(color: .themeLucian)
+                                .padding(.horizontal, .margin32)
+                                .accessibilityAddTraits(.updatesFrequently)
+                        }
+                    })),
+                    .buttonGroup(.init(buttons: [
+                        .init(style: .gray, title: "lost_accounts.remove_button".localized) {
+                            do {
+                                try onRemove()
+                                isPresented = false
+                                HudHelper.instance.show(banner: .deleted)
+                            } catch {
+                                removalFailed = true
+                            }
+                        },
+                        .init(style: .transparent, title: "button.cancel".localized) {
+                            confirmingRemoval = false
+                            removalFailed = false
+                        },
+                    ])),
+                ])
+            } else {
+                BottomSheetView(items: [
+                    .title(icon: ThemeImage.warning, title: "lost_accounts.warning_title".localized),
+                    .text(text: "lost_accounts.recovery_message".localized(walletNames)),
+                    .buttonGroup(.init(buttons: [
+                        .init(style: .yellow, title: "button.i_understand".localized) {
+                            isPresented = false
+                        },
+                        .init(style: .gray, title: "lost_accounts.remove_button".localized) {
+                            confirmingRemoval = true
+                        },
+                    ])),
+                ])
+            }
+        }
     }
 }
 

--- a/packages/WalletCore/Sources/WalletCore/Modules/Main/StartScreenAlertManager.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/Main/StartScreenAlertManager.swift
@@ -3,7 +3,7 @@ import Foundation
 
 class StartScreenAlertManager {
     private var cancellables = Set<AnyCancellable>()
-    private var isPresentingLostAccounts = false
+    private let lostAccountsAlertState = LostAccountsAlertState()
 
     let accountManager: AccountManager
     let jailbreakService: JailbreakService
@@ -45,7 +45,7 @@ class StartScreenAlertManager {
     }
 
     func handleNextAlert() {
-        guard !lockManager.isLocked, !isPresentingLostAccounts else {
+        guard !lockManager.isLocked, !lostAccountsAlertState.isPresented else {
             return
         }
 
@@ -56,14 +56,22 @@ class StartScreenAlertManager {
                 self?.handleNextAlert()
             }
         } else if let records = accountManager.lostAccountRecords {
-            isPresentingLostAccounts = true
-            Coordinator.shared.present(type: .bottomSheet) { [accountManager] isPresented in
+            lostAccountsAlertState.beginPresentation()
+            Coordinator.shared.present(type: .bottomSheet) { [accountManager, lostAccountsAlertState] isPresented in
                 AccountsLostView(records: records, isPresented: isPresented) {
-                    try accountManager.removeLostAccounts(ids: Set(records.map(\.id)))
+                    try lostAccountsAlertState.remove {
+                        try accountManager.removeLostAccounts(ids: Set(records.map(\.id)))
+                    }
                 }
             } onDismiss: { [weak self] in
-                self?.accountManager.lostAccountRecords = nil
-                self?.isPresentingLostAccounts = false
+                guard let self else {
+                    return
+                }
+                lostAccountsAlertState.dismiss {
+                    accountManager.lostAccountRecords = nil
+                } showNextAlert: {
+                    handleNextAlert()
+                }
             }
         } else if jailbreakService.needToShowAlert {
             Coordinator.shared.present { isPresented in

--- a/packages/WalletCore/Sources/WalletCore/Modules/Main/StartScreenAlertManager.swift
+++ b/packages/WalletCore/Sources/WalletCore/Modules/Main/StartScreenAlertManager.swift
@@ -3,6 +3,7 @@ import Foundation
 
 class StartScreenAlertManager {
     private var cancellables = Set<AnyCancellable>()
+    private var isPresentingLostAccounts = false
 
     let accountManager: AccountManager
     let jailbreakService: JailbreakService
@@ -44,7 +45,7 @@ class StartScreenAlertManager {
     }
 
     func handleNextAlert() {
-        guard !lockManager.isLocked else {
+        guard !lockManager.isLocked, !isPresentingLostAccounts else {
             return
         }
 
@@ -55,10 +56,14 @@ class StartScreenAlertManager {
                 self?.handleNextAlert()
             }
         } else if let records = accountManager.lostAccountRecords {
-            Coordinator.shared.present(type: .bottomSheet) { isPresented in
-                AccountsLostView(records: records, isPresented: isPresented)
+            isPresentingLostAccounts = true
+            Coordinator.shared.present(type: .bottomSheet) { [accountManager] isPresented in
+                AccountsLostView(records: records, isPresented: isPresented) {
+                    try accountManager.removeLostAccounts(ids: Set(records.map(\.id)))
+                }
             } onDismiss: { [weak self] in
                 self?.accountManager.lostAccountRecords = nil
+                self?.isPresentingLostAccounts = false
             }
         } else if jailbreakService.needToShowAlert {
             Coordinator.shared.present { isPresented in


### PR DESCRIPTION
An account whose Keychain data cannot be read is excluded from normal wallet management, while the startup warning only offers dismissal. After device migration, restoring the mnemonic can create a new account UUID and leave the old record triggering the warning indefinitely.

This adds an explicit, confirmed **Remove unavailable wallets** action to the warning. It removes the displayed, currently accessible-level lost record IDs in one SQLite transaction, then updates the cached and published lost-record state. A failed transaction leaves the snapshot intact and shows a retryable error. Valid accounts, including a restored wallet with the same name, are excluded from this deletion path.

Related to #7216. **Please keep that issue open pending device validation and a released fix.**

### Implementation

- Wire the lost-account sheet to a guarded AccountManager removal operation. Dismissal and cancellation do not delete anything.
- Replace the unused cached raw-ID deletion path with lost-only batch removal. Filter lost records by the existing passcode-level visibility rule and recheck eligibility when confirming.
- Make database errors propagate through the new path; update the snapshot only after the transaction succeeds. Clear lost state when clearing accounts.
- Suppress duplicate lost-account sheets while one is already presented, including publication triggered by removal. Refresh the published records on every passcode-level change. After successful removal, preserve the refreshed snapshot and process the next alert after dismissal; acknowledgement still clears the warning.
- Add English and Chinese copy; include English fallback values for the new keys in the other existing locale files so their language bundles do not display raw keys. Those fallbacks can go through the project's translation workflow.
- Add eleven regression tests using real SQLite storage and an injected readable/unreadable classification, avoiding the test host's Keychain.

### Validation

- All **11 Swift Testing tests passed** in a directly compiled macOS harness with GRDB 6.29.3. The harness used the production AccountCachedStorage/protocol, LostAccountsAlertState, AccountRecord and ActiveAccount models, their storage implementations, and the unchanged test file. Only the crypto-bearing Account model was substituted with a minimal fixture model. Covered persistent removal/cold-cache reconstruction, same-name restored-account preservation, no-action preservation, idempotency, transaction rollback, passcode-level changes, reconstructed-account protection, snapshot clearing, newly visible records after a level change, and success/acknowledgement/failure dismissal behavior.
- Changed Swift files passed syntax parsing; the regression test file also passed typechecking against the harness.
- All nine Localizable.strings files passed plutil validation; git diff --check passed.
- **Not verified:** full WalletCore/iOS app build, AppTests running in Xcode, simulator/device UI, Dynamic Type/VoiceOver, or a real iPhone migration. This machine has Command Line Tools only; SwiftPM also fails at PackageDescription linking, so the focused tests were compiled directly.

### Scope / remaining review

This preserves the device-only Keychain policy and never automatically deletes a record merely because a read fails. The action deliberately removes local account records only; it does not delete potentially temporarily inaccessible Keychain items or emulate a full Account deletion event. Existing dependent kit/session metadata is outside this targeted change, so this should not be treated as secure erasure.

The separate restore-save error propagation and first-launch Keychain ordering concerns are not changed here. Keeping this PR in draft until an iOS build and UI/device validation can be completed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a guided flow for removing accounts that are no longer accessible.
  - Users can review affected wallet names, confirm removal, or dismiss the warning.
  - Account removal now supports selecting multiple records at once.
- **Bug Fixes**
  - Added clear success and failure feedback when removing lost accounts.
  - Prevented account alerts from being interrupted while the removal flow is open.
  - Preserved restored or newly recovered accounts from accidental removal.
  - Refreshed lost-account alerts correctly after passcode-level changes.
- **Tests**
  - Added coverage for removal, rollback, filtering, restoration, and alert behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->