### PR TITLE
Fix Ethereum sync source name

### DIFF
--- a/packages/WalletCore/Sources/WalletCore/Core/Managers/EvmSyncSourceManager.swift
+++ b/packages/WalletCore/Sources/WalletCore/Core/Managers/EvmSyncSourceManager.swift
@@ -63,7 +63,7 @@ extension EvmSyncSourceManager {
             } else {
                 return [
                     EvmSyncSource(
-                        name: "BlocksDecoded",
+                        name: "Unstoppable",
                         rpcSource: .http(urls: [URL(string: "https://ethereum-rpc.unstoppable.money")!], auth: nil),
                         transactionSource: defaultTransactionSource(blockchainType: blockchainType)
                     ),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated the default Ethereum mainnet sync source to “Unstoppable.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->